### PR TITLE
chore: GCS 이미지 버킷 생성 및 관련 설정 추가 (#42)

### DIFF
--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -164,10 +164,10 @@ resource "google_service_account" "api" {
   display_name = "${var.env} API Server Service Account"
 }
 
-resource "google_project_iam_member" "api_sa_token_creator" {
-  project = var.project_id
-  role    = "roles/iam.serviceAccountTokenCreator"
-  member  = "serviceAccount:${google_service_account.api.email}"
+resource "google_service_account_iam_member" "api_sa_token_creator" {
+  service_account_id = google_service_account.api.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.api.email}"
 }
 
 # ============================================

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -143,10 +143,59 @@ resource "google_compute_instance" "api" {
     }
   }
 
+  service_account {
+    email  = google_service_account.api.email
+    scopes = ["cloud-platform"]
+  }
+
   tags = ["api-server"]
 
   labels = {
     env     = var.env
     service = var.service_name
   }
+}
+
+# ============================================
+# Service Account (이미지 버킷용)
+# ============================================
+resource "google_service_account" "api" {
+  account_id   = "${var.env}-${var.service_name}-api-sa"
+  display_name = "${var.env} API Server Service Account"
+}
+
+resource "google_project_iam_member" "api_sa_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${google_service_account.api.email}"
+}
+
+# ============================================
+# GCS Image Bucket
+# ============================================
+resource "google_storage_bucket" "images" {
+  name          = "${var.env}-${var.service_name}-images"
+  location      = var.region
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+
+  cors {
+    origin          = ["https://senti.today"]
+    method          = ["GET", "PUT"]
+    response_header = ["Content-Type", "Access-Control-Allow-Origin"]
+    max_age_seconds = 3600
+  }
+}
+
+resource "google_storage_bucket_iam_member" "images_public_read" {
+  bucket = google_storage_bucket.images.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+resource "google_storage_bucket_iam_member" "images_api_sa_admin" {
+  bucket = google_storage_bucket.images.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.api.email}"
 }

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -174,7 +174,7 @@ resource "google_project_iam_member" "api_sa_token_creator" {
 # GCS Image Bucket
 # ============================================
 resource "google_storage_bucket" "images" {
-  name          = "${var.env}-senti-images"
+  name          = "${var.env}-${var.service_name}-images"
   location      = var.region
   force_destroy = false
 

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -174,7 +174,7 @@ resource "google_project_iam_member" "api_sa_token_creator" {
 # GCS Image Bucket
 # ============================================
 resource "google_storage_bucket" "images" {
-  name          = "${var.env}-${var.service_name}-images"
+  name          = "${var.env}-senti-images"
   location      = var.region
   force_destroy = false
 

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -24,7 +24,7 @@ variable "env" {
 variable "service_name" {
   description = "서비스 이름"
   type        = string
-  default     = "firstpenguin"
+  default     = "senti"
 }
 
 variable "machine_type" {


### PR DESCRIPTION
## 개요

이미지 업로드/서빙을 위한 GCS 버킷과 서비스 어카운트를 Terraform으로 구성하고 관련 설정을 추가한다.

## 변경 사항

### Terraform (`infra/terraform/dev/main.tf`)
- `google_service_account` 생성 (`dev-firstpenguin-api-sa`)
- VM 인스턴스에 SA 연결 — 키 파일 없이 ADC(Application Default Credentials) 방식으로 동작
- GCS 버킷 생성 (`dev-firstpenguin-images`)
  - 공개 읽기 (`allUsers objectViewer`) — 이미지 URL 직접 서빙
  - SA에 `objectAdmin` 권한 — Presigned URL 발급용
  - CORS: `https://senti.today`, `GET/PUT` 허용

### Secret Submodule (`application-dev.yml`)
- `gcs.bucket-name`, `gcs.base-url` 추가
- `auth.oauth2.success-redirect-url`: `/login/kakao/callback` → `/login/callback`

## 참고

- Presigned URL 발급 시 SA가 `roles/iam.serviceAccountTokenCreator` 권한으로 서명
- 로컬 환경은 dev 버킷을 공유해서 사용 (`application-local.yml` gitignore 처리됨)

## 완료 조건

- [ ] `terraform plan` 확인
- [ ] `terraform apply` 적용 및 버킷 생성 확인
- [ ] Presigned URL 발급 및 이미지 업로드 동작 확인

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 이미지 저장 및 공개 접근 기능이 추가되었습니다.
* CORS 설정으로 다중 도메인 접근을 지원합니다.

## Chores
* API 서비스 계정이 추가되고 클라우드 권한이 구성되었습니다.
* 이미지 저장소에 대한 관리 권한이 설정되었습니다.
* 인프라 배포 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->