### PR TITLE
chore: submodule 최신 여부 검사를 pre-push 단계로 이동

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,32 +8,5 @@ else
   echo "gitleaks 미설치: 비밀키 검사를 건너뜁니다."
 fi
 
-# submodule 최신 여부 확인
-SUBMODULE_PATH="secret"
-SUBMODULE_URL=$(git config --file .gitmodules submodule."$SUBMODULE_PATH".url)
-SUBMODULE_BRANCH=$(git config --file .gitmodules submodule."$SUBMODULE_PATH".branch 2>/dev/null || echo "main")
-
-# 스테이징된 submodule 커밋 (실제로 커밋될 값)
-STAGED_COMMIT=$(git ls-files --stage -- "$SUBMODULE_PATH" | awk '{print $2}')
-
-if [ -n "$STAGED_COMMIT" ]; then
-  # ls-remote를 파이프 없이 실행해 exit code 마스킹 방지
-  LS_REMOTE_OUTPUT=$(git ls-remote "$SUBMODULE_URL" "refs/heads/$SUBMODULE_BRANCH")
-  REMOTE_COMMIT=$(echo "$LS_REMOTE_OUTPUT" | awk '{print $1}')
-
-  if [ -z "$REMOTE_COMMIT" ]; then
-    echo "❌ submodule 원격 커밋을 가져오지 못했습니다. 네트워크 또는 인증 오류를 확인하세요."
-    exit 1
-  fi
-
-  if [ "$STAGED_COMMIT" != "$REMOTE_COMMIT" ]; then
-    echo "❌ submodule '$SUBMODULE_PATH'이 최신 상태가 아닙니다."
-    echo "   현재: $STAGED_COMMIT"
-    echo "   최신: $REMOTE_COMMIT"
-    echo "   git submodule update --remote --checkout $SUBMODULE_PATH 후 다시 커밋하세요."
-    exit 1
-  fi
-fi
-
 # 최소 컴파일 검증 (app 모듈)
 cd app && ./gradlew testClasses

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,30 @@
 #!/usr/bin/env sh
 set -eu
 
+# submodule 최신 여부 확인
+SUBMODULE_PATH="secret"
+SUBMODULE_URL=$(git config --file .gitmodules submodule."$SUBMODULE_PATH".url)
+SUBMODULE_BRANCH=$(git config --file .gitmodules submodule."$SUBMODULE_PATH".branch 2>/dev/null || echo "main")
+
+# HEAD에 커밋된 submodule 포인터
+COMMITTED_COMMIT=$(git ls-tree HEAD -- "$SUBMODULE_PATH" | awk '{print $3}')
+
+if [ -n "$COMMITTED_COMMIT" ]; then
+  LS_REMOTE_OUTPUT=$(git ls-remote "$SUBMODULE_URL" "refs/heads/$SUBMODULE_BRANCH")
+  REMOTE_COMMIT=$(echo "$LS_REMOTE_OUTPUT" | awk '{print $1}')
+
+  if [ -z "$REMOTE_COMMIT" ]; then
+    echo "❌ submodule 원격 커밋을 가져오지 못했습니다. 네트워크 또는 인증 오류를 확인하세요."
+    exit 1
+  fi
+
+  if [ "$COMMITTED_COMMIT" != "$REMOTE_COMMIT" ]; then
+    echo "❌ submodule '$SUBMODULE_PATH'이 최신 상태가 아닙니다."
+    echo "   현재: $COMMITTED_COMMIT"
+    echo "   최신: $REMOTE_COMMIT"
+    echo "   git submodule update --remote --checkout $SUBMODULE_PATH 후 커밋하고 다시 push하세요."
+    exit 1
+  fi
+fi
+
 cd app && ./gradlew clean test


### PR DESCRIPTION
## 개요

submodule(`secret`)이 최신 상태가 아닐 때 커밋을 막던 로직을 **push 단계로 이동**합니다.

## 변경 사항

### `.husky/pre-commit`
- submodule 최신 여부 검사 제거
- gitleaks 비밀키 검사 + `testClasses` 컴파일 검증만 수행

### `.husky/pre-push`
- submodule 최신 여부 검사 추가
- `git ls-tree HEAD`로 커밋된 submodule 포인터를 원격 최신 커밋과 비교
- 불일치 시 push 차단 및 업데이트 안내 메시지 출력
- 기존 `clean test` 수행

## 변경 이유

기존 pre-commit 방식은 submodule이 오래됐을 때 **커밋 자체를 막아** 개발 흐름을 불필요하게 방해했습니다.
submodule 최신 여부는 **원격에 반영되는 시점(push)** 에 강제하는 것이 적절합니다.

## 테스트

- submodule이 최신이 아닌 상태에서 push 시 차단 메시지 확인
- submodule 업데이트 후 커밋 → push 정상 동작 확인