### PR TITLE
feat: 전역 에러 처리 구조 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/global/exception/CustomException.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/global/exception/CustomException.kt
@@ -1,0 +1,5 @@
+package com.firstpenguin.app.global.exception
+
+class CustomException(
+    val errorCode: ErrorCode,
+) : RuntimeException(errorCode.message)

--- a/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
@@ -1,0 +1,21 @@
+package com.firstpenguin.app.global.exception
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorCode(
+    val status: HttpStatus,
+    val code: String,
+    val message: String,
+) {
+    // Common
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "서버 내부 오류가 발생했습니다"),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "C002", "잘못된 입력값입니다"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C003", "허용되지 않는 HTTP 메서드입니다"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "C004", "요청한 리소스를 찾을 수 없습니다"),
+
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다"),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A003", "토큰이 만료되었습니다"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "유효하지 않은 토큰입니다"),
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/global/exception/GlobalExceptionHandler.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/global/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,43 @@
+package com.firstpenguin.app.global.exception
+
+import com.firstpenguin.app.global.response.ErrorResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.resource.NoResourceFoundException
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(CustomException::class)
+    fun handleCustomException(e: CustomException): ResponseEntity<ErrorResponse> =
+        ResponseEntity.status(e.errorCode.status).body(ErrorResponse.of(e.errorCode))
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        val message =
+            e.bindingResult.fieldErrors
+                .firstOrNull()
+                ?.defaultMessage
+                ?: ErrorCode.INVALID_INPUT.message
+        return ResponseEntity.badRequest().body(ErrorResponse.of(ErrorCode.INVALID_INPUT.code, message))
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    fun handleMethodNotAllowed(): ResponseEntity<ErrorResponse> =
+        ResponseEntity.status(ErrorCode.METHOD_NOT_ALLOWED.status).body(ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED))
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    fun handleNoResourceFound(): ResponseEntity<ErrorResponse> =
+        ResponseEntity.status(ErrorCode.NOT_FOUND.status).body(ErrorResponse.of(ErrorCode.NOT_FOUND))
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
+        log.error("Unhandled exception occurred", e)
+        return ResponseEntity.internalServerError().body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR))
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/global/response/ErrorResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/global/response/ErrorResponse.kt
@@ -1,0 +1,17 @@
+package com.firstpenguin.app.global.response
+
+import com.firstpenguin.app.global.exception.ErrorCode
+
+data class ErrorResponse(
+    val code: String,
+    val message: String,
+) {
+    companion object {
+        fun of(errorCode: ErrorCode) = ErrorResponse(errorCode.code, errorCode.message)
+
+        fun of(
+            code: String,
+            message: String,
+        ) = ErrorResponse(code, message)
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 공통 `ErrorCode` enum 추가
  - Common 에러 코드
  - Auth 에러 코드
- 비즈니스 예외용 `CustomException` 추가
- 공통 에러 응답 DTO `ErrorResponse` 추가
- `GlobalExceptionHandler` 추가
  - `CustomException` 처리
  - Bean Validation 실패 처리
  - 지원하지 않는 HTTP method 처리
  - 존재하지 않는 resource 처리
  - 미처리 예외 fallback 처리 및 로그 기록

## 검증

- `./gradlew testClasses`
- `./gradlew lintKotlin`
- `./gradlew detekt`
- `DB_URL=jdbc:postgresql://localhost:5432/changeme DB_USER=changeme DB_PASSWORD=changeme ./gradlew test`
- pre-push hook: `./gradlew clean test`

## 참고

- 기존 `fix/#19/cd-deploy-script-path` 로컬 브랜치에 있던 전역 에러 처리 구현을 현재 `dev` 기준으로 분리 적용했습니다.
- 현재 `dev`에는 이미 `spring-boot-starter-web` 의존성이 있으므로 별도 build.gradle 변경은 포함하지 않았습니다.
- CodeRabbit 리뷰는 rate limit으로 실행하지 못했습니다.

Closes #26
