### PR TITLE
fix: OAuth 사용자 upsert ON CONFLICT 컬럼 한정자 제거

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserRepository.kt
@@ -35,7 +35,7 @@ class UserRepository(
             .set(UserTable.LAST_LOGIN_AT, now)
             .set(UserTable.CREATED_AT, now)
             .set(UserTable.UPDATED_AT, now)
-            .onConflict(UserTable.PROVIDER, UserTable.PROVIDER_ID)
+            .onConflict(PROVIDER_CONFLICT_TARGET, PROVIDER_ID_CONFLICT_TARGET)
             .doUpdate()
             .set(UserTable.EMAIL, DSL.coalesce(DSL.excluded(UserTable.EMAIL), UserTable.EMAIL))
             .set(UserTable.NICKNAME, DSL.excluded(UserTable.NICKNAME))
@@ -64,6 +64,9 @@ class UserRepository(
         )
 
     private companion object {
+        val PROVIDER_CONFLICT_TARGET = DSL.field(DSL.name("provider"), String::class.java)
+        val PROVIDER_ID_CONFLICT_TARGET = DSL.field(DSL.name("provider_id"), String::class.java)
+
         val USER_FIELDS: List<Field<*>> =
             listOf(
                 UserTable.ID,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/repository/UserRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/repository/UserRepositoryTest.kt
@@ -1,0 +1,93 @@
+package com.firstpenguin.app.domain.user.repository
+
+import com.firstpenguin.app.domain.user.model.OAuthUserProfile
+import com.firstpenguin.app.domain.user.model.Provider
+import com.firstpenguin.app.domain.user.model.UserStatus
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.jooq.tools.jdbc.MockConnection
+import org.jooq.tools.jdbc.MockDataProvider
+import org.jooq.tools.jdbc.MockResult
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UserRepositoryTest {
+    @Test
+    fun `OAuth 사용자 upsert는 ON CONFLICT에 테이블 한정자를 사용하지 않는다`() {
+        var capturedSql = ""
+        lateinit var dsl: DSLContext
+        val connection =
+            MockConnection(
+                MockDataProvider { context ->
+                    capturedSql = context.sql()
+                    arrayOf(MockResult(1, userResult(dsl)))
+                },
+            )
+        dsl = DSL.using(connection, SQLDialect.POSTGRES)
+
+        UserRepository(dsl).upsertOAuthUser(OAUTH_USER_PROFILE)
+
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+        assertTrue(
+            normalizedSql.contains("""on conflict ("provider", "provider_id")"""),
+            normalizedSql,
+        )
+        assertFalse(
+            normalizedSql.contains("""on conflict ("users"."provider", "users"."provider_id")"""),
+            normalizedSql,
+        )
+    }
+
+    private fun userResult(dsl: DSLContext) =
+        dsl.newResult(*USER_FIELDS).apply {
+            add(userRecord(dsl))
+        }
+
+    private fun userRecord(dsl: DSLContext): Record {
+        val now = LocalDateTime.now()
+
+        return dsl.newRecord(*USER_FIELDS).apply {
+            set(UserTable.ID, USER_ID)
+            set(UserTable.PROVIDER, Provider.KAKAO.name)
+            set(UserTable.PROVIDER_ID, "dev-user")
+            set(UserTable.EMAIL, "dev@firstpenguin.com")
+            set(UserTable.NICKNAME, "개발자")
+            set(UserTable.PROFILE_IMAGE_ID, null as Long?)
+            set(UserTable.STATUS, UserStatus.ACTIVE.name)
+            set(UserTable.LAST_LOGIN_AT, now)
+            set(UserTable.DELETED_AT, null as LocalDateTime?)
+            set(UserTable.CREATED_AT, now)
+            set(UserTable.UPDATED_AT, now)
+        }
+    }
+
+    private companion object {
+        const val USER_ID = 1L
+        val OAUTH_USER_PROFILE =
+            OAuthUserProfile(
+                provider = Provider.KAKAO,
+                providerId = "dev-user",
+                email = "dev@firstpenguin.com",
+                nickname = "개발자",
+            )
+        val USER_FIELDS: Array<Field<*>> =
+            arrayOf(
+                UserTable.ID,
+                UserTable.PROVIDER,
+                UserTable.PROVIDER_ID,
+                UserTable.EMAIL,
+                UserTable.NICKNAME,
+                UserTable.PROFILE_IMAGE_ID,
+                UserTable.STATUS,
+                UserTable.LAST_LOGIN_AT,
+                UserTable.DELETED_AT,
+                UserTable.CREATED_AT,
+                UserTable.UPDATED_AT,
+            )
+    }
+}


### PR DESCRIPTION
## 📢 요약
- `UserRepository.upsertOAuthUser`의 `ON CONFLICT` conflict target에서 테이블 한정자가 포함된 jOOQ field를 사용하지 않도록 수정했습니다.
- PostgreSQL이 `ON CONFLICT ("users"."provider", "users"."provider_id")` 형태를 문법 오류로 거부해 DEV 토큰 발급 및 OAuth 로그인 경로에서 500이 발생할 수 있던 문제를 해결합니다.
- jOOQ mock 기반 repository 테스트를 추가해 생성 SQL이 `ON CONFLICT ("provider", "provider_id")` 형태인지 검증했습니다.

🔗 연관 이슈: Resolves #60

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트 불필요

## 📸 스크린샷 / 테스트 결과
- 로컬 Swagger로 DEV 토큰 발급 동작 확인
- `./gradlew test`
- `./gradlew lintKotlin`
- `./gradlew detekt`

## 📜 기타
- base 브랜치: `dev`
- head 브랜치: `fix/#60/on-conflict-qualified-column`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * OAuth 사용자 동기화 시 데이터 충돌 처리 방식을 개선하여 사용자 정보 저장의 안정성 강화

* **테스트**
  * OAuth 사용자 동기화 프로세스에 대한 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->