### PR TITLE
feat: presigned URL 발급 시 images row 생성 및 imageId 반환

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ cd app && ./gradlew build      # 빌드
 cd app && ./gradlew test       # 테스트
 cd app && ./gradlew bootRun    # 실행
 cd app && ./gradlew testClasses # 컴파일 검증만
+cd app && ./gradlew ktlintFormat # 코드 포맷 자동 수정 — push 전 반드시 실행
 ```
 
 ## 프로젝트 구조

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ cd app && ./gradlew build      # 빌드
 cd app && ./gradlew test       # 테스트
 cd app && ./gradlew bootRun    # 실행
 cd app && ./gradlew testClasses # 컴파일 검증만
-cd app && ./gradlew ktlintFormat # 코드 포맷 자동 수정 — push 전 반드시 실행
+cd app && ./gradlew formatKotlin # 코드 포맷 자동 수정 — push 전 반드시 실행
 ```
 
 ## 프로젝트 구조

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ cd app && ./gradlew test       # 테스트
 cd app && ./gradlew bootRun    # 실행
 cd app && ./gradlew testClasses # 컴파일 검증만
 cd app && ./gradlew formatKotlin # 코드 포맷 자동 수정 — push 전 반드시 실행
+cd app && ./gradlew lintKotlin   # 포맷 lint 검사 — push 전 반드시 실행
 cd app && ./gradlew detekt       # 정적 분석 — push 전 반드시 실행
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ cd app && ./gradlew test       # 테스트
 cd app && ./gradlew bootRun    # 실행
 cd app && ./gradlew testClasses # 컴파일 검증만
 cd app && ./gradlew formatKotlin # 코드 포맷 자동 수정 — push 전 반드시 실행
