### PR TITLE
feat: Swagger 테스트용 Access Token 발급 API 추가 (#55)

### DIFF
--- a/app/settings.gradle.kts
+++ b/app/settings.gradle.kts
@@ -1,3 +1,10 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
@@ -110,6 +110,7 @@ class SecurityConfig(
             arrayOf(
                 "/auth/refresh",
                 "/auth/logout",
+                "/auth/dev-token",
                 "/oauth2/**",
                 "/login/oauth2/**",
                 "/swagger-ui/**",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthController.kt
@@ -1,10 +1,7 @@
 package com.firstpenguin.app.domain.auth.controller
 
 import com.firstpenguin.app.domain.auth.dto.AccessTokenResponse
-import com.firstpenguin.app.domain.auth.token.JwtTokenProvider
-import com.firstpenguin.app.domain.user.model.OAuthUserProfile
-import com.firstpenguin.app.domain.user.model.Provider
-import com.firstpenguin.app.domain.user.repository.UserRepository
+import com.firstpenguin.app.domain.auth.usecase.DevAuthUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -17,23 +14,9 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/auth")
 @Tag(name = "인증")
 class DevAuthController(
-    private val userRepository: UserRepository,
-    private val jwtTokenProvider: JwtTokenProvider,
+    private val devAuthUseCase: DevAuthUseCase,
 ) {
     @GetMapping("/dev-token")
-    @Operation(summary = "[DEV] 개발용 토큰 발급", description = "dev 프로필에서만 활성화됩니다. 고정 더미 유저의 Access Token을 반환합니다.")
-    fun devToken(): AccessTokenResponse {
-        val devUser = userRepository.upsertOAuthUser(DEV_USER_PROFILE)
-        return AccessTokenResponse(jwtTokenProvider.createAccessToken(devUser))
-    }
-
-    private companion object {
-        val DEV_USER_PROFILE =
-            OAuthUserProfile(
-                provider = Provider.KAKAO,
-                providerId = "dev-user",
-                email = "dev@firstpenguin.com",
-                nickname = "개발자",
-            )
-    }
+    @Operation(summary = "[DEV] 개발용 토큰 발급", description = "app.token.enabled=true일 때만 활성화. 고정 더미 유저의 Access Token 반환.")
+    fun devToken(): AccessTokenResponse = devAuthUseCase.issueDevToken()
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthController.kt
@@ -1,0 +1,39 @@
+package com.firstpenguin.app.domain.auth.controller
+
+import com.firstpenguin.app.domain.auth.dto.AccessTokenResponse
+import com.firstpenguin.app.domain.auth.token.JwtTokenProvider
+import com.firstpenguin.app.domain.user.model.OAuthUserProfile
+import com.firstpenguin.app.domain.user.model.Provider
+import com.firstpenguin.app.domain.user.repository.UserRepository
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@ConditionalOnProperty("app.token.enabled", havingValue = "true")
+@RequestMapping("/auth")
+@Tag(name = "인증")
+class DevAuthController(
+    private val userRepository: UserRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+) {
+    @GetMapping("/dev-token")
+    @Operation(summary = "[DEV] 개발용 토큰 발급", description = "dev 프로필에서만 활성화됩니다. 고정 더미 유저의 Access Token을 반환합니다.")
+    fun devToken(): AccessTokenResponse {
+        val devUser = userRepository.upsertOAuthUser(DEV_USER_PROFILE)
+        return AccessTokenResponse(jwtTokenProvider.createAccessToken(devUser))
+    }
+
+    private companion object {
+        val DEV_USER_PROFILE =
+            OAuthUserProfile(
+                provider = Provider.KAKAO,
+                providerId = "dev-user",
+                email = "dev@firstpenguin.com",
+                nickname = "개발자",
+            )
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCase.kt
@@ -1,0 +1,29 @@
+package com.firstpenguin.app.domain.auth.usecase
+
+import com.firstpenguin.app.domain.auth.dto.AccessTokenResponse
+import com.firstpenguin.app.domain.auth.token.JwtTokenProvider
+import com.firstpenguin.app.domain.user.model.OAuthUserProfile
+import com.firstpenguin.app.domain.user.model.Provider
+import com.firstpenguin.app.domain.user.repository.UserRepository
+import org.springframework.stereotype.Component
+
+@Component
+class DevAuthUseCase(
+    private val userRepository: UserRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+) {
+    fun issueDevToken(): AccessTokenResponse {
+        val devUser = userRepository.upsertOAuthUser(DEV_USER_PROFILE)
+        return AccessTokenResponse(jwtTokenProvider.createAccessToken(devUser))
+    }
+
+    private companion object {
+        val DEV_USER_PROFILE =
+            OAuthUserProfile(
+                provider = Provider.KAKAO,
+                providerId = "dev-user",
+                email = "dev@firstpenguin.com",
+                nickname = "개발자",
+            )
+    }
+}


### PR DESCRIPTION
## 개요
OAuth2 로그인만 지원하는 환경에서 Swagger로 인증 API를 테스트하기 어려운 문제를 해결합니다.

## 변경 사항
- `GET /auth/dev-token` 엔드포인트 추가
  - 고정 더미 유저를 upsert 후 Access Token 반환
  - `app.token.enabled=true`일 때만 빈 등록 (`@ConditionalOnProperty`)
- `SecurityConfig` permitAll 목록에 `/auth/dev-token` 추가
- secret: dev 환경 `app.token.enabled: true`, prod `false` 설정

## 사용 방법
1. Swagger UI → `GET /auth/dev-token` 호출
2. 반환된 accessToken 복사
3. Swagger 우상단 **Authorize** → Bearer 토큰 입력
4. 인증 필요 API 테스트 가능

## 관련 이슈
Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개발 환경 전용 토큰 발급 엔드포인트 추가
  * 인증 없이 접근 가능한 개발 토큰 획득 기능 제공
  * JWT 기반 액세스 토큰 자동 생성 및 반환

<!-- end of auto-generated comment: release notes by coderabbit.ai -->