### PR TITLE
ci: CD 배포 스크립트 경로를 vars에서 secrets으로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,4 +50,4 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          script: bash ${{ secrets.DEPLOY_SCRIPT_PATH }}
+          script: bash ${{ vars.DEPLOY_SCRIPT_PATH }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,4 +50,4 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          script: bash ${{ vars.DEPLOY_SCRIPT_PATH }}
+          script: bash ${{ secrets.DEPLOY_SCRIPT_PATH }}

--- a/docs/cd-pipeline.md
+++ b/docs/cd-pipeline.md
@@ -72,12 +72,7 @@ gradle:8.13-jdk21                   eclipse-temurin:21-jre
 | `SERVER_HOST` | 서버 외부 IP |
 | `SERVER_USER` | SSH 사용자 (ubuntu) |
 | `SERVER_SSH_KEY` | 배포용 SSH 개인키 |
-
-### Variables (Settings → Environments → 환경별 등록)
-
-| Variable | dev | prod |
-|----------|-----|------|
-| `DEPLOY_SCRIPT_PATH` | `/opt/firstpenguin/scripts/deploy-dev.sh` | `/opt/firstpenguin/scripts/deploy-prod.sh` |
+| `DEPLOY_SCRIPT_PATH` | 배포 스크립트 절대 경로 (dev: `/opt/firstpenguin/scripts/deploy-dev.sh`, prod: `/opt/firstpenguin/scripts/deploy-prod.sh`) |
 
 ### SSH 키 생성 방법
 


### PR DESCRIPTION
## Summary
- `cd.yml`에서 `${{ vars.DEPLOY_SCRIPT_PATH }}` → `${{ secrets.DEPLOY_SCRIPT_PATH }}` 로 수정
- `DEPLOY_SCRIPT_PATH`는 GitHub Variables가 아닌 Secrets에 등록되어 있어, 기존 코드는 빈 값으로 `bash` 실행
- SSH 접속 성공 시에도 배포 스크립트가 실행되지 않는 문제 해결

## 관련 이슈
Closes #19

## Test plan
- [ ] `dev` 브랜치 merge 후 CD 워크플로우 트리거 확인
- [ ] GCP VM SSH 접속 및 `deploy-dev.sh` 실행 성공 여부 확인
- [ ] 추가 확인: `SERVER_HOST` 시크릿이 현재 VM IP(`34.64.217.68`)와 일치하는지 점검

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이 릴리스에는 최종 사용자에게 직접적인 영향을 주는 변경 사항이 없습니다. 내부 배포 프로세스의 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->