### PR TITLE
feat: 오늘 진행 상태 조회 API 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/controller/DiaryController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/controller/DiaryController.kt
@@ -4,7 +4,6 @@ import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
 import com.firstpenguin.app.domain.diary.dto.CreateDiaryRequest
 import com.firstpenguin.app.domain.diary.dto.CreateDiaryResponse
 import com.firstpenguin.app.domain.diary.dto.DiaryDetailResponse
-import com.firstpenguin.app.domain.diary.dto.DiaryExistsResponse
 import com.firstpenguin.app.domain.diary.dto.DiaryPeriodResponse
 import com.firstpenguin.app.domain.diary.dto.UpdateDiaryContentRequest
 import com.firstpenguin.app.domain.diary.usecase.DiaryUseCase
@@ -207,23 +206,6 @@ class DiaryController(
             diaryId = diaryId,
             request = request,
         )
-    }
-
-    @GetMapping("/today/exists")
-    @Operation(
-        summary = "오늘 일기 작성 여부 조회 API",
-        description = "로그인한 사용자가 오늘 작성한 일기가 있는지 조회한다.",
-        security = [SecurityRequirement(name = "bearerAuth")],
-    )
-    fun hasTodayDiary(
-        @Parameter(hidden = true)
-        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser?,
-    ): ResponseEntity<DiaryExistsResponse> {
-        if (authenticatedUser == null) {
-            throw CustomException(ErrorCode.UNAUTHORIZED)
-        }
-
-        return ResponseEntity.ok(diaryUseCase.hasTodayDiary(authenticatedUser.id))
     }
 
     @GetMapping("/{diaryId}")

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/controller/DiaryController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/controller/DiaryController.kt
@@ -47,15 +47,12 @@ class DiaryController(
     )
     @PostMapping
     fun createDiary(
-        @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser?,
+        @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
         @Valid @RequestBody request: CreateDiaryRequest,
-    ): ResponseEntity<CreateDiaryResponse> {
-        if (authenticatedUser == null) {
-            throw CustomException(ErrorCode.UNAUTHORIZED)
-        }
-
-        return ResponseEntity.ok(diaryUseCase.createDiary(authenticatedUser.id, request))
-    }
+    ): ResponseEntity<CreateDiaryResponse> =
+        ResponseEntity.ok(
+            diaryUseCase.createDiary(authenticatedUser.id, request),
+        )
 
     @DeleteMapping("/{diaryId}")
     @Operation(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/dto/DiaryExistsResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/dto/DiaryExistsResponse.kt
@@ -1,9 +1,0 @@
-package com.firstpenguin.app.domain.diary.dto
-
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "오늘 일기 작성 여부 응답")
-data class DiaryExistsResponse(
-    @field:Schema(description = "오늘 작성된 일기 존재 여부", example = "true")
-    val exists: Boolean,
-)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/usecase/DiaryUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/usecase/DiaryUseCase.kt
@@ -3,7 +3,6 @@ package com.firstpenguin.app.domain.diary.usecase
 import com.firstpenguin.app.domain.diary.dto.CreateDiaryRequest
 import com.firstpenguin.app.domain.diary.dto.CreateDiaryResponse
 import com.firstpenguin.app.domain.diary.dto.DiaryDetailResponse
-import com.firstpenguin.app.domain.diary.dto.DiaryExistsResponse
 import com.firstpenguin.app.domain.diary.dto.DiaryPeriodResponse
 import com.firstpenguin.app.domain.diary.dto.UpdateDiaryContentRequest
 import com.firstpenguin.app.domain.diary.model.CreatedDiary
@@ -153,9 +152,6 @@ class DiaryUseCase(
 
         return diaryShareImageService.generate(diary)
     }
