### PR TITLE
Husky Co-authored-by 차단 제거 및 문서 보정

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -10,11 +10,6 @@ fi
 first_line=$(sed -n '1p' "$COMMIT_MESSAGE_FILE")
 remaining_lines=$(tail -n +2 "$COMMIT_MESSAGE_FILE")
 
-if grep -Eiq '^[[:space:]]*co-authored-by:[[:space:]]*' "$COMMIT_MESSAGE_FILE"; then
-  echo "⛔ 공동 커밋자(Co-authored-by) 트레일러가 포함되어 있어 커밋을 막았습니다."
-  exit 1
-fi
-
 case "$first_line" in
   "✨ feat"*)      exit 0 ;;
   "🐛 fix"*)       exit 0 ;;

--- a/docs/husky.md
+++ b/docs/husky.md
@@ -105,7 +105,6 @@ npx husky init
 **역할**
 - 커밋 타입 검증 (feat, fix, refactor 등)
 - 타입에 맞는 이모지 자동 prefix
-- `Co-authored-by` 트레일러 차단 (AI 공동 커밋 방지)
 
 **커밋 타입**
 


### PR DESCRIPTION
## 📢 요약
- commit-msg 훅에서 Co-authored-by 차단 로직 제거
- gitleaks deprecated 명령어 수정
- husky 문서 마크다운 린트 수정 및 pre-push 설명 보정

🔗 연관 이슈: Resolves #2

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트