### PR TITLE
feat: Swagger(OpenAPI) API 문서화 도입 (#18)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,9 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/app/src/main/resources/application-prod.yml
+++ b/app/src/main/resources/application-prod.yml
@@ -1,0 +1,7 @@
+# prod profile
+# Swagger UI 노출을 막으려면 아래 두 키의 주석을 해제한다.
+#springdoc:
+#  api-docs:
+#    enabled: false
+#  swagger-ui:
+#    enabled: false

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   application:
     name: app
 
+server:
+  servlet:
+    context-path: /api
+
 springdoc:
   api-docs:
     enabled: true

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -1,3 +1,11 @@
 spring:
   application:
     name: app
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    operations-sorter: alpha
+    tags-sorter: alpha


### PR DESCRIPTION
## 요약

- `spring-boot-starter-web` 의존성 추가
- `springdoc-openapi-starter-webmvc-ui:3.0.3` 도입 (Spring Boot 4 호환)
- `server.servlet.context-path=/api` 설정으로 모든 엔드포인트 `/api` prefix 통일
- `application-prod.yml` 분리 — swagger 비활성화 토글 키 주석으로 안내

## 엔드포인트

| 항목 | URL |
|------|-----|
| Swagger UI | `/api/swagger-ui.html` |
| API Docs | `/api/v3/api-docs` |

## 테스트

- `./gradlew lintKotlin detekt testClasses` 통과
- bootRun 실측: `/api/swagger-ui.html` → 200, `/api/v3/api-docs` → 200
- `/v3/api-docs` (prefix 없는 루트) → 404 확인

## 관련 이슈

closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* API 문서 및 Swagger UI를 통한 상호작용형 API 테스트 인터페이스 추가
* API 엔드포인트가 `/api` 경로 아래에서 제공됨
* Swagger UI에서 작업 및 태그가 알파벳순으로 자동 정렬됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->