### PR TITLE
Terraform을 통한 GCP dev 인프라 코드화

### DIFF
--- a/infra/terraform/dev/.terraform.lock.hcl
+++ b/infra/terraform/dev/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -56,6 +56,7 @@ resource "google_compute_firewall" "allow_ssh" {
     ports    = ["22"]
   }
 
+  target_tags   = ["api-server"]
   source_ranges = ["0.0.0.0/0"]
 }
 
@@ -68,6 +69,7 @@ resource "google_compute_firewall" "allow_app" {
     ports    = ["8080"]
   }
 
+  target_tags   = ["api-server"]
   source_ranges = ["0.0.0.0/0"]
 }
 
@@ -79,6 +81,7 @@ resource "google_compute_firewall" "allow_icmp" {
     protocol = "icmp"
   }
 
+  target_tags   = ["api-server"]
   source_ranges = ["0.0.0.0/0"]
 }
 
@@ -101,18 +104,6 @@ resource "google_compute_firewall" "allow_internal" {
   }
 
   source_ranges = ["10.0.0.0/16"]
-}
-
-resource "google_compute_firewall" "deny_all_ingress" {
-  name     = "${var.env}-${var.service_name}-fw-deny-all-ingress"
-  network  = google_compute_network.vpc.id
-  priority = 65534
-
-  deny {
-    protocol = "all"
-  }
-
-  source_ranges = ["0.0.0.0/0"]
 }
 
 # ============================================

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -1,6 +1,11 @@
 terraform {
   required_version = ">= 1.0"
 
+  backend "gcs" {
+    bucket = "firstpenguin-tf-state"
+    prefix = "terraform/dev"
+  }
+
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -1,0 +1,152 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# ============================================
+# VPC
+# ============================================
+resource "google_compute_network" "vpc" {
+  name                    = "${var.env}-${var.service_name}-vpc"
+  auto_create_subnetworks = false
+}
+
+# ============================================
+# Subnets
+# ============================================
+resource "google_compute_subnetwork" "public" {
+  name          = "${var.env}-${var.service_name}-subnet-public"
+  ip_cidr_range = "10.0.1.0/24"
+  region        = var.region
+  network       = google_compute_network.vpc.id
+}
+
+resource "google_compute_subnetwork" "private" {
+  name          = "${var.env}-${var.service_name}-subnet-private"
+  ip_cidr_range = "10.0.10.0/24"
+  region        = var.region
+  network       = google_compute_network.vpc.id
+}
+
+# ============================================
+# Firewall Rules
+# ============================================
+resource "google_compute_firewall" "allow_ssh" {
+  name    = "${var.env}-${var.service_name}-fw-allow-ssh"
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_firewall" "allow_app" {
+  name    = "${var.env}-${var.service_name}-fw-allow-app"
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8080"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_firewall" "allow_icmp" {
+  name    = "${var.env}-${var.service_name}-fw-allow-icmp"
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "google_compute_firewall" "allow_internal" {
+  name    = "${var.env}-${var.service_name}-fw-allow-internal"
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = ["10.0.0.0/16"]
+}
+
+resource "google_compute_firewall" "deny_all_ingress" {
+  name     = "${var.env}-${var.service_name}-fw-deny-all-ingress"
+  network  = google_compute_network.vpc.id
+  priority = 65534
+
+  deny {
+    protocol = "all"
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+# ============================================
+# Static IP
+# ============================================
+resource "google_compute_address" "api" {
+  name   = "${var.env}-${var.service_name}-ip-api"
+  region = var.region
+}
+
+# ============================================
+# VM Instance
+# ============================================
+resource "google_compute_instance" "api" {
+  name         = "${var.env}-${var.service_name}-vm-api"
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
+      size  = 30
+      type  = "pd-ssd"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.vpc.id
+    subnetwork = google_compute_subnetwork.public.id
+
+    access_config {
+      nat_ip = google_compute_address.api.address
+    }
+  }
+
+  tags = ["api-server"]
+
+  labels = {
+    env     = var.env
+    service = var.service_name
+  }
+}

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -131,6 +131,10 @@ resource "google_compute_instance" "api" {
   machine_type = var.machine_type
   zone         = var.zone
 
+  metadata = {
+    block-project-ssh-keys = "true"
+  }
+
   boot_disk {
     initialize_params {
       image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"

--- a/infra/terraform/dev/outputs.tf
+++ b/infra/terraform/dev/outputs.tf
@@ -1,0 +1,14 @@
+output "vm_external_ip" {
+  description = "VM 외부 IP"
+  value       = google_compute_address.api.address
+}
+
+output "vm_name" {
+  description = "VM 인스턴스 이름"
+  value       = google_compute_instance.api.name
+}
+
+output "vpc_name" {
+  description = "VPC 이름"
+  value       = google_compute_network.vpc.name
+}

--- a/infra/terraform/dev/terraform.tfvars
+++ b/infra/terraform/dev/terraform.tfvars
@@ -1,0 +1,6 @@
+project_id   = "project-10e57bb0-e960-4b16-9fa"
+region       = "asia-northeast3"
+zone         = "asia-northeast3-a"
+env          = "dev"
+service_name = "firstpenguin"
+machine_type = "e2-medium"

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -1,0 +1,34 @@
+variable "project_id" {
+  description = "GCP 프로젝트 ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP 리전"
+  type        = string
+  default     = "asia-northeast3"
+}
+
+variable "zone" {
+  description = "GCP 존"
+  type        = string
+  default     = "asia-northeast3-a"
+}
+
+variable "env" {
+  description = "환경 (dev, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "service_name" {
+  description = "서비스 이름"
+  type        = string
+  default     = "firstpenguin"
+}
+
+variable "machine_type" {
+  description = "VM 머신 타입"
+  type        = string
+  default     = "e2-medium"
+}

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -1,0 +1,2 @@
+# prod 환경은 추후 구성
+# dev/main.tf를 참고하여 prod 값으로 설정


### PR DESCRIPTION
## 📢 요약
- GCP 콘솔에서 수동 생성한 dev 인프라를 Terraform으로 코드화
- dev/prod 환경 디렉토리 분리 구조 적용

🔗 연관 이슈: Resolves #3

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료 (`terraform apply` 성공)
- [x] 문서 업데이트

## 📸 Terraform 리소스 현황

| 리소스 | 이름 |
|--------|------|
| VPC | `dev-firstpenguin-vpc` |
| Public Subnet | `dev-firstpenguin-subnet-public` (10.0.1.0/24) |
| Private Subnet | `dev-firstpenguin-subnet-private` (10.0.10.0/24) |
| VM | `dev-firstpenguin-vm-api` (e2-medium, Ubuntu 24.04) |
| 고정 IP | `dev-firstpenguin-ip-api` |
| 방화벽 | SSH(22), App(8080), ICMP, Internal, Deny-all |

## 📜 기타
- `terraform.tfstate`는 gitignore 처리 (로컬 관리)
- `.terraform.lock.hcl`은 포함 (provider 버전 고정)
- prod 디렉토리는 placeholder만 생성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 개발 환경용 Terraform 인프라 추가: VPC(퍼블릭/프라이빗 서브넷), 방화벽 규칙, 고정 외부 IP, 단일 VM 프로비저닝 및 관련 출력값(외부 IP, VM 이름, VPC 이름).
  * 원격 상태 백엔드 구성 및 기본 변수값(프로젝트, 리전, 존, 환경, 서비스명, 머신타입) 설정 포함.

* **Chores**
  * Terraform 락 파일 추가로 공급자 버전 고정 및 의존성 안정성 개선.
  * 프로덕션 설정에 향후 구성을 위한 주석 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->