### PR TITLE
✨ feat: random quotes 10개 랜덤 문장 응답으로 변경

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/home/controller/HomeController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/home/controller/HomeController.kt
@@ -30,7 +30,7 @@ class HomeController(
         description = "홈화면 랜덤 추천 문구를 정보를 반환한다.",
     )
     @GetMapping("/random")
-    fun getRandomQuote(): ResponseEntity<QuoteResponse> = ResponseEntity.ok(homeUseCase.getRandomQuote())
+    fun getRandomQuotes(): ResponseEntity<List<QuoteResponse>> = ResponseEntity.ok(homeUseCase.getRandomQuotes())
 
     @Operation(
         summary = "홈 요약 API",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/home/useCase/HomeUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/home/useCase/HomeUseCase.kt
@@ -5,10 +5,13 @@ import com.firstpenguin.app.domain.diary.service.DiaryService
 import com.firstpenguin.app.domain.home.dto.HomeSummaryResponse
 import com.firstpenguin.app.domain.home.dto.MonthlyDiaryResponse
 import com.firstpenguin.app.domain.quote.dto.QuoteResponse
+import com.firstpenguin.app.domain.quote.model.Quote
 import com.firstpenguin.app.domain.quote.service.QuoteService
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+
+private const val RANDOM_QUOTE_COUNT = 10
 
 @Component
 class HomeUseCase(
@@ -35,15 +38,23 @@ class HomeUseCase(
     }
 
     @Transactional(readOnly = true)
-    fun getRandomQuote(): QuoteResponse {
-        val randomQuote = quoteService.getRandomQuote()
+    fun getRandomQuotes(): List<QuoteResponse> {
+        val randomQuotes =
+            quoteService.getRandomQuotesExcludingIds(
+                excludedQuoteIds = emptyList(),
+                count = RANDOM_QUOTE_COUNT,
+            )
 
-        val book = bookService.findBookById(randomQuote.bookId)
+        return randomQuotes.map(::toQuoteResponse)
+    }
+
+    private fun toQuoteResponse(quote: Quote): QuoteResponse {
+        val book = bookService.findBookById(quote.bookId)
 
         return QuoteResponse(
-            quoteId = randomQuote.id,
+            quoteId = quote.id,
             bookId = book.id,
-            content = randomQuote.content,
+            content = quote.content,
             title = book.title,
             author = book.author,
             image = book.coverImageUrl,


### PR DESCRIPTION
## 📢 요약
- 홈 화면 랜덤 추천 문구 API 응답을 단건 문장에서 10개 문장 리스트로 변경했습니다.
- 기존 랜덤 문장 조회 로직을 활용해 중복되지 않는 랜덤 문장 10개를 반환하도록 수정했습니다.
- 각 문장 응답에는 기존과 동일하게 책 정보와 표지 이미지 URL을 포함합니다.

🔗 연관 이슈: Resolves #이슈번호

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
```bash
./gradlew testClasses
./gradlew lintKotlin
./gradlew detekt
./gradlew test
```

모두 성공했습니다.

응답 예시:

```json
[
  {
    "quoteId": 1,
    "bookId": 1,
    "content": "문장 내용",
    "title": "책 제목",
    "author": "저자",
    "image": "https://example.com/book-cover.jpg"
  },
  {
    "quoteId": 2,
    "bookId": 1,
    "content": "문장 내용",
    "title": "책 제목",
    "author": "저자",
    "image": "https://example.com/book-cover.jpg"
  }
]
```

## 📜 기타
- 홈 화면 랜덤 문장 API는 `/home/random` 경로를 유지합니다.
- 응답 구조만 `QuoteResponse` 단건에서 `List<QuoteResponse>`로 변경됩니다.
- 랜덤 문장 개수는 서버에서 10개로 고정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 랜덤 인용문 조회 기능이 단일 인용문 반환에서 여러 인용문 목록(10개) 반환으로 업데이트되었습니다. 사용자는 한 번의 요청으로 더 많은 추천 인용문을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->