-
-    @Transactional(readOnly = true)
-    fun hasTodayDiary(userId: Long): DiaryExistsResponse = DiaryExistsResponse(diaryService.hasTodayDiary(userId))
 
     @Transactional(readOnly = true)
     fun getDiary(diaryId: Long): DiaryDetailResponse {

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/home/controller/HomeController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/home/controller/HomeController.kt
@@ -42,8 +42,7 @@ class HomeController(
     fun getTodayStatus(
         @Parameter(hidden = true)
         @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
-    ): ResponseEntity<TodayStatusResponse> =
-        ResponseEntity.ok(homeUseCase.getTodayStatus(authenticatedUser.id))
+    ): ResponseEntity<TodayStatusResponse> = ResponseEntity.ok(homeUseCase.getTodayStatus(authenticatedUser.id))
 
     @Operation(
         summary = "홈 요약 API",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/home/controller/HomeController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/home/controller/HomeController.kt
@@ -2,6 +2,7 @@ package com.firstpenguin.app.domain.home.controller
 
 import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
 import com.firstpenguin.app.domain.home.dto.HomeSummaryResponse
+import com.firstpenguin.app.domain.home.dto.TodayStatusResponse
 import com.firstpenguin.app.domain.home.useCase.HomeUseCase
 import com.firstpenguin.app.domain.quote.dto.QuoteResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -31,6 +32,18 @@ class HomeController(
     )
     @GetMapping("/random")
     fun getRandomQuotes(): ResponseEntity<List<QuoteResponse>> = ResponseEntity.ok(homeUseCase.getRandomQuotes())
+
+    @GetMapping("/today/status")
+    @Operation(
+        summary = "오늘 진행 상태 조회 API",
+        description = "로그인한 사용자의 오늘 추천 문구 생성 여부와 일기 작성 여부를 조회한다.",
+        security = [SecurityRequirement(name = "bearerAuth")],
+    )
+    fun getTodayStatus(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
+    ): ResponseEntity<TodayStatusResponse> =
+        ResponseEntity.ok(homeUseCase.getTodayStatus(authenticatedUser.id))
 
     @Operation(
         summary = "홈 요약 API",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/home/dto/TodayStatusResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/home/dto/TodayStatusResponse.kt
@@ -1,0 +1,7 @@
+package com.firstpenguin.app.domain.home.dto
+
+data class TodayStatusResponse(
+    val hasTodayRecommendation: Boolean,
+    val hasTodayDiary: Boolean,
+    val dailyRecommendationId: Long?,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/home/useCase/HomeUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/home/useCase/HomeUseCase.kt
@@ -4,9 +4,11 @@ import com.firstpenguin.app.domain.book.service.BookService
 import com.firstpenguin.app.domain.diary.service.DiaryService
 import com.firstpenguin.app.domain.home.dto.HomeSummaryResponse
 import com.firstpenguin.app.domain.home.dto.MonthlyDiaryResponse
+import com.firstpenguin.app.domain.home.dto.TodayStatusResponse
 import com.firstpenguin.app.domain.quote.dto.QuoteResponse
 import com.firstpenguin.app.domain.quote.model.Quote
 import com.firstpenguin.app.domain.quote.service.QuoteService
+import com.firstpenguin.app.domain.recommendation.service.RecommendationService
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -18,6 +20,7 @@ class HomeUseCase(
     private val quoteService: QuoteService,
     private val bookService: BookService,
     private val diaryService: DiaryService,
+    private val recommendationService: RecommendationService,
 ) {
     @Transactional(readOnly = true)
     fun getSummary(userId: Long): HomeSummaryResponse {
@@ -46,6 +49,20 @@ class HomeUseCase(
             )
 
         return randomQuotes.map(::toQuoteResponse)
+    }
+
+    @Transactional(readOnly = true)
+    fun getTodayStatus(userId: Long): TodayStatusResponse {
+        val dailyRecommendation = recommendationService.findByUserIdAndRecommendationDate(userId)
+        val hasTodayDiary = diaryService.hasTodayDiary(userId)
+
+        return TodayStatusResponse(
+            hasTodayRecommendation = dailyRecommendation != null,
+            hasTodayDiary = hasTodayDiary,
+            dailyRecommendationId = dailyRecommendation
+                ?.takeIf { !hasTodayDiary }
+                ?.id,
+        )
     }
 
     private fun toQuoteResponse(quote: Quote): QuoteResponse {

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/home/useCase/HomeUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/home/useCase/HomeUseCase.kt
@@ -59,9 +59,10 @@ class HomeUseCase(
         return TodayStatusResponse(
             hasTodayRecommendation = dailyRecommendation != null,
             hasTodayDiary = hasTodayDiary,
-            dailyRecommendationId = dailyRecommendation
-                ?.takeIf { !hasTodayDiary }
-                ?.id,
+            dailyRecommendationId =
+                dailyRecommendation
+                    ?.takeIf { !hasTodayDiary }
+                    ?.id,
         )
     }
 

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
@@ -2,19 +2,15 @@ package com.firstpenguin.app.domain.recommendation.controller
 
 import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
 import com.firstpenguin.app.domain.quote.dto.QuoteResponse
-import com.firstpenguin.app.domain.recommendation.dto.RecommendationExistsResponse
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationRequest
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationResponse
 import com.firstpenguin.app.domain.recommendation.useCase.RecommendationUseCase
-import com.firstpenguin.app.global.exception.CustomException
-import com.firstpenguin.app.global.exception.ErrorCode
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -33,15 +29,10 @@ class RecommendationController(
     )
     @PostMapping("/quotes")
     fun recommendationQuote(
-        @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser?,
+        @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
         @Valid @RequestBody request: RecommendationRequest,
-    ): ResponseEntity<RecommendationResponse> {
-        if (authenticatedUser == null) {
-            throw CustomException(ErrorCode.UNAUTHORIZED)
-        }
-
-        return ResponseEntity.ok(recommendationUseCase.recommendQuote(authenticatedUser.id, request))
-    }
+    ): ResponseEntity<RecommendationResponse> =
+        ResponseEntity.ok(recommendationUseCase.recommendQuote(authenticatedUser.id, request))
 
     @Operation(
         summary = "문장 더보기 조회 API",
@@ -49,33 +40,13 @@ class RecommendationController(
     )
     @PostMapping("/{dailyRecommendationId}/quotes")
     fun getNextRecommendationQuotes(
-        @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser?,
+        @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
         @PathVariable dailyRecommendationId: Long,
-    ): ResponseEntity<List<QuoteResponse>> {
-        if (authenticatedUser == null) {
-            throw CustomException(ErrorCode.UNAUTHORIZED)
-        }
-
-        return ResponseEntity.ok(
+    ): ResponseEntity<List<QuoteResponse>> =
+        ResponseEntity.ok(
             recommendationUseCase.getNextRecommendationQuotes(
                 userId = authenticatedUser.id,
                 dailyRecommendationId = dailyRecommendationId,
             ),
         )
-    }
-
-    @Operation(
-        summary = "오늘 추천 문구 생성 여부 조회 API",
-        description = "로그인한 사용자가 오늘 생성한 추천 문구가 있는지 조회한다.",
-    )
-    @GetMapping("/today/exists")
-    fun hasTodayRecommendation(
-        @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser?,
-    ): ResponseEntity<RecommendationExistsResponse> {
-        if (authenticatedUser == null) {
-            throw CustomException(ErrorCode.UNAUTHORIZED)
-        }
-
-        return ResponseEntity.ok(recommendationUseCase.hasTodayRecommendation(authenticatedUser.id))
-    }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
@@ -35,7 +35,7 @@ class RecommendationController(
         ResponseEntity.ok(
             recommendationUseCase.recommendQuote(
                 userId = authenticatedUser.id,
-                request = request
+                request = request,
             ),
         )
 

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
@@ -31,8 +31,7 @@ class RecommendationController(
     fun recommendationQuote(
         @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
         @Valid @RequestBody request: RecommendationRequest,
-    ): ResponseEntity<RecommendationResponse> =
-        ResponseEntity.ok(recommendationUseCase.recommendQuote(authenticatedUser.id, request))
+    ): ResponseEntity<RecommendationResponse> = ResponseEntity.ok(recommendationUseCase.recommendQuote(authenticatedUser.id, request))
 
     @Operation(
         summary = "문장 더보기 조회 API",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
@@ -32,7 +32,12 @@ class RecommendationController(
         @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
         @Valid @RequestBody request: RecommendationRequest,
     ): ResponseEntity<RecommendationResponse> =
-        ResponseEntity.ok(recommendationUseCase.recommendQuote(authenticatedUser.id, request))
+        ResponseEntity.ok(recommendationUseCase
+            .recommendQuote(
+                userId = authenticatedUser.id,
+                request = request,
+            )
+        )
 
     @Operation(
         summary = "문장 더보기 조회 API",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/dto/RecommendationExistsResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/dto/RecommendationExistsResponse.kt
@@ -1,9 +1,0 @@
-package com.firstpenguin.app.domain.recommendation.dto
-
-import io.swagger.v3.oas.annotations.media.Schema
-
-@Schema(description = "오늘 추천 문구 생성 여부 응답")
-data class RecommendationExistsResponse(
-    @field:Schema(description = "오늘 생성된 추천 문구 존재 여부", example = "true")
-    val exists: Boolean,
-)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/DailyRecommendationRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/DailyRecommendationRepository.kt
@@ -38,16 +38,17 @@ class DailyRecommendationRepository(
             ?: throw CustomException(ErrorCode.DAILY_RECOMMENDATION_ALREADY_EXISTS)
     }
 
-    fun existsByUserIdAndRecommendationDate(
+    fun findByUserIdAndRecommendationDate(
         userId: Long,
         recommendationDate: LocalDate,
-    ): Boolean =
-        dsl.fetchExists(
-            DailyRecommendationTable.DAILY_RECOMMENDATIONS,
-            DailyRecommendationTable.USER_ID
-                .eq(userId)
-                .and(DailyRecommendationTable.RECOMMENDATION_DATE.eq(recommendationDate)),
-        )
+    ): DailyRecommendation? =
+        dsl
+            .select(DAILY_RECOMMENDATION_FIELDS)
+            .from(DailyRecommendationTable.DAILY_RECOMMENDATIONS)
+            .where(DailyRecommendationTable.USER_ID.eq(userId))
+            .and(DailyRecommendationTable.RECOMMENDATION_DATE.eq(recommendationDate))
+            .fetchOne()
+            ?.let(::toDailyRecommendation)
 
     fun findDailyRecommendationByPkForUpdate(id: Long): DailyRecommendation? =
         dsl

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationService.kt
@@ -50,14 +50,14 @@ class RecommendationService(
         dailyRecommendationQuoteRepository
             .findByDailyRecommendationId(dailyRecommendationId)
 
-    fun hasRecommendedToday(userId: Long): Boolean {
+    fun findByUserIdAndRecommendationDate(userId: Long): DailyRecommendation? {
         val today = LocalDate.now()
 
-        return dailyRecommendationRepository.existsByUserIdAndRecommendationDate(userId, today)
+        return dailyRecommendationRepository.findByUserIdAndRecommendationDate(userId, today)
     }
 
     fun validateRecommendationAvailable(userId: Long) {
-        if (hasRecommendedToday(userId)) {
+        findByUserIdAndRecommendationDate(userId)?.let {
             throw CustomException(ErrorCode.DAILY_RECOMMENDATION_ALREADY_EXISTS)
         }
     }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationUseCase.kt
@@ -4,7 +4,6 @@ import com.firstpenguin.app.domain.book.service.BookService
 import com.firstpenguin.app.domain.emotion.service.EmotionService
 import com.firstpenguin.app.domain.quote.dto.QuoteResponse
 import com.firstpenguin.app.domain.quote.service.QuoteService
-import com.firstpenguin.app.domain.recommendation.dto.RecommendationExistsResponse
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationRequest
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationResponse
 import com.firstpenguin.app.domain.recommendation.service.RecommendationService
@@ -92,10 +91,6 @@ class RecommendationUseCase(
 
         return nextQuotes.map(::toQuoteResponse)
     }
-
-    @Transactional(readOnly = true)
-    fun hasTodayRecommendation(userId: Long): RecommendationExistsResponse =
-        RecommendationExistsResponse(exists = recommendationService.hasRecommendedToday(userId))
 
     private fun toQuoteResponse(quote: com.firstpenguin.app.domain.quote.model.Quote): QuoteResponse {
         val book = bookService.findBookById(quote.bookId)


### PR DESCRIPTION
## 📢 요약
- 프론트가 오늘의 다음 플로우를 판단할 수 있도록 오늘 진행 상태 조회 API를 추가했습니다.
- 오늘 문장 추천 생성 여부와 오늘 일기 작성 여부를 함께 내려줍니다.
- 오늘 추천은 받았지만 일기를 작성하지 않은 경우, 문장 추천 이후 플로우로 복귀할 수 있도록 `dailyRecommendationId`를 함께 반환합니다.

🔗 연관 이슈: Resolves #이슈번호

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
```bash
./gradlew lintKotlin
```

성공했습니다.

응답 예시:

```json
{
  "hasTodayRecommendation": true,
  "hasTodayDiary": false,
  "dailyRecommendationId": 1
}
```

## 📜 기타
- `dailyRecommendationId`는 오늘 추천은 존재하고 오늘 일기는 작성하지 않은 경우에만 내려줍니다.
- 프론트는 응답값을 기준으로 감정/태그 선택 플로우, 문장 추천 이후 플로우, 일기 완료 상태를 분기할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 오늘의 추천 여부·일기 여부와 추천 ID를 한 번에 조회하는 "오늘 상태" 엔드포인트 추가

* **리팩토링**
  * 추천/일기 존재 여부를 반환하던 개별 엔드포인트들을 통합해 호출 수 감소 및 응답 간소화
  * 일부 작성/추천 관련 엔드포인트는 인증된 사용자만 호출하도록 인증 요구가 명확화되었습니다
<!-- end of auto-generated comment: release notes by coderabbit.ai -->