### PR TITLE
feat: Google OAuth2 OIDC 로그인 지원 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
@@ -1,6 +1,7 @@
 package com.firstpenguin.app.domain.auth.config
 
 import com.firstpenguin.app.domain.auth.oauth.CustomOAuth2UserService
+import com.firstpenguin.app.domain.auth.oauth.CustomOidcUserService
 import com.firstpenguin.app.domain.auth.oauth.JwtIssueSuccessHandler
 import com.firstpenguin.app.domain.auth.oauth.OAuth2FailureHandler
 import com.firstpenguin.app.domain.auth.token.JWT_AUTHENTICATION_ERROR_ATTRIBUTE
@@ -29,6 +30,7 @@ import tools.jackson.databind.json.JsonMapper
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
     private val customOAuth2UserService: CustomOAuth2UserService,
+    private val customOidcUserService: CustomOidcUserService,
     private val jwtIssueSuccessHandler: JwtIssueSuccessHandler,
     private val oAuth2FailureHandler: OAuth2FailureHandler,
     private val jsonMapper: JsonMapper,
@@ -63,7 +65,10 @@ class SecurityConfig(
 
     private fun configureOAuth2Login(http: HttpSecurity) {
         http.oauth2Login { oauth2 ->
-            oauth2.userInfoEndpoint { userInfo -> userInfo.userService(customOAuth2UserService) }
+            oauth2.userInfoEndpoint { userInfo ->
+                userInfo.userService(customOAuth2UserService)
+                userInfo.oidcUserService(customOidcUserService)
+            }
             oauth2.successHandler(jwtIssueSuccessHandler)
             oauth2.failureHandler(oAuth2FailureHandler)
         }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/CustomOidcUserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/CustomOidcUserService.kt
@@ -17,18 +17,22 @@ class CustomOidcUserService(
         val externalId = oidcUser.subject
         val nickname = oidcUser.fullName
 
-        val profile = OAuthUserProfile(
-            provider = Provider.GOOGLE,
-            providerId = externalId,
-            email = oidcUser.email,
-            nickname = normalizeNickname(nickname, externalId),
-        )
+        val profile =
+            OAuthUserProfile(
+                provider = Provider.GOOGLE,
+                providerId = externalId,
+                email = oidcUser.email,
+                nickname = normalizeNickname(nickname, externalId),
+            )
         val user = oAuthUserUseCase.upsertOAuthUser(profile)
 
         return OidcAuthenticatedUser(user = user, idToken = oidcUser.idToken, userInfo = oidcUser.userInfo)
     }
 
-    private fun normalizeNickname(nickname: String?, externalId: String): String {
+    private fun normalizeNickname(
+        nickname: String?,
+        externalId: String,
+    ): String {
         val normalized = nickname.orEmpty().replace(WHITESPACE_REGEX, "").take(NICKNAME_MAX_LENGTH)
         if (normalized.isNotBlank()) return normalized
         return "google${externalId.takeLast(FALLBACK_SUFFIX_LENGTH)}".take(NICKNAME_MAX_LENGTH)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/CustomOidcUserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/CustomOidcUserService.kt
@@ -1,0 +1,42 @@
+package com.firstpenguin.app.domain.auth.oauth
+
+import com.firstpenguin.app.domain.user.model.OAuthUserProfile
+import com.firstpenguin.app.domain.user.model.Provider
+import com.firstpenguin.app.domain.user.usecase.OAuthUserUseCase
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.stereotype.Service
+
+@Service
+class CustomOidcUserService(
+    private val oAuthUserUseCase: OAuthUserUseCase,
+) : OidcUserService() {
+    override fun loadUser(userRequest: OidcUserRequest): OidcUser {
+        val oidcUser = super.loadUser(userRequest)
+        val externalId = oidcUser.subject
+        val nickname = oidcUser.fullName
+
+        val profile = OAuthUserProfile(
+            provider = Provider.GOOGLE,
+            providerId = externalId,
+            email = oidcUser.email,
+            nickname = normalizeNickname(nickname, externalId),
+        )
+        val user = oAuthUserUseCase.upsertOAuthUser(profile)
+
+        return OidcAuthenticatedUser(user = user, idToken = oidcUser.idToken, userInfo = oidcUser.userInfo)
+    }
+
+    private fun normalizeNickname(nickname: String?, externalId: String): String {
+        val normalized = nickname.orEmpty().replace(WHITESPACE_REGEX, "").take(NICKNAME_MAX_LENGTH)
+        if (normalized.isNotBlank()) return normalized
+        return "google${externalId.takeLast(FALLBACK_SUFFIX_LENGTH)}".take(NICKNAME_MAX_LENGTH)
+    }
+
+    private companion object {
+        const val NICKNAME_MAX_LENGTH = 15
+        const val FALLBACK_SUFFIX_LENGTH = 6
+        val WHITESPACE_REGEX = Regex("\\s+")
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/JwtIssueSuccessHandler.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/JwtIssueSuccessHandler.kt
@@ -21,11 +21,12 @@ class JwtIssueSuccessHandler(
         response: HttpServletResponse,
         authentication: Authentication,
     ) {
-        val user = when (val principal = authentication.principal) {
-            is OAuth2AuthenticatedUser -> principal.user
-            is OidcAuthenticatedUser -> principal.user
-            else -> error("Unsupported principal type: ${principal!!::class}")
-        }
+        val user =
+            when (val principal = authentication.principal) {
+                is OAuth2AuthenticatedUser -> principal.user
+                is OidcAuthenticatedUser -> principal.user
+                else -> error("Unsupported principal type: ${principal!!::class}")
+            }
         val refreshToken = refreshTokenUseCase.issue(user)
 
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookieManager.create(refreshToken).toString())

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/JwtIssueSuccessHandler.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/JwtIssueSuccessHandler.kt
@@ -21,8 +21,12 @@ class JwtIssueSuccessHandler(
         response: HttpServletResponse,
         authentication: Authentication,
     ) {
-        val oAuth2User = authentication.principal as OAuth2AuthenticatedUser
-        val refreshToken = refreshTokenUseCase.issue(oAuth2User.user)
+        val user = when (val principal = authentication.principal) {
+            is OAuth2AuthenticatedUser -> principal.user
+            is OidcAuthenticatedUser -> principal.user
+            else -> error("Unsupported principal type: ${principal!!::class}")
+        }
+        val refreshToken = refreshTokenUseCase.issue(user)
 
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookieManager.create(refreshToken).toString())
         response.sendRedirect(authProperties.oauth2.successRedirectUrl)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/OidcAuthenticatedUser.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/OidcAuthenticatedUser.kt
@@ -1,0 +1,14 @@
+package com.firstpenguin.app.domain.auth.oauth
+
+import com.firstpenguin.app.domain.user.model.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.oauth2.core.oidc.OidcIdToken
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser
+
+class OidcAuthenticatedUser(
+    val user: User,
+    idToken: OidcIdToken,
+    userInfo: OidcUserInfo?,
+    authorities: Collection<GrantedAuthority> = emptyList(),
+) : DefaultOidcUser(authorities, idToken, userInfo)


### PR DESCRIPTION
## 개요

Google OAuth2 로그인 시 발생하던 `ClassCastException` 수정 및 OIDC 플로우 지원 추가

## 원인

Google은 `openid` scope 포함 시 OIDC 플로우로 처리되어 Spring Security가 `DefaultOidcUser`를 반환합니다. 기존 코드는 `userService`만 등록하고 `oidcUserService`를 등록하지 않아 `JwtIssueSuccessHandler`에서 `OAuth2AuthenticatedUser`로 캐스팅 시 `ClassCastException`이 발생했습니다.

## 변경 사항

- `OidcAuthenticatedUser` 추가 — `DefaultOidcUser`를 상속하며 `User` 보관
- `CustomOidcUserService` 추가 — OIDC 플로우에서 사용자 upsert 후 `OidcAuthenticatedUser` 반환
- `SecurityConfig` — `oidcUserService` 등록
- `JwtIssueSuccessHandler` — `OAuth2AuthenticatedUser` / `OidcAuthenticatedUser` 두 타입 처리
- `secret` — Google OAuth2 클라이언트 등록 (dev)

## 테스트 체크리스트

- [ ] Google 로그인 성공 후 JWT 발급 확인
- [ ] Kakao 로그인 정상 동작 유지 확인
- [ ] DB에 Google 사용자 정상 저장 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * OpenID Connect(OIDC) 인증 지원 추가

* **개선사항**
  * 보안 설정 업데이트로 OIDC 사용자 관리 통합
  * JWT 발급 핸들러가 여러 인증 타입을 지원하도록 개선
  * 의존성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->