+cd app && ./gradlew detekt       # 정적 분석 — push 전 반드시 실행
 ```
 
 ## 프로젝트 구조

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/controller/ImageController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/controller/ImageController.kt
@@ -66,7 +66,8 @@ class ImageController(
     )
     fun issuePresignedUrl(
         @RequestBody request: PresignedUrlRequest,
-    ): ResponseEntity<PresignedUrlResponse> = ResponseEntity.ok(imageUseCase.issuePresignedUrl(request.type, request.contentType))
+    ): ResponseEntity<PresignedUrlResponse> =
+        ResponseEntity.ok(imageUseCase.issuePresignedUrl(request.type, request.contentType))
 
     private companion object {
         const val PRESIGNED_URL_DESCRIPTION =

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/controller/ImageController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/controller/ImageController.kt
@@ -3,6 +3,15 @@ package com.firstpenguin.app.domain.image.controller
 import com.firstpenguin.app.domain.image.dto.PresignedUrlRequest
 import com.firstpenguin.app.domain.image.dto.PresignedUrlResponse
 import com.firstpenguin.app.domain.image.service.ImageService
+import com.firstpenguin.app.global.response.ErrorResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -11,14 +20,62 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/images")
+@Tag(name = "이미지", description = "이미지 업로드 API")
 class ImageController(
     private val imageService: ImageService,
 ) {
     @PostMapping("/presigned-url")
+    @Operation(
+        summary = "이미지 업로드용 presigned URL 발급",
+        description = PRESIGNED_URL_DESCRIPTION,
+        security = [SecurityRequirement(name = "bearerAuth")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "presigned URL 발급 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = PresignedUrlResponse::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "지원하지 않는 contentType입니다. (image/jpeg, image/png, image/webp만 허용)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ErrorResponse::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "access token이 없거나, 만료되었거나, 유효하지 않습니다.",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ErrorResponse::class),
+                    ),
+                ],
+            ),
+        ],
+    )
     fun issuePresignedUrl(
         @RequestBody request: PresignedUrlRequest,
     ): ResponseEntity<PresignedUrlResponse> {
         val (presignedUrl, imageId) = imageService.issue(request.type, request.contentType)
         return ResponseEntity.ok(PresignedUrlResponse(presignedUrl, imageId))
+    }
+
+    private companion object {
+        const val PRESIGNED_URL_DESCRIPTION =
+            "GCS에 이미지를 직접 업로드하기 위한 presigned URL과 imageId를 반환합니다. " +
+                "클라이언트는 presigned URL로 GCS에 PUT 업로드한 뒤, " +
+                "도메인 생성 API 호출 시 imageId를 함께 전달합니다. " +
+                "contentType은 image/jpeg, image/png, image/webp만 허용합니다."
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/controller/ImageController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/controller/ImageController.kt
@@ -66,8 +66,7 @@ class ImageController(
     )
     fun issuePresignedUrl(
         @RequestBody request: PresignedUrlRequest,
-    ): ResponseEntity<PresignedUrlResponse> =
-        ResponseEntity.ok(imageUseCase.issuePresignedUrl(request.type, request.contentType))
+    ): ResponseEntity<PresignedUrlResponse> = ResponseEntity.ok(imageUseCase.issuePresignedUrl(request))
 
     private companion object {
         const val PRESIGNED_URL_DESCRIPTION =

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/controller/ImageController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/controller/ImageController.kt
@@ -18,7 +18,7 @@ class ImageController(
     fun issuePresignedUrl(
         @RequestBody request: PresignedUrlRequest,
     ): ResponseEntity<PresignedUrlResponse> {
-        val (presignedUrl, publicUrl) = imageService.issue(request.type, request.contentType)
-        return ResponseEntity.ok(PresignedUrlResponse(presignedUrl, publicUrl))
+        val (presignedUrl, imageId) = imageService.issue(request.type, request.contentType)
+        return ResponseEntity.ok(PresignedUrlResponse(presignedUrl, imageId))
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/controller/ImageController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/controller/ImageController.kt
@@ -2,7 +2,7 @@ package com.firstpenguin.app.domain.image.controller
 
 import com.firstpenguin.app.domain.image.dto.PresignedUrlRequest
 import com.firstpenguin.app.domain.image.dto.PresignedUrlResponse
-import com.firstpenguin.app.domain.image.service.ImageService
+import com.firstpenguin.app.domain.image.usecase.ImageUseCase
 import com.firstpenguin.app.global.response.ErrorResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/images")
 @Tag(name = "이미지", description = "이미지 업로드 API")
 class ImageController(
-    private val imageService: ImageService,
+    private val imageUseCase: ImageUseCase,
 ) {
     @PostMapping("/presigned-url")
     @Operation(
@@ -66,10 +66,7 @@ class ImageController(
     )
     fun issuePresignedUrl(
         @RequestBody request: PresignedUrlRequest,
-    ): ResponseEntity<PresignedUrlResponse> {
-        val (presignedUrl, imageId) = imageService.issue(request.type, request.contentType)
-        return ResponseEntity.ok(PresignedUrlResponse(presignedUrl, imageId))
-    }
+    ): ResponseEntity<PresignedUrlResponse> = ResponseEntity.ok(imageUseCase.issuePresignedUrl(request.type, request.contentType))
 
     private companion object {
         const val PRESIGNED_URL_DESCRIPTION =

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/dto/PresignedUrlRequest.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/dto/PresignedUrlRequest.kt
@@ -1,8 +1,12 @@
 package com.firstpenguin.app.domain.image.dto
 
 import com.firstpenguin.app.domain.image.model.ImageType
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(description = "presigned URL 발급 요청")
 data class PresignedUrlRequest(
+    @field:Schema(description = "이미지 타입", example = "DIARY")
     val type: ImageType,
+    @field:Schema(description = "이미지 MIME 타입. image/jpeg, image/png, image/webp만 허용", example = "image/jpeg")
     val contentType: String,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/dto/PresignedUrlResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/dto/PresignedUrlResponse.kt
@@ -4,7 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "presigned URL 발급 응답")
 data class PresignedUrlResponse(
-    @field:Schema(description = "GCS PUT 업로드용 presigned URL (15분 유효)", example = "https://storage.googleapis.com/bucket/diary/uuid.jpg?X-Goog-Signature=...")
+    @field:Schema(
+        description = "GCS PUT 업로드용 presigned URL (15분 유효)",
+        example = "https://storage.googleapis.com/bucket/diary/uuid.jpg?X-Goog-Signature=...",
+    )
     val presignedUrl: String,
     @field:Schema(description = "업로드된 이미지의 ID. 도메인 생성 시 전달", example = "1")
     val imageId: Long,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/dto/PresignedUrlResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/dto/PresignedUrlResponse.kt
@@ -2,5 +2,5 @@ package com.firstpenguin.app.domain.image.dto
 
 data class PresignedUrlResponse(
     val presignedUrl: String,
-    val publicUrl: String,
+    val imageId: Long,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/dto/PresignedUrlResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/dto/PresignedUrlResponse.kt
@@ -1,6 +1,11 @@
 package com.firstpenguin.app.domain.image.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "presigned URL 발급 응답")
 data class PresignedUrlResponse(
+    @field:Schema(description = "GCS PUT 업로드용 presigned URL (15분 유효)", example = "https://storage.googleapis.com/bucket/diary/uuid.jpg?X-Goog-Signature=...")
     val presignedUrl: String,
+    @field:Schema(description = "업로드된 이미지의 ID. 도메인 생성 시 전달", example = "1")
     val imageId: Long,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/repository/ImageRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/repository/ImageRepository.kt
@@ -30,4 +30,11 @@ class ImageRepository(
             .and(ImageOwnerTable.OWNER_ID.eq(ownerId))
             .orderBy(ImageOwnerTable.SORT_ORDER.asc())
             .fetch(ImageTable.URL)
+
+    fun save(url: String): Long =
+        dsl
+            .insertInto(ImageTable.IMAGES, ImageTable.URL)
+            .values(url)
+            .returning(ImageTable.ID)
+            .fetchOne(ImageTable.ID)!!
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/repository/ImageRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/repository/ImageRepository.kt
@@ -4,6 +4,7 @@ import com.firstpenguin.app.domain.image.repository.table.ImageOwnerTable
 import com.firstpenguin.app.domain.image.repository.table.ImageTable
 import com.firstpenguin.app.global.enums.ImageOwner
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -37,4 +38,23 @@ class ImageRepository(
             .values(url)
             .returning(ImageTable.ID)
             .fetchOne(ImageTable.ID)!!
+
+    fun saveOwners(
+        ownerType: ImageOwner,
+        ownerId: Long,
+        imageIds: List<Long>,
+    ) {
+        dsl
+            .insertInto(
+                ImageOwnerTable.IMAGE_OWNERS,
+                ImageOwnerTable.IMAGE_ID,
+                ImageOwnerTable.OWNER_TYPE,
+                ImageOwnerTable.OWNER_ID,
+                ImageOwnerTable.SORT_ORDER,
+            ).valuesOfRows(
+                imageIds.mapIndexed { index, imageId ->
+                    DSL.row(imageId, ownerType.name, ownerId, index)
+                },
+            ).execute()
+    }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/service/ImageService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/service/ImageService.kt
@@ -32,4 +32,13 @@ class ImageService(
         val imageId = imageRepository.save(publicUrl)
         return presignedUrl to imageId
     }
+
+    fun saveImages(
+        imageIds: List<Long>,
+        ownerType: ImageOwner,
+        ownerId: Long,
+    ) {
+        if (imageIds.isEmpty()) return
+        imageRepository.saveOwners(ownerType, ownerId, imageIds)
+    }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/service/ImageService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/service/ImageService.kt
@@ -24,10 +24,12 @@ class ImageService(
     fun issue(
         type: ImageType,
         contentType: String,
-    ): Pair<String, String> {
+    ): Pair<String, Long> {
         if (contentType !in ALLOWED_CONTENT_TYPES) {
             throw CustomException(ErrorCode.UNSUPPORTED_IMAGE_CONTENT_TYPE)
         }
-        return cloudStorageService.issuePresignedUrl(type, contentType)
+        val (presignedUrl, publicUrl) = cloudStorageService.issuePresignedUrl(type, contentType)
+        val imageId = imageRepository.save(publicUrl)
+        return presignedUrl to imageId
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/usecase/ImageUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/usecase/ImageUseCase.kt
@@ -1,7 +1,7 @@
 package com.firstpenguin.app.domain.image.usecase
 
+import com.firstpenguin.app.domain.image.dto.PresignedUrlRequest
 import com.firstpenguin.app.domain.image.dto.PresignedUrlResponse
-import com.firstpenguin.app.domain.image.model.ImageType
 import com.firstpenguin.app.domain.image.service.ImageService
 import org.springframework.stereotype.Component
 
@@ -9,11 +9,8 @@ import org.springframework.stereotype.Component
 class ImageUseCase(
     private val imageService: ImageService,
 ) {
-    fun issuePresignedUrl(
-        type: ImageType,
-        contentType: String,
-    ): PresignedUrlResponse {
-        val (presignedUrl, imageId) = imageService.issue(type, contentType)
+    fun issuePresignedUrl(request: PresignedUrlRequest): PresignedUrlResponse {
+        val (presignedUrl, imageId) = imageService.issue(request.type, request.contentType)
         return PresignedUrlResponse(presignedUrl, imageId)
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/image/usecase/ImageUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/image/usecase/ImageUseCase.kt
@@ -1,0 +1,19 @@
+package com.firstpenguin.app.domain.image.usecase
+
+import com.firstpenguin.app.domain.image.dto.PresignedUrlResponse
+import com.firstpenguin.app.domain.image.model.ImageType
+import com.firstpenguin.app.domain.image.service.ImageService
+import org.springframework.stereotype.Component
+
+@Component
+class ImageUseCase(
+    private val imageService: ImageService,
+) {
+    fun issuePresignedUrl(
+        type: ImageType,
+        contentType: String,
+    ): PresignedUrlResponse {
+        val (presignedUrl, imageId) = imageService.issue(type, contentType)
+        return PresignedUrlResponse(presignedUrl, imageId)
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/image/service/ImageServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/image/service/ImageServiceTest.kt
@@ -1,0 +1,71 @@
+package com.firstpenguin.app.domain.image.service
+
+import com.firstpenguin.app.domain.image.model.ImageType
+import com.firstpenguin.app.domain.image.repository.ImageRepository
+import com.firstpenguin.app.global.enums.ImageOwner
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class ImageServiceTest {
+    @Mock
+    lateinit var imageRepository: ImageRepository
+
+    @Mock
+    lateinit var cloudStorageService: CloudStorageService
+
+    @InjectMocks
+    lateinit var imageService: ImageService
+
+    @Test
+    fun `issue - 허용된 contentType이면 presignedUrl과 imageId를 반환한다`() {
+        val presignedUrl = "https://storage.googleapis.com/presigned"
+        val publicUrl = "https://storage.googleapis.com/bucket/diary/uuid.jpg"
+        val imageId = 1L
+
+        Mockito
+            .`when`(cloudStorageService.issuePresignedUrl(ImageType.DIARY, "image/jpeg"))
+            .thenReturn(presignedUrl to publicUrl)
+        Mockito.`when`(imageRepository.save(publicUrl)).thenReturn(imageId)
+
+        val (resultPresignedUrl, resultImageId) = imageService.issue(ImageType.DIARY, "image/jpeg")
+
+        assertEquals(presignedUrl, resultPresignedUrl)
+        assertEquals(imageId, resultImageId)
+    }
+
+    @Test
+    fun `issue - 허용되지 않은 contentType이면 예외를 던진다`() {
+        val exception =
+            assertThrows(CustomException::class.java) {
+                imageService.issue(ImageType.DIARY, "image/gif")
+            }
+
+        assertEquals(ErrorCode.UNSUPPORTED_IMAGE_CONTENT_TYPE, exception.errorCode)
+        Mockito.verifyNoInteractions(cloudStorageService, imageRepository)
+    }
+
+    @Test
+    fun `saveImages - imageIds가 있으면 saveOwners를 호출한다`() {
+        val imageIds = listOf(1L, 2L, 3L)
+
+        imageService.saveImages(imageIds, ImageOwner.DIARY, 10L)
+
+        Mockito.verify(imageRepository).saveOwners(ImageOwner.DIARY, 10L, imageIds)
+    }
+
+    @Test
+    fun `saveImages - imageIds가 비어있으면 saveOwners를 호출하지 않는다`() {
+        imageService.saveImages(emptyList(), ImageOwner.DIARY, 10L)
+
+        Mockito.verifyNoInteractions(imageRepository)
+    }
+}

--- a/docs/cd-pipeline.md
+++ b/docs/cd-pipeline.md
@@ -80,8 +80,8 @@ gradle:8.13-jdk21                   eclipse-temurin:21-jre
 # 로컬에서 키 생성
 ssh-keygen -t ed25519 -C "github-actions-deploy" -f ~/.ssh/deploy_key
 
-# 공개키를 서버에 등록
-cat ~/.ssh/deploy_key.pub | ssh ubuntu@{서버IP} "cat >> ~/.ssh/authorized_keys"
+# 공개키를 Terraform ssh_public_keys에 등록한 뒤 인프라에 반영
+terraform -chdir=infra/terraform/dev apply
 
 # 개인키를 GitHub Secrets에 등록 (SERVER_SSH_KEY)
 cat ~/.ssh/deploy_key

--- a/docs/image-policy.md
+++ b/docs/image-policy.md
@@ -1,4 +1,4 @@
-# 이미지 정책
+# 이미지 업로드 흐름과 저장 정책
 
 ## 기본 원칙
 
@@ -8,6 +8,7 @@
 DB에는 최종 조회용 public URL을 저장한다.
 `images.url`은 서비스가 허용한 스토리지에 업로드된 이미지의 절대 public URL을 의미한다.
 presigned URL은 업로드용 임시 URL이므로 DB에 저장하지 않는다.
+클라이언트는 public URL을 직접 저장 API에 전달하지 않고, 백엔드가 발급한 `imageId`만 도메인 API에 전달한다.
 
 현재 스토리지는 GCP Cloud Storage(dev 환경)를 사용한다.
 
@@ -16,16 +17,30 @@ presigned URL은 업로드용 임시 URL이므로 DB에 저장하지 않는다.
 이미지 업로드는 클라이언트 직접 업로드 방식으로 처리한다.
 
 1. 클라이언트가 백엔드에 presigned URL 발급을 요청한다. 요청 시 이미지 타입과 파일 형식을 함께 전달한다.
-2. 백엔드는 타입에 따라 경로 prefix를 결정하고, UUID로 파일명을 생성한 뒤 presigned URL과 public URL을 함께 반환한다.
-3. 클라이언트는 presigned URL로 스토리지에 파일을 직접 업로드한다. PUT 요청 시 `Content-Type` 헤더를 발급 시 지정한 값과 동일하게 설정해야 한다.
-4. 업로드 성공 후 클라이언트는 public URL을 백엔드 저장 API에 전달한다.
-5. 백엔드는 public URL을 검증한 뒤 `images.url`에 저장한다.
+2. 백엔드는 타입에 따라 경로 prefix를 결정하고, UUID로 파일명을 생성한다.
+3. 백엔드는 GCS 업로드용 presigned URL과 최종 조회용 public URL을 생성한다.
+4. 백엔드는 public URL을 `images.url`에 먼저 저장하고, 생성된 `images.id`를 `imageId`로 반환한다.
+5. 클라이언트는 presigned URL로 스토리지에 파일을 직접 업로드한다. PUT 요청 시 `Content-Type` 헤더를 발급 시 지정한 값과 동일하게 설정해야 한다.
+6. 도메인 생성 API는 클라이언트가 전달한 `imageIds`를 받아 `image_owners`에 owner 연결만 저장한다.
+
+```text
+POST /images/presigned-url
+  -> GCS presigned URL 생성
+  -> images INSERT(publicUrl)
+  <- { presignedUrl, imageId }
+
+클라이언트 GCS PUT 업로드
+
+POST /diaries 또는 다른 도메인 생성 API
+  body: { ..., imageIds: [123] }
+  -> image_owners INSERT(imageId, ownerType, ownerId, sortOrder)
+```
 
 ### Presigned URL 발급 요청
 
 ```json
 {
-  "type": "DIARY_IMAGE",
+  "type": "DIARY",
   "contentType": "image/webp"
 }
 ```
@@ -35,10 +50,52 @@ presigned URL은 업로드용 임시 URL이므로 DB에 저장하지 않는다.
 | 필드 | 설명 |
 |------|------|
 | `presignedUrl` | 클라이언트가 스토리지에 파일을 업로드할 때 사용하는 임시 PUT URL |
-| `publicUrl` | 업로드 성공 후 DB에 저장하고 API 응답으로 내려줄 조회용 URL |
+| `imageId` | `images` 테이블에 저장된 이미지 ID. 도메인 생성 API 호출 시 전달 |
 
-스토리지 업로드 성공 여부는 클라이언트가 presigned URL 요청의 응답으로 판단한다.
-현재 단계에서는 `uploadId`, 임시 업로드 테이블, 스토리지 `HEAD` 검증, 완료 상태 관리는 도입하지 않는다.
+스토리지 업로드 성공 여부는 클라이언트가 GCS PUT 요청 결과로 판단한다.
+현재 응답에는 public URL을 노출하지 않는다.
+
+## 서버 저장 로직
+
+### `ImageService.issue(type, contentType)`
+
+presigned URL 발급 API에서 사용하는 로직이다.
+
+1. `contentType`이 허용 목록에 포함되는지 검증한다.
+2. `CloudStorageService.issuePresignedUrl(type, contentType)`으로 presigned URL과 public URL을 생성한다.
+3. `ImageRepository.save(publicUrl)`로 `images` row를 생성한다.
+4. `presignedUrl`과 `imageId`를 반환한다.
+
+### `ImageService.saveImages(imageIds, ownerType, ownerId)`
+
+도메인 생성 로직에서 가져다 쓰는 공용 연결 로직이다.
+
+1. `imageIds`가 비어 있으면 아무 작업도 하지 않는다.
+2. `ImageRepository.saveOwners(ownerType, ownerId, imageIds)`를 호출한다.
+3. `image_owners`에는 `image_id`, `owner_type`, `owner_id`, `sort_order`가 저장된다.
+
+`images` row는 presigned URL 발급 시점에 이미 생성되어 있으므로, 도메인 생성 시점에는 `image_owners` 연결만 만든다.
+
+## DB 저장 구조
+
+### `images`
+
+| 컬럼 | 설명 |
+|------|------|
+| `id` | 이미지 ID. presigned URL 발급 응답의 `imageId` |
+| `url` | 최종 조회용 public URL |
+| `created_at` | 이미지 row 생성 시각 |
+
+### `image_owners`
+
+| 컬럼 | 설명 |
+|------|------|
+| `image_id` | `images.id` |
+| `owner_type` | 이미지를 소유하거나 참조하는 도메인 타입 |
+| `owner_id` | 도메인 row ID |
+| `sort_order` | 같은 owner 내 이미지 정렬 순서 |
+
+하나의 도메인 owner가 여러 이미지를 가질 수 있으므로 `imageIds`는 리스트로 전달한다.
 
 ## 경로 정책
 
@@ -47,23 +104,18 @@ presigned URL은 업로드용 임시 URL이므로 DB에 저장하지 않는다.
 
 | ImageType | 경로 prefix |
 |-----------|------------|
-| `DIARY_IMAGE` | `diary/` |
-| `USER_PROFILE_IMAGE` | `user/profile/` |
+| `DIARY` | `diary/` |
+| `USER_PROFILE` | `user/profile/` |
+| `REPORT` | `report/` |
 
 최종 오브젝트 키 예시: `diary/550e8400-e29b-41d4-a716.webp`
 
-## URL 검증
+## URL 정책
 
-백엔드는 클라이언트가 전달한 public URL을 그대로 신뢰하지 않는다.
-저장 전에 최소한 다음 조건을 검증한다.
+백엔드는 클라이언트가 전달한 public URL을 저장하지 않는다.
+public URL은 백엔드가 GCS object key와 설정된 base URL로 직접 생성한다.
 
-- URL 형식이 정상이어야 한다.
-- 현재 환경에서 허용한 public base URL 또는 host에 속해야 한다.
-- presigned URL처럼 query string이 포함된 값은 저장하지 않는다.
-
-검증에 실패하면 DB에 저장하지 않고 `400 Bad Request`로 응답한다.
-
-환경별 허용 public URL 기준값은 설정으로 관리한다.
+환경별 public URL 기준값은 설정으로 관리한다.
 
 ```yaml
 gcs:
