### PR TITLE
PR 생성 시 리뷰어 자동 할당 워크플로우 추가

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+<!-- PR 제목 형식: 타입: 설명 (예: feat: 회원가입 API 추가) -->
+<!-- 타입: feat, fix, perf, refactor, test, docs, style, chore, ci, build, revert -->
+
 ## 📢 요약
 - 무엇을, 왜 변경했는지 설명
 

--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -1,0 +1,26 @@
+name: PR 리뷰어 자동 할당
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 리뷰어 자동 할당
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const team = ['kimseonj', 'OhYeHyun', 'KoungQ'];
+            const author = context.payload.pull_request.user.login;
+            const reviewers = team.filter(member => member !== author);
+
+            if (reviewers.length === 0) return;
+
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers: reviewers,
+            });

--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   assign-reviewers:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: 리뷰어 자동 할당
         uses: actions/github-script@v7

--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -24,3 +24,10 @@ jobs:
               pull_number: context.payload.pull_request.number,
               reviewers: reviewers,
             });
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [author],
+            });


### PR DESCRIPTION
## 설명
PR이 생성되면 작성자를 제외한 나머지 팀원이 자동으로 리뷰어로 할당되는 GitHub Actions 워크플로우를 추가합니다.

## 변경 사항
- `.github/workflows/auto-reviewer.yml` 추가
- 대상: kimseonj, OhYeHyun, KoungQ
- PR `opened` 시 작성자를 제외한 나머지 팀원을 리뷰어로 자동 할당

## 테스트
- [ ] PR 생성 시 리뷰어 자동 할당 확인

closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **자동화**
  * PR 생성 시 미리 지정된 팀 구성원에게 자동으로 검토 요청이 전송됩니다. PR 작성자는 검토자 목록에서 자동으로 제외됩니다.
  * PR 생성 시 해당 PR의 작성자가 자동으로 이슈 담당자(Assignee)로 지정됩니다.
* **문서**
  * PR 템플릿에 요구되는 제목 형식과 허용되는 타입 목록이 안내 문구로 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->