### PR TITLE
[Refactor] 이미지 테이블 수정으로 인한 후속 작업

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/model/Diary.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/model/Diary.kt
@@ -6,7 +6,6 @@ data class Diary(
     val id: Long,
     val userId: Long,
     val quoteId: Long,
-    val diaryImageId: Long?,
     val emotionIntensity: String,
     val content: String?,
     val createdAt: LocalDateTime,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/repository/DiaryRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/repository/DiaryRepository.kt
@@ -2,7 +2,10 @@ package com.firstpenguin.app.domain.diary.repository
 
 import com.firstpenguin.app.domain.book.repository.BookTable
 import com.firstpenguin.app.domain.diary.model.Diary
+import com.firstpenguin.app.domain.image.repository.table.ImageOwnerTable
+import com.firstpenguin.app.domain.image.repository.table.ImageTable
 import com.firstpenguin.app.domain.quote.repository.QuoteTable
+import com.firstpenguin.app.global.enums.ImageOwner
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
@@ -43,6 +46,18 @@ class DiaryRepository(
             .where(DiaryTable.ID.eq(id))
             .and(DiaryTable.DELETED_AT.isNull)
             .fetchOne(::toDiary)
+
+    fun findDiaryImageUrlByDiaryId(id: Long): String? =
+        dsl
+            .select(ImageTable.URL)
+            .from(ImageOwnerTable.IMAGE_OWNERS)
+            .join(ImageTable.IMAGES)
+            .on(ImageOwnerTable.IMAGE_ID.eq(ImageTable.ID))
+            .where(ImageOwnerTable.OWNER_TYPE.eq(ImageOwner.DIARY.name))
+            .and(ImageOwnerTable.OWNER_ID.eq(id))
+            .orderBy(ImageOwnerTable.SORT_ORDER.asc(), ImageOwnerTable.IMAGE_ID.asc())
+            .limit(1)
+            .fetchOne(ImageTable.URL)
 
     fun updateContent(
         id: Long,
@@ -87,7 +102,6 @@ class DiaryRepository(
             id = record.get(DiaryTable.ID),
             userId = record.get(DiaryTable.USER_ID),
             quoteId = record.get(DiaryTable.QUOTE_ID),
-            diaryImageId = record.get(DiaryTable.DIARY_IMAGE_ID),
             emotionIntensity = record.get(DiaryTable.EMOTION_INTENSITY),
             content = record.get(DiaryTable.CONTENT),
             createdAt = record.get(DiaryTable.CREATED_AT),
@@ -108,7 +122,6 @@ class DiaryRepository(
                 DiaryTable.ID,
                 DiaryTable.USER_ID,
                 DiaryTable.QUOTE_ID,
-                DiaryTable.DIARY_IMAGE_ID,
                 DiaryTable.EMOTION_INTENSITY,
                 DiaryTable.CONTENT,
                 DiaryTable.CREATED_AT,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/repository/DiaryTable.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/repository/DiaryTable.kt
@@ -8,7 +8,6 @@ internal object DiaryTable {
     val ID = DSL.field(DSL.name("diaries", "id"), Long::class.java)
     val USER_ID = DSL.field(DSL.name("diaries", "user_id"), Long::class.java)
     val QUOTE_ID = DSL.field(DSL.name("diaries", "quote_id"), Long::class.java)
-    val DIARY_IMAGE_ID = DSL.field(DSL.name("diaries", "diary_image_id"), Long::class.java)
     val EMOTION_INTENSITY = DSL.field(DSL.name("diaries", "emotion_intensity"), String::class.java)
     val CONTENT = DSL.field(DSL.name("diaries", "content"), String::class.java)
     val CREATED_AT = DSL.field(DSL.name("diaries", "created_at"), LocalDateTime::class.java)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/service/DiaryService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/service/DiaryService.kt
@@ -16,6 +16,8 @@ class DiaryService(
         diaryRepository.findById(id)
             ?: throw CustomException(ErrorCode.DIARY_NOT_FOUND)
 
+    fun findDiaryImageUrlByDiaryId(id: Long): String? = diaryRepository.findDiaryImageUrlByDiaryId(id)
+
     fun updateContent(
         id: Long,
         userId: Long,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/usecase/DiaryUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/usecase/DiaryUseCase.kt
@@ -4,7 +4,6 @@ import com.firstpenguin.app.domain.diary.dto.DiaryDetailResponse
 import com.firstpenguin.app.domain.diary.dto.DiaryPeriodResponse
 import com.firstpenguin.app.domain.diary.dto.UpdateDiaryContentRequest
 import com.firstpenguin.app.domain.diary.service.DiaryService
-import com.firstpenguin.app.domain.image.service.ImageService
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.stereotype.Component
@@ -14,7 +13,6 @@ import java.time.LocalDate
 @Component
 class DiaryUseCase(
     private val diaryService: DiaryService,
-    private val imageService: ImageService,
 ) {
     @Transactional
     fun deleteDiary(
@@ -70,7 +68,9 @@ class DiaryUseCase(
     ): DiaryDetailResponse {
         val diary = diaryService.getById(diaryId)
         validateDiaryOwner(ownerId = diary.userId, userId = userId)
-        val diaryImageUrl = diary.diaryImageId?.let(imageService::findUrlById)
+        val diaryImageUrl =
+            diaryService
+                .findDiaryImageUrlByDiaryId(diary.id)
 
         return DiaryDetailResponse.from(diary, diaryImageUrl)
     }

--- a/app/src/main/resources/db/migration/V17__drop_diary_image_id_from_diaries.sql
+++ b/app/src/main/resources/db/migration/V17__drop_diary_image_id_from_diaries.sql
@@ -1,0 +1,2 @@
+ALTER TABLE diaries
+    DROP COLUMN diary_image_id;

--- a/app/src/main/resources/db/migration/V18__insert_dummy_diary_data.sql
+++ b/app/src/main/resources/db/migration/V18__insert_dummy_diary_data.sql
@@ -1,0 +1,71 @@
+INSERT INTO users (
+    id,
+    provider,
+    provider_id,
+    email,
+    nickname,
+    profile_image_id,
+    status,
+    last_login_at,
+    deleted_at,
+    created_at,
+    updated_at
+) OVERRIDING SYSTEM VALUE VALUES (
+    9001,
+    'KAKAO',
+    'dummy-kakao-provider-id',
+    'dummy@example.com',
+    '더미사용자',
+    NULL,
+    'ACTIVE',
+    CURRENT_TIMESTAMP,
+    NULL,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+);
+
+INSERT INTO images (
+    id,
+    url,
+    created_at
+) OVERRIDING SYSTEM VALUE VALUES (
+    9002,
+    'https://cdn.example.com/dummy-diary-image.png',
+    CURRENT_TIMESTAMP
+);
+
+INSERT INTO diaries (
+    id,
+    user_id,
+    quote_id,
+    emotion_intensity,
+    content,
+    created_at,
+    updated_at,
+    deleted_at
+) OVERRIDING SYSTEM VALUE VALUES (
+    9003,
+    9001,
+    1,
+    'HIGH',
+    '더미 일기 데이터입니다.',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    NULL
+);
+
+INSERT INTO image_owners (
+    image_id,
+    owner_type,
+    owner_id,
+    sort_order
+) VALUES (
+    9002,
+    'DIARY',
+    9003,
+    0
+);
+
+SELECT setval('users_id_seq', (SELECT COALESCE(MAX(id), 1) FROM users), true);
+SELECT setval('images_id_seq', (SELECT COALESCE(MAX(id), 1) FROM images), true);
+SELECT setval('diaries_id_seq', (SELECT COALESCE(MAX(id), 1) FROM diaries), true);

--- a/app/src/main/resources/db/migration/V19__restore_books_cover_image_url.sql
+++ b/app/src/main/resources/db/migration/V19__restore_books_cover_image_url.sql
@@ -1,0 +1,2 @@
+ALTER TABLE books
+    ADD COLUMN cover_image_url TEXT NOT NULL DEFAULT 'https://cdn.example.com/book-cover-placeholder.png';


### PR DESCRIPTION
## 📢 요약
- `diary`가 직접 `diary_image_id`를 들고 있던 구조를 제거하고, `image_owners -> images` 조인으로 일기 이미지를 조회하도록 변경했습니다.
- 일기 상세 조회는 `diary.id` 기준으로 `ImageOwner.DIARY`에 연결된 대표 이미지를 사용합니다.
- `books.cover_image_url`은 유지되도록 복구 마이그레이션을 추가했습니다.
- 로컬에서 바로 확인할 수 있도록 최소 더미 데이터도 추가했습니다.

🔗 연관 이슈: Resolves #번호

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
```bash
./gradlew compileKotlin --rerun-tasks
./gradlew lintKotlin
./gradlew detekt

## 📜 기타

- 일기 이미지는 이제 image_owners(owner_type = 'DIARY', owner_id = diary.id) 기준으로 해석합니다.
- 책 표지 이미지는 기존처럼 books.cover_image_url을 사용합니다.
- V18 더미 데이터는 로컬 확인용입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 도서 표지 이미지 URL 지원 추가

* **리팩토링**
  * 일기 이미지 조회 메커니즘 개선
  * 데이터베이스 스키마 정규화 및 최적화
  * 이미지 소유권 기반 관리 시스템 강화
  * 내부 서비스 의존성 구조 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->