@@ -91,6 +143,20 @@ SVG, GIF, 동영상, 문서 파일은 이미지 업로드 대상에 포함하지
 
 이미지를 삭제하거나 교체하면 DB 레코드와 스토리지 객체 정리 책임이 함께 발생한다.
 스토리지 객체 정리를 즉시 처리할지, 별도 배치나 운영 작업으로 처리할지는 구현 시점에 정한다.
+
+## 현재 구현 범위와 TODO
+
+현재 구현은 presigned URL 발급 시 `images` row를 생성하고, 도메인 생성 로직에서 재사용할 수 있는 `saveImages()` 연결 메서드를 제공한다.
+
+다음 항목은 아직 구현하지 않았다.
+
+- `ImageCleanupScheduler` 기반 orphan image row 정리
+- GCS orphan object 정리
+- `imageId` 소유권 검증
+- `images.created_at` 기반 cleanup 인덱스
+
+presigned URL을 발급받았지만 도메인 생성까지 이어지지 않은 경우 `images` row가 orphan 상태로 남을 수 있다.
+추후 cleanup을 추가할 때는 `image_owners`에 연결되지 않고 일정 시간 이상 지난 `images` row를 삭제하는 방식으로 처리한다.
 
 ## 변경 가능성
 

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -19,6 +19,12 @@ provider "google" {
   region  = var.region
 }
 
