### PR TITLE
chore: pre-commit에 submodule 최신버전 체크 훅 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,5 +8,23 @@ else
   echo "gitleaks 미설치: 비밀키 검사를 건너뜁니다."
 fi
 
+# submodule 최신 여부 확인
+SUBMODULE_PATH="secret"
+SUBMODULE_URL=$(git config --file .gitmodules submodule."$SUBMODULE_PATH".url)
+SUBMODULE_BRANCH=$(git config --file .gitmodules submodule."$SUBMODULE_PATH".branch 2>/dev/null || echo "main")
+
+# 스테이징된 submodule 커밋 (실제로 커밋될 값)
+STAGED_COMMIT=$(git ls-files --stage -- "$SUBMODULE_PATH" | awk '{print $2}')
+
+if [ -n "$STAGED_COMMIT" ]; then
+  REMOTE_COMMIT=$(git ls-remote "$SUBMODULE_URL" "refs/heads/$SUBMODULE_BRANCH" | awk '{print $1}')
+  if [ "$STAGED_COMMIT" != "$REMOTE_COMMIT" ]; then
+    echo "⚠️  submodule '$SUBMODULE_PATH'이 최신 상태가 아닙니다. 자동으로 업데이트합니다..."
+    git submodule update --remote --merge "$SUBMODULE_PATH"
+    git add "$SUBMODULE_PATH"
+    echo "✅ submodule이 $REMOTE_COMMIT 으로 업데이트되었습니다."
+  fi
+fi
+
 # 최소 컴파일 검증 (app 모듈)
 cd app && ./gradlew testClasses

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,11 +17,32 @@ SUBMODULE_BRANCH=$(git config --file .gitmodules submodule."$SUBMODULE_PATH".bra
 STAGED_COMMIT=$(git ls-files --stage -- "$SUBMODULE_PATH" | awk '{print $2}')
 
 if [ -n "$STAGED_COMMIT" ]; then
-  REMOTE_COMMIT=$(git ls-remote "$SUBMODULE_URL" "refs/heads/$SUBMODULE_BRANCH" | awk '{print $1}')
+  # ls-remote를 파이프 없이 실행해 exit code 마스킹 방지
+  LS_REMOTE_OUTPUT=$(git ls-remote "$SUBMODULE_URL" "refs/heads/$SUBMODULE_BRANCH")
+  REMOTE_COMMIT=$(echo "$LS_REMOTE_OUTPUT" | awk '{print $1}')
+
+  if [ -z "$REMOTE_COMMIT" ]; then
+    echo "❌ submodule 원격 커밋을 가져오지 못했습니다. 네트워크 또는 인증 오류를 확인하세요."
+    exit 1
+  fi
+
   if [ "$STAGED_COMMIT" != "$REMOTE_COMMIT" ]; then
+    # 로컬 submodule에 uncommitted 변경이 있으면 자동 업데이트 중단
+    if ! git -C "$SUBMODULE_PATH" diff --quiet || ! git -C "$SUBMODULE_PATH" diff --cached --quiet; then
+      echo "❌ submodule에 로컬 변경이 있어 자동 업데이트를 건너뜁니다. 수동으로 처리하세요."
+      exit 1
+    fi
+
     echo "⚠️  submodule '$SUBMODULE_PATH'이 최신 상태가 아닙니다. 자동으로 업데이트합니다..."
-    git submodule update --remote --merge "$SUBMODULE_PATH"
+    git submodule update --remote --checkout "$SUBMODULE_PATH"
     git add "$SUBMODULE_PATH"
+
+    UPDATED_COMMIT=$(git ls-files --stage -- "$SUBMODULE_PATH" | awk '{print $2}')
+    if [ "$UPDATED_COMMIT" != "$REMOTE_COMMIT" ]; then
+      echo "❌ submodule 업데이트 후 커밋이 원격과 일치하지 않습니다."
+      exit 1
+    fi
+
     echo "✅ submodule이 $REMOTE_COMMIT 으로 업데이트되었습니다."
   fi
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -27,23 +27,11 @@ if [ -n "$STAGED_COMMIT" ]; then
   fi
 
   if [ "$STAGED_COMMIT" != "$REMOTE_COMMIT" ]; then
-    # 로컬 submodule에 uncommitted 변경이 있으면 자동 업데이트 중단
-    if ! git -C "$SUBMODULE_PATH" diff --quiet || ! git -C "$SUBMODULE_PATH" diff --cached --quiet; then
-      echo "❌ submodule에 로컬 변경이 있어 자동 업데이트를 건너뜁니다. 수동으로 처리하세요."
-      exit 1
-    fi
-
-    echo "⚠️  submodule '$SUBMODULE_PATH'이 최신 상태가 아닙니다. 자동으로 업데이트합니다..."
-    git submodule update --remote --checkout "$SUBMODULE_PATH"
-    git add "$SUBMODULE_PATH"
-
-    UPDATED_COMMIT=$(git ls-files --stage -- "$SUBMODULE_PATH" | awk '{print $2}')
-    if [ "$UPDATED_COMMIT" != "$REMOTE_COMMIT" ]; then
-      echo "❌ submodule 업데이트 후 커밋이 원격과 일치하지 않습니다."
-      exit 1
-    fi
-
-    echo "✅ submodule이 $REMOTE_COMMIT 으로 업데이트되었습니다."
+    echo "❌ submodule '$SUBMODULE_PATH'이 최신 상태가 아닙니다."
+    echo "   현재: $STAGED_COMMIT"
+    echo "   최신: $REMOTE_COMMIT"
+    echo "   git submodule update --remote --checkout $SUBMODULE_PATH 후 다시 커밋하세요."
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
## 개요

커밋 시점에 `secret` submodule이 원격 최신 상태가 아니면 경고를 출력하고 커밋을 중단하는 pre-commit 훅을 추가한다.

## 변경 내용

- `.husky/pre-commit`: submodule 최신 여부 확인 후 최신이 아닌 경우 현재/최신 커밋 해시를 안내하고 abort

## 동작 방식

1. 스테이징된 submodule 커밋 해시와 원격 최신 커밋 해시를 비교한다.
2. 다를 경우 현재 커밋과 최신 커밋을 출력하고 커밋을 중단한다.
3. `git submodule update --remote --checkout secret` 후 재커밋하도록 안내한다.

## 관련 이슈

close #32