### PR TITLE
fix: CD 파이프라인 buildx 드라이버 및 이미지 이름 이슈 수정 (#16)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/api
 
 jobs:
   deploy:
@@ -20,6 +19,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: 이미지 이름 소문자화
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}/api" >> $GITHUB_ENV
 
       - name: GHCR 로그인
         uses: docker/login-action@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Buildx 설정
+        uses: docker/setup-buildx-action@v3
+
       - name: Docker 이미지 빌드 및 푸시
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Closes #16

## 배경
CD 워크플로우 실행 시 발생한 두 건의 오류를 함께 수정한다. 상세 분석은 이슈 #16 참조.

## 1. buildx 드라이버 이슈

### 문제
```
ERROR: failed to build: Cache export is not supported for the docker driver.
```

`cache-from: type=gha` / `cache-to: type=gha`는 GitHub Actions 캐시 서비스를 캐시 백엔드로 사용하는 옵션인데, buildx 기본 `docker` 드라이버(Docker 데몬 내장 BuildKit)는 외부 캐시 export를 지원하지 않는다.

### 해결
`docker/setup-buildx-action@v3` 스텝을 추가하여 `docker-container` 드라이버(독립된 BuildKit 컨테이너)로 전환. 해당 드라이버는 `type=gha`, `type=registry`, `type=s3` 등 모든 캐시 백엔드를 지원한다.

## 2. 이미지 이름 대소문자 이슈

### 문제
`env.IMAGE_NAME: ${{ github.repository }}/api`로 지정했는데 `github.repository`는 `depromeet/18th-team1-BE`처럼 대문자가 섞인 원본 레포명을 그대로 반환한다. Docker 이미지 레퍼런스 스펙상 경로는 소문자만 허용되어 push/pull 동작이 비일관적이 될 수 있다.

### 해결
별도 스텝에서 bash 파라미터 확장 `${GITHUB_REPOSITORY,,}`로 전체 소문자화 후 `GITHUB_ENV`에 `IMAGE_NAME`을 주입.

```yaml
- name: 이미지 이름 소문자화
  run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}/api" >> $GITHUB_ENV
```

이미 `docker-compose-dev.yml`, `scripts/deploy-dev.sh`, 문서들은 소문자(`18th-team1-be`) 기준으로 작성되어 있어 이번 수정으로 전체가 일관돼진다.

## 테스트 플랜
- [ ] dev 브랜치 push 시 CD 워크플로우가 성공적으로 완료되는지 확인
- [ ] GHCR에 `ghcr.io/depromeet/18th-team1-be/api:dev` 태그로 이미지가 정상 푸시되는지 확인
- [ ] 두 번째 실행부터 GHA 캐시가 재사용되어 빌드 시간이 단축되는지 확인
- [ ] 서버 배포 스텝이 정상적으로 새 이미지를 pull 하는지 확인
