### PR TITLE
JWT 사용자 인증 검증 중앙화

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/token/JwtAuthenticationFilter.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/token/JwtAuthenticationFilter.kt
@@ -1,12 +1,10 @@
 package com.firstpenguin.app.domain.auth.token
 
-import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
 import com.firstpenguin.app.global.exception.CustomException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
@@ -15,7 +13,7 @@ const val JWT_AUTHENTICATION_ERROR_ATTRIBUTE = "jwtAuthenticationError"
 
 @Component
 class JwtAuthenticationFilter(
-    private val jwtTokenProvider: JwtTokenProvider,
+    private val jwtAuthenticator: JwtAuthenticator,
 ) : OncePerRequestFilter() {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -37,10 +35,7 @@ class JwtAuthenticationFilter(
         }
 
         try {
-            val claims = jwtTokenProvider.validateAccessToken(token)
-            val principal = AuthenticatedUser(id = claims.userId)
-            val authentication = UsernamePasswordAuthenticationToken(principal, null, emptyList())
-            SecurityContextHolder.getContext().authentication = authentication
+            SecurityContextHolder.getContext().authentication = jwtAuthenticator.authenticate(token)
         } catch (e: CustomException) {
             log.debug("JWT authentication failed", e)
             request.setAttribute(JWT_AUTHENTICATION_ERROR_ATTRIBUTE, e.errorCode)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/token/JwtAuthenticator.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/token/JwtAuthenticator.kt
@@ -1,0 +1,20 @@
+package com.firstpenguin.app.domain.auth.token
+
+import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
+import com.firstpenguin.app.domain.user.service.UserService
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+
+@Component
+class JwtAuthenticator(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val userService: UserService,
+) {
+    fun authenticate(token: String): Authentication {
+        val claims = jwtTokenProvider.validateAccessToken(token)
+        userService.validateAuthenticatableUser(claims.userId)
+
+        return UsernamePasswordAuthenticationToken(AuthenticatedUser(claims.userId), null, emptyList())
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
@@ -2,6 +2,7 @@ package com.firstpenguin.app.domain.user.service
 
 import com.firstpenguin.app.domain.user.model.OAuthUserProfile
 import com.firstpenguin.app.domain.user.model.User
+import com.firstpenguin.app.domain.user.model.UserStatus
 import com.firstpenguin.app.domain.user.repository.UserRepository
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
@@ -13,5 +14,19 @@ class UserService(
 ) {
     fun getById(id: Long): User = userRepository.findById(id) ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
+    fun validateAuthenticatableUser(userId: Long) {
+        val user = userRepository.findById(userId) ?: throw CustomException(ErrorCode.AUTH_USER_NOT_FOUND)
+        validateAuthenticatableStatus(user)
+    }
+
     fun upsertOAuthUser(profile: OAuthUserProfile): User = userRepository.upsertOAuthUser(profile)
+
+    private fun validateAuthenticatableStatus(user: User) {
+        if (user.status == UserStatus.DELETED || user.deletedAt != null) {
+            throw CustomException(ErrorCode.AUTH_USER_DELETED)
+        }
+        if (user.status == UserStatus.BLOCKED) {
+            throw CustomException(ErrorCode.AUTH_USER_BLOCKED)
+        }
+    }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
@@ -22,11 +22,19 @@ class UserService(
     fun upsertOAuthUser(profile: OAuthUserProfile): User = userRepository.upsertOAuthUser(profile)
 
     private fun validateAuthenticatableStatus(user: User) {
-        if (user.status == UserStatus.DELETED || user.deletedAt != null) {
-            throw CustomException(ErrorCode.AUTH_USER_DELETED)
-        }
-        if (user.status == UserStatus.BLOCKED) {
-            throw CustomException(ErrorCode.AUTH_USER_BLOCKED)
-        }
+        val errorCode =
+            when {
+                user.deletedAt != null -> ErrorCode.AUTH_USER_DELETED
+                else -> authenticatableStatusErrorCode(user.status)
+            }
+
+        errorCode?.let { throw CustomException(it) }
     }
+
+    private fun authenticatableStatusErrorCode(status: UserStatus): ErrorCode? =
+        when (status) {
+            UserStatus.ACTIVE -> null
+            UserStatus.BLOCKED -> ErrorCode.AUTH_USER_BLOCKED
+            UserStatus.DELETED -> ErrorCode.AUTH_USER_DELETED
+        }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
@@ -17,6 +17,9 @@ enum class ErrorCode(
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
+    AUTH_USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증된 사용자를 찾을 수 없습니다"),
+    AUTH_USER_DELETED(HttpStatus.UNAUTHORIZED, "탈퇴한 사용자입니다"),
+    AUTH_USER_BLOCKED(HttpStatus.UNAUTHORIZED, "차단된 사용자입니다"),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Access Token이 만료되었습니다"),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Access Token입니다"),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Refresh Token이 만료되었습니다"),

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/token/JwtAuthenticationFilterTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/token/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,88 @@
+package com.firstpenguin.app.domain.auth.token
+
+import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+import jakarta.servlet.FilterChain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class JwtAuthenticationFilterTest {
+    private lateinit var jwtAuthenticator: JwtAuthenticator
+    private lateinit var jwtAuthenticationFilter: JwtAuthenticationFilter
+
+    @BeforeEach
+    fun setUp() {
+        SecurityContextHolder.clearContext()
+        jwtAuthenticator = Mockito.mock(JwtAuthenticator::class.java)
+        jwtAuthenticationFilter = JwtAuthenticationFilter(jwtAuthenticator)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `Bearer 토큰이 없으면 인증을 시도하지 않는다`() {
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        var chainCalled = false
+
+        jwtAuthenticationFilter.doFilter(request, response, FilterChain { _, _ -> chainCalled = true })
+
+        assertTrue(chainCalled)
+        assertNull(SecurityContextHolder.getContext().authentication)
+        Mockito.verifyNoInteractions(jwtAuthenticator)
+    }
+
+    @Test
+    fun `인증 성공 시 SecurityContext에 Authentication을 저장한다`() {
+        val request = requestWithBearerToken()
+        val response = MockHttpServletResponse()
+        val authentication = authentication()
+        Mockito.`when`(jwtAuthenticator.authenticate(TOKEN)).thenReturn(authentication)
+
+        jwtAuthenticationFilter.doFilter(request, response, FilterChain { _, _ -> })
+
+        assertSame(authentication, SecurityContextHolder.getContext().authentication)
+        assertNull(request.getAttribute(JWT_AUTHENTICATION_ERROR_ATTRIBUTE))
+    }
+
+    @Test
+    fun `인증 실패 시 인증 에러를 저장하고 SecurityContext를 비운다`() {
+        val request = requestWithBearerToken()
+        val response = MockHttpServletResponse()
+        SecurityContextHolder.getContext().authentication = authentication()
+        Mockito
+            .`when`(jwtAuthenticator.authenticate(TOKEN))
+            .thenThrow(CustomException(ErrorCode.AUTH_USER_DELETED))
+
+        jwtAuthenticationFilter.doFilter(request, response, FilterChain { _, _ -> })
+
+        assertNull(SecurityContextHolder.getContext().authentication)
+        assertEquals(ErrorCode.AUTH_USER_DELETED, request.getAttribute(JWT_AUTHENTICATION_ERROR_ATTRIBUTE))
+    }
+
+    private fun requestWithBearerToken(): MockHttpServletRequest =
+        MockHttpServletRequest().apply {
+            addHeader("Authorization", "Bearer $TOKEN")
+        }
+
+    private fun authentication() = UsernamePasswordAuthenticationToken(AuthenticatedUser(USER_ID), null, emptyList())
+
+    private companion object {
+        const val TOKEN = "access-token"
+        const val USER_ID = 1L
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/token/JwtAuthenticationFilterTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/token/JwtAuthenticationFilterTest.kt
@@ -63,15 +63,17 @@ class JwtAuthenticationFilterTest {
     fun `인증 실패 시 인증 에러를 저장하고 SecurityContext를 비운다`() {
         val request = requestWithBearerToken()
         val response = MockHttpServletResponse()
+        val filterChain = Mockito.mock(FilterChain::class.java)
         SecurityContextHolder.getContext().authentication = authentication()
         Mockito
             .`when`(jwtAuthenticator.authenticate(TOKEN))
             .thenThrow(CustomException(ErrorCode.AUTH_USER_DELETED))
 
-        jwtAuthenticationFilter.doFilter(request, response, FilterChain { _, _ -> })
+        jwtAuthenticationFilter.doFilter(request, response, filterChain)
 
         assertNull(SecurityContextHolder.getContext().authentication)
         assertEquals(ErrorCode.AUTH_USER_DELETED, request.getAttribute(JWT_AUTHENTICATION_ERROR_ATTRIBUTE))
+        Mockito.verify(filterChain).doFilter(request, response)
     }
 
     private fun requestWithBearerToken(): MockHttpServletRequest =

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/token/JwtAuthenticatorTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/token/JwtAuthenticatorTest.kt
@@ -1,0 +1,66 @@
+package com.firstpenguin.app.domain.auth.token
+
+import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
+import com.firstpenguin.app.domain.auth.model.TokenClaims
+import com.firstpenguin.app.domain.user.service.UserService
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class JwtAuthenticatorTest {
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var userService: UserService
+    private lateinit var jwtAuthenticator: JwtAuthenticator
+
+    @BeforeEach
+    fun setUp() {
+        jwtTokenProvider = Mockito.mock(JwtTokenProvider::class.java)
+        userService = Mockito.mock(UserService::class.java)
+        jwtAuthenticator = JwtAuthenticator(jwtTokenProvider, userService)
+    }
+
+    @Test
+    fun `유효한 토큰과 인증 가능한 사용자면 Authentication을 반환한다`() {
+        Mockito.`when`(jwtTokenProvider.validateAccessToken(TOKEN)).thenReturn(TokenClaims(USER_ID))
+
+        val authentication = jwtAuthenticator.authenticate(TOKEN)
+        val principal = assertIs<AuthenticatedUser>(authentication.principal)
+
+        assertEquals(USER_ID, principal.id)
+        Mockito.verify(userService).validateAuthenticatableUser(USER_ID)
+    }
+
+    @Test
+    fun `토큰 검증 실패는 그대로 전파한다`() {
+        Mockito
+            .`when`(jwtTokenProvider.validateAccessToken(TOKEN))
+            .thenThrow(CustomException(ErrorCode.INVALID_ACCESS_TOKEN))
+
+        val exception = assertFailsWith<CustomException> { jwtAuthenticator.authenticate(TOKEN) }
+
+        assertEquals(ErrorCode.INVALID_ACCESS_TOKEN, exception.errorCode)
+    }
+
+    @Test
+    fun `사용자 인증 가능성 검증 실패는 그대로 전파한다`() {
+        Mockito.`when`(jwtTokenProvider.validateAccessToken(TOKEN)).thenReturn(TokenClaims(USER_ID))
+        Mockito
+            .doThrow(CustomException(ErrorCode.AUTH_USER_BLOCKED))
+            .`when`(userService)
+            .validateAuthenticatableUser(USER_ID)
+
+        val exception = assertFailsWith<CustomException> { jwtAuthenticator.authenticate(TOKEN) }
+
+        assertEquals(ErrorCode.AUTH_USER_BLOCKED, exception.errorCode)
+    }
+
+    private companion object {
+        const val TOKEN = "access-token"
+        const val USER_ID = 1L
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
@@ -1,0 +1,94 @@
+package com.firstpenguin.app.domain.user.service
+
+import com.firstpenguin.app.domain.user.model.Provider
+import com.firstpenguin.app.domain.user.model.User
+import com.firstpenguin.app.domain.user.model.UserStatus
+import com.firstpenguin.app.domain.user.repository.UserRepository
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class UserServiceTest {
+    private lateinit var userRepository: UserRepository
+    private lateinit var userService: UserService
+
+    @BeforeEach
+    fun setUp() {
+        userRepository = Mockito.mock(UserRepository::class.java)
+        userService = UserService(userRepository)
+    }
+
+    @Test
+    fun `인증 사용자가 존재하지 않으면 인증 실패`() {
+        Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(null)
+
+        val exception = assertFailsWith<CustomException> { userService.validateAuthenticatableUser(USER_ID) }
+
+        assertEquals(ErrorCode.AUTH_USER_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    fun `탈퇴 상태 사용자는 인증 실패`() {
+        Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(user(status = UserStatus.DELETED))
+
+        val exception = assertFailsWith<CustomException> { userService.validateAuthenticatableUser(USER_ID) }
+
+        assertEquals(ErrorCode.AUTH_USER_DELETED, exception.errorCode)
+    }
+
+    @Test
+    fun `삭제 시간이 있으면 인증 실패`() {
+        val deletedAt = LocalDateTime.now()
+        Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(user(deletedAt = deletedAt))
+
+        val exception = assertFailsWith<CustomException> { userService.validateAuthenticatableUser(USER_ID) }
+
+        assertEquals(ErrorCode.AUTH_USER_DELETED, exception.errorCode)
+    }
+
+    @Test
+    fun `차단 상태 사용자는 인증 실패`() {
+        Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(user(status = UserStatus.BLOCKED))
+
+        val exception = assertFailsWith<CustomException> { userService.validateAuthenticatableUser(USER_ID) }
+
+        assertEquals(ErrorCode.AUTH_USER_BLOCKED, exception.errorCode)
+    }
+
+    @Test
+    fun `활성 사용자는 인증 가능`() {
+        Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(user())
+
+        userService.validateAuthenticatableUser(USER_ID)
+    }
+
+    private fun user(
+        status: UserStatus = UserStatus.ACTIVE,
+        deletedAt: LocalDateTime? = null,
+    ): User {
+        val now = LocalDateTime.now()
+
+        return User(
+            id = USER_ID,
+            provider = Provider.KAKAO,
+            providerId = "provider-id",
+            email = "user@example.com",
+            nickname = "penguin",
+            profileImageId = null,
+            status = status,
+            lastLoginAt = now,
+            deletedAt = deletedAt,
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    private companion object {
+        const val USER_ID = 1L
+    }
+}


### PR DESCRIPTION
## 변경 사항

- `JwtAuthenticator`를 추가해 access token 검증, 사용자 인증 가능 상태 검증, `Authentication` 생성을 한 곳으로 모았습니다.
- `JwtAuthenticationFilter`는 Bearer token 추출과 `SecurityContext` 반영만 담당하도록 정리했습니다.
- 인증된 `userId`가 없거나 탈퇴/차단 상태인 경우 401 에러코드를 내려주도록 추가했습니다.
- `secret` submodule 포인터를 원격 최신 커밋으로 갱신했습니다.

## 배경

JWT 자체가 유효하더라도 claims의 `userId`가 실제 인증 가능한 사용자라는 보장이 필요합니다. 이를 controller/usecase/service에 반복하지 않고 인증 계층에서 중앙 처리합니다.

Closes #54

## 검증

- `./gradlew test lintKotlin detekt`
- `git push` pre-push hook: `./gradlew clean test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 시스템의 사용자 상태 검증 강화
  * 미존재, 탈퇴, 차단된 사용자에 대한 구체적인 오류 메시지 추가로 인증 흐름 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->