+locals {
+  instance_ssh_keys = [
+    for ssh_key in var.ssh_public_keys : "${ssh_key.user}:${ssh_key.key}"
+  ]
+}
+
 # ============================================
 # VPC
 # ============================================
@@ -124,9 +130,14 @@ resource "google_compute_instance" "api" {
 
   allow_stopping_for_update = true
 
-  metadata = {
-    block-project-ssh-keys = "true"
-  }
+  metadata = merge(
+    {
+      block-project-ssh-keys = "true"
+    },
+    length(local.instance_ssh_keys) > 0 ? {
+      ssh-keys = join("\n", local.instance_ssh_keys)
+    } : {}
+  )
 
   boot_disk {
     initialize_params {

--- a/infra/terraform/dev/terraform.tfvars
+++ b/infra/terraform/dev/terraform.tfvars
@@ -4,3 +4,18 @@ zone         = "asia-northeast3-a"
 env          = "dev"
 service_name = "firstpenguin"
 machine_type = "e2-medium"
+
+ssh_public_keys = [
+  {
+    user = "ubuntu"
+    key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCqxGaKI8EFWkYt5MUmVkilFEbVA6a8iheAzU6hSA/e5FcdOXOabkZF135eE5pWAqIhwRnFZqsv33/xSnjXoa4uqcV2yPjTdr6iV4ed5dTerBfVwru8MNySPsy2J3gDlTJgyXSdpqwsSfmDvKF3taJw3+kHm/aH95uJ5ROQBKsDRcXDxdUeHFJOEwdWI/Z1nEpCfCWk6r53e0T1cZnXlmFc28TRLcP0q+fHxwgZQsxBXSqlUuJ069EYTpXlN3eAUVr5HIT3P0nHx0iUx6+OiZIxbcgH6uSB5LTHvvTIlUoN/icYdRjhPKEqpbm4CR3vco4C6/SzGD1Qci7oHqBG38iT8+Im1SFQTlDmLPFAF5uvgudf3Ih4uu8kX7mvPXQmCMI8k8BhXkrfPv+UN7cTecokW9j0o5vkw7HgG51qovGJ3gjhB4+yeQyyCcU9xhs876frH+Hs86udX1eNaV2j3XK/VvSFjjWXvZbbXzgdcgiM9uFqksJTHSTKkb5nMALU8E0="
+  },
+  {
+    user = "ubuntu"
+    key  = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFlgZGizA/SJSCulz3GkHD4EIX0OggijIPTcYLX+SKwd"
+  },
+  {
+    user = "ubuntu"
+    key  = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJmEd2Y1//SM9jRchQF4UT4nhBGCr+eVTEQlNhj1oxC2"
+  },
+]

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -32,3 +32,12 @@ variable "machine_type" {
   type        = string
   default     = "e2-medium"
 }
+
+variable "ssh_public_keys" {
+  description = "VM 인스턴스에 등록할 SSH 공개키 목록"
+  type = list(object({
+    user = string
+    key  = string
+  }))
+  default = []
+}


### PR DESCRIPTION
## 개요

Closes #51

presigned URL 발급 시점에 `images` row를 생성하고 `imageId`를 반환하도록 변경합니다.
도메인 생성 시에는 `imageId`를 받아 `image_owners` 연결만 처리합니다.

## 변경 사항

### 핵심 플로우 변경
- `PresignedUrlResponse`: `publicUrl` → `imageId: Long`
- `ImageService.issue()`: GCS presigned URL 생성 후 `images` INSERT, `Pair<String, Long>` 반환
- `ImageService.saveImages()`: `urls` 대신 `imageIds` 받아 `image_owners` INSERT만 수행
- `ImageRepository`: `save(url): Long`, `saveOwners()` 추가

### 문서 & 테스트
- `docs/image-policy.md`: 업로드 흐름, DB 구조, 경로/URL/파일 정책 정리
- `ImageServiceTest`: `issue()`, `saveImages()` 단위 테스트 4개 추가
- Swagger: presigned URL API `@Operation`, `@ApiResponses`, `@Schema` 추가
- `CLAUDE.md`: `formatKotlin` 태스크명 추가

## 클라이언트 흐름

```
POST /images/presigned-url
← { presignedUrl, imageId }

클라이언트 → GCS PUT 업로드 (presignedUrl 사용)

POST /diaries (또는 다른 도메인 생성)
body: { ..., imageIds: [123] }
```

## 미구현 TODO (별도 이슈로 처리 예정)

- orphan `images` row 정리 스케줄러 (`image_owners` 미연결 + 24시간 경과)
- GCS orphan 파일 정리 (lifecycle rule 별도 설정 필요)
- `imageId` 소유권 검증 (`images.created_by_user_id` 추가 필요)

> TODO 중 imageId 소유권 검증은 별도 이슈로 트래킹할지 여부를 검토해주세요.

## 테스트

- [x] `./gradlew test` 통과
- [x] `./gradlew formatKotlin` 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - presigned URL 발급 기능 개선: 발급 시 이미지 고유 ID(imageId)를 반환하고 서버에 이미지 저장 기록을 생성
  - 이미지 소유자 연계 저장 기능 추가
  - 업로드 시 MIME 타입 검증 강화

* **Documentation**
  - 이미지 업로드/저장 정책 및 도메인 흐름 문서 갱신
  - CD 파이프라인 문서 및 빌드/실행 안내(코틀린 포맷 명령 포함) 업데이트

* **Tests**
  - 이미지 서비스 단위 테스트 추가

* **Infra**
  - SSH 공개키 등록을 Terraform 기반으로 전환
<!-- end of auto-generated comment: release notes by coderabbit.ai -->