### PR TITLE
feat: 일일 추천 상세 조회 및 태그 저장 구현

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/controller/DiaryController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/controller/DiaryController.kt
@@ -4,7 +4,6 @@ import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
 import com.firstpenguin.app.domain.diary.dto.CreateDiaryRequest
 import com.firstpenguin.app.domain.diary.dto.CreateDiaryResponse
 import com.firstpenguin.app.domain.diary.dto.DiaryDetailResponse
-import com.firstpenguin.app.domain.diary.dto.DiaryExistsResponse
 import com.firstpenguin.app.domain.diary.dto.DiaryPeriodResponse
 import com.firstpenguin.app.domain.diary.dto.UpdateDiaryContentRequest
 import com.firstpenguin.app.domain.diary.usecase.DiaryUseCase
@@ -48,15 +47,12 @@ class DiaryController(
     )
     @PostMapping
     fun createDiary(
-        @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser?,
+        @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
         @Valid @RequestBody request: CreateDiaryRequest,
-    ): ResponseEntity<CreateDiaryResponse> {
-        if (authenticatedUser == null) {
-            throw CustomException(ErrorCode.UNAUTHORIZED)
-        }
-
-        return ResponseEntity.ok(diaryUseCase.createDiary(authenticatedUser.id, request))
-    }
+    ): ResponseEntity<CreateDiaryResponse> =
+        ResponseEntity.ok(
+            diaryUseCase.createDiary(authenticatedUser.id, request),
+        )
 
     @DeleteMapping("/{diaryId}")
     @Operation(
@@ -207,23 +203,6 @@ class DiaryController(
             diaryId = diaryId,
             request = request,
         )
-    }
-
-    @GetMapping("/today/exists")
-    @Operation(
-        summary = "오늘 일기 작성 여부 조회 API",
-        description = "로그인한 사용자가 오늘 작성한 일기가 있는지 조회한다.",
-        security = [SecurityRequirement(name = "bearerAuth")],
-    )
-    fun hasTodayDiary(
-        @Parameter(hidden = true)
-        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser?,
-    ): ResponseEntity<DiaryExistsResponse> {
-        if (authenticatedUser == null) {
-            throw CustomException(ErrorCode.UNAUTHORIZED)
-        }
-
-        return ResponseEntity.ok(diaryUseCase.hasTodayDiary(authenticatedUser.id))
     }
 
     @GetMapping("/{diaryId}")

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/dto/CreateDiaryRequest.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/dto/CreateDiaryRequest.kt
@@ -13,7 +13,6 @@ data class CreateDiaryRequest(
     @field:Min(MIN_EMOTION_VALUE)
     @field:Max(MAX_EMOTION_VALUE)
     val emotionValue: Int,
-    val tagIds: List<Long>,
     val dailyRecommendationId: Long,
     val quoteId: Long,
     @field:Size(max = 300, message = "일기 내용은 300자 이하로 입력해주세요")

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/diary/usecase/DiaryUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/diary/usecase/DiaryUseCase.kt
@@ -5,13 +5,11 @@ import com.firstpenguin.app.domain.diary.dto.CreateDiaryResponse
 import com.firstpenguin.app.domain.diary.dto.DiaryDetailResponse
 import com.firstpenguin.app.domain.diary.dto.DiaryPeriodResponse
 import com.firstpenguin.app.domain.diary.dto.UpdateDiaryContentRequest
-import com.firstpenguin.app.domain.diary.model.CreatedDiary
 import com.firstpenguin.app.domain.diary.service.DiaryService
 import com.firstpenguin.app.domain.diary.service.DiaryShareImageService
 import com.firstpenguin.app.domain.diary.service.DiaryTagService
 import com.firstpenguin.app.domain.emotion.service.EmotionService
 import com.firstpenguin.app.domain.image.service.ImageService
-import com.firstpenguin.app.domain.recommendation.model.DailyRecommendation
 import com.firstpenguin.app.domain.recommendation.service.RecommendationService
 import com.firstpenguin.app.global.enums.ImageOwner
 import com.firstpenguin.app.global.exception.ErrorCode
@@ -34,65 +32,36 @@ class DiaryUseCase(
         request: CreateDiaryRequest,
     ): CreateDiaryResponse {
         diaryService.validateCanCreateTodayDiary(userId)
-        val dailyRecommendation = validateRecommendation(userId, request)
-        validateEmotion(dailyRecommendation, request)
-        val createdDiary = persistDiary(userId, request)
-        persistAssociations(createdDiary.diaryId, request)
-        return CreateDiaryResponse(createdDiary.diaryId, createdDiary.createdAt)
-    }
-
-    private fun validateRecommendation(
-        userId: Long,
-        request: CreateDiaryRequest,
-    ): DailyRecommendation {
         val dailyRecommendation =
-            recommendationService.getDailyRecommendation(request.dailyRecommendationId)
-
-        recommendationService.validateOwner(userId, dailyRecommendation)
-        recommendationService.validateTodayRecommendation(dailyRecommendation.recommendationDate)
-        recommendationService.validateRecommendedQuote(
-            dailyRecommendationId = dailyRecommendation.id,
-            quoteId = request.quoteId,
-        )
-
-        return dailyRecommendation
-    }
-
-    private fun validateEmotion(
-        dailyRecommendation: DailyRecommendation,
-        request: CreateDiaryRequest,
-    ) {
+            recommendationService.validateDailyRecommendationQuote(
+                userId = userId,
+                dailyRecommendationId = request.dailyRecommendationId,
+                quoteId = request.quoteId,
+            )
         val emotionRange = emotionService.getEmotionRange(request.emotionValue)
+
         recommendationService.validateSelectedEmotionRange(
             dailyRecommendation = dailyRecommendation,
             emotionRangeId = emotionRange.id,
         )
-        emotionService.validateEmotionTagsInRange(
-            tagIds = request.tagIds,
-            emotionRangeId = emotionRange.id,
-        )
-    }
 
-    private fun persistDiary(
-        userId: Long,
-        request: CreateDiaryRequest,
-    ): CreatedDiary {
-        val content = request.content?.takeIf { it.isNotBlank() }
+        val createdDiary =
+            diaryService.createDiary(
+                userId = userId,
+                emotionValue = request.emotionValue,
+                quoteId = request.quoteId,
+                content = request.content?.takeIf { it.isNotBlank() },
+            )
 
-        return diaryService.createDiary(
-            userId = userId,
-            emotionValue = request.emotionValue,
-            quoteId = request.quoteId,
-            content = content,
-        )
-    }
+        val recommendationTagIds =
+            recommendationService
+                .getRecommendationTags(request.dailyRecommendationId)
+                .map { recommendationTag -> recommendationTag.tagId }
 
-    private fun persistAssociations(
-        diaryId: Long,
-        request: CreateDiaryRequest,
-    ) {
-        diaryTagService.createDiaryTags(diaryId, request.tagIds)
-        imageService.saveImages(request.imageIds, ImageOwner.DIARY, diaryId)
+        diaryTagService.createDiaryTags(createdDiary.diaryId, recommendationTagIds)
+        imageService.saveImages(request.imageIds, ImageOwner.DIARY, createdDiary.diaryId)
+
+        return CreateDiaryResponse(createdDiary.diaryId, createdDiary.createdAt)
     }
 
     @Transactional

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/dto/TagDto.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/dto/TagDto.kt
@@ -1,5 +1,6 @@
 package com.firstpenguin.app.domain.emotion.dto
 
+import com.firstpenguin.app.domain.emotion.model.Tag
 import com.firstpenguin.app.global.enums.TagType
 
 data class TagDto(
@@ -7,4 +8,14 @@ data class TagDto(
     val label: String,
     val type: TagType,
     val emotionRangeId: Long?,
-)
+) {
+    companion object {
+        fun from(tag: Tag): TagDto =
+            TagDto(
+                id = tag.id,
+                label = tag.label,
+                type = tag.type,
+                emotionRangeId = tag.emotionRangeId,
+            )
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/service/EmotionService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/service/EmotionService.kt
@@ -1,6 +1,5 @@
 package com.firstpenguin.app.domain.emotion.service
 
-import com.firstpenguin.app.domain.emotion.dto.TagDto
 import com.firstpenguin.app.domain.emotion.model.EmotionRange
 import com.firstpenguin.app.domain.emotion.model.Tag
 import com.firstpenguin.app.domain.emotion.repository.EmotionRangeRepository
@@ -8,7 +7,6 @@ import com.firstpenguin.app.domain.emotion.repository.TagRepository
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.stereotype.Service
-import kotlin.collections.map
 
 @Service
 class EmotionService(
@@ -27,38 +25,39 @@ class EmotionService(
 
     fun getToneTags(): List<Tag> = tagRepository.getToneTags()
 
-    fun selectEmotionTags(emotionTagIds: List<Long>): List<TagDto> {
+    fun selectEmotionTags(emotionTagIds: List<Long>): List<Tag> {
         val emotionTags = tagRepository.getEmotionTagsByTagIdsIn(emotionTagIds)
 
         validateEmotionTags(emotionTags, emotionTagIds)
         validateSameEmotionRange(emotionTags)
 
-        return emotionTags.map {
-            TagDto(
-                id = it.id,
-                label = it.label,
-                type = it.type,
-                emotionRangeId = it.emotionRangeId,
-            )
-        }
+        return emotionTags
     }
 
-    fun selectToneTags(toneTagIds: List<Long>): List<TagDto> {
+    fun selectToneTags(toneTagIds: List<Long>): List<Tag> {
         val toneTags = tagRepository.getToneTagsByTagIdsIn(toneTagIds)
 
         validateToneTags(toneTags, toneTagIds)
 
-        return toneTags.map {
-            TagDto(
-                id = it.id,
-                label = it.label,
-                type = it.type,
-                emotionRangeId = it.emotionRangeId,
-            )
-        }
+        return toneTags
     }
 
-    fun validateEmotionTagsInRange(
+    fun getTagsByIds(tagIds: List<Long>): Pair<List<Tag>, List<Tag>> =
+        tagRepository.getEmotionTagsByTagIdsIn(tagIds) to tagRepository.getToneTagsByTagIdsIn(tagIds)
+
+    fun validateEmotionTags(
+        emotionValue: Int,
+        tagIds: List<Long>,
+    ) {
+        val emotionRange = getEmotionRange(emotionValue)
+
+        validateEmotionTagsInRange(
+            tagIds = tagIds,
+            emotionRangeId = emotionRange.id,
+        )
+    }
+
+    private fun validateEmotionTagsInRange(
         tagIds: List<Long>,
         emotionRangeId: Long,
     ) {

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/useCase/EmotionUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/useCase/EmotionUseCase.kt
@@ -16,14 +16,7 @@ class EmotionUseCase(
 
         return TagResponse(
             tags =
-                emotionTags.map {
-                    TagDto(
-                        id = it.id,
-                        label = it.label,
-                        type = it.type,
-                        emotionRangeId = it.emotionRangeId,
-                    )
-                },
+                emotionTags.map(TagDto::from),
         )
     }
 
@@ -33,14 +26,7 @@ class EmotionUseCase(
 
         return TagResponse(
             tags =
-                toneTags.map {
-                    TagDto(
-                        id = it.id,
-                        label = it.label,
-                        type = it.type,
-                        emotionRangeId = it.emotionRangeId,
-                    )
-                },
+                toneTags.map(TagDto::from),
         )
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/home/useCase/HomeUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/home/useCase/HomeUseCase.kt
@@ -69,13 +69,9 @@ class HomeUseCase(
     private fun toQuoteResponse(quote: Quote): QuoteResponse {
         val book = bookService.findBookById(quote.bookId)
 
-        return QuoteResponse(
-            quoteId = quote.id,
-            bookId = book.id,
-            content = quote.content,
-            title = book.title,
-            author = book.author,
-            image = book.coverImageUrl,
+        return QuoteResponse.from(
+            quote = quote,
+            book = book,
         )
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quote/dto/QuoteResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quote/dto/QuoteResponse.kt
@@ -1,5 +1,8 @@
 package com.firstpenguin.app.domain.quote.dto
 
+import com.firstpenguin.app.domain.book.model.Book
+import com.firstpenguin.app.domain.quote.model.Quote
+
 data class QuoteResponse(
     val quoteId: Long,
     val bookId: Long,
@@ -7,4 +10,19 @@ data class QuoteResponse(
     val title: String,
     val author: String,
     val image: String,
-)
+) {
+    companion object {
+        fun from(
+            quote: Quote,
+            book: Book,
+        ): QuoteResponse =
+            QuoteResponse(
+                quoteId = quote.id,
+                bookId = book.id,
+                content = quote.content,
+                title = book.title,
+                author = book.author,
+                image = book.coverImageUrl,
+            )
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quote/service/QuoteService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quote/service/QuoteService.kt
@@ -42,6 +42,10 @@ class QuoteService(
         throw CustomException(ErrorCode.NOT_ENOUGH_QUOTES)
     }
 
+    fun findQuoteById(id: Long) =
+        quoteRepository.findQuoteById(id)
+            ?: throw CustomException(ErrorCode.QUOTE_NOT_FOUND)
+
     private fun findRandomQuoteExcludingIds(excludedQuoteIds: Set<Long>): Quote? {
         val maxQuoteId = quoteRepository.getMaxQuoteId()
         if (maxQuoteId == 0L) return null

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
@@ -2,15 +2,18 @@ package com.firstpenguin.app.domain.recommendation.controller
 
 import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
 import com.firstpenguin.app.domain.quote.dto.QuoteResponse
+import com.firstpenguin.app.domain.recommendation.dto.DailyRecommendationResponse
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationRequest
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationResponse
 import com.firstpenguin.app.domain.recommendation.useCase.RecommendationUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -23,6 +26,24 @@ import org.springframework.web.bind.annotation.RestController
 class RecommendationController(
     private val recommendationUseCase: RecommendationUseCase,
 ) {
+    @Operation(
+        summary = "일일 추천 상세 조회 API",
+        description = "dailyRecommendationId를 기준으로 추천 당시 선택한 태그와 추천 문장 정보를 조회한다.",
+        security = [SecurityRequirement(name = "bearerAuth")],
+    )
+    @GetMapping("/{dailyRecommendationId}")
+    fun getDailyRecommendationDetail(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
+        @PathVariable dailyRecommendationId: Long,
+    ): ResponseEntity<DailyRecommendationResponse> =
+        ResponseEntity.ok(
+            recommendationUseCase.getDailyRecommendationDetail(
+                userId = authenticatedUser.id,
+                dailyRecommendationId = dailyRecommendationId,
+            ),
+        )
+
     @Operation(
         summary = "감정/톤 태그 선택, 사용자 문장을 받아 추천된 문장 반환 API",
         description = "사용자가 선택한 감정 태그와 톤 태그를 검증하고, 추천된 문장을 반환한다.",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
@@ -35,7 +35,7 @@ class RecommendationController(
         ResponseEntity.ok(
             recommendationUseCase.recommendQuote(
                 userId = authenticatedUser.id,
-                request = request
+                request = request,
             ),
         )
 

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/dto/DailyRecommendationResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/dto/DailyRecommendationResponse.kt
@@ -1,8 +1,11 @@
 package com.firstpenguin.app.domain.recommendation.dto
 
+import com.firstpenguin.app.domain.emotion.dto.TagDto
 import com.firstpenguin.app.domain.quote.dto.QuoteResponse
 
-data class RecommendationResponse(
+data class DailyRecommendationResponse(
     val dailyRecommendationId: Long,
     val quote: QuoteResponse,
+    val emotionTags: List<TagDto>,
+    val toneTags: List<TagDto>,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/DailyRecommendationTag.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/DailyRecommendationTag.kt
@@ -1,0 +1,10 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+import java.time.LocalDateTime
+
+data class DailyRecommendationTag(
+    val id: Long,
+    val dailyRecommendationId: Long,
+    val tagId: Long,
+    val createdAt: LocalDateTime,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/DailyRecommendationRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/DailyRecommendationRepository.kt
@@ -50,6 +50,14 @@ class DailyRecommendationRepository(
             .fetchOne()
             ?.let(::toDailyRecommendation)
 
+    fun findDailyRecommendationById(id: Long): DailyRecommendation? =
+        dsl
+            .select(DAILY_RECOMMENDATION_FIELDS)
+            .from(DailyRecommendationTable.DAILY_RECOMMENDATIONS)
+            .where(DailyRecommendationTable.ID.eq(id))
+            .fetchOne()
+            ?.let(::toDailyRecommendation)
+
     fun findDailyRecommendationByPkForUpdate(id: Long): DailyRecommendation? =
         dsl
             .select(DAILY_RECOMMENDATION_FIELDS)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/DailyRecommendationTagRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/DailyRecommendationTagRepository.kt
@@ -1,0 +1,62 @@
+package com.firstpenguin.app.domain.recommendation.repository
+
+import com.firstpenguin.app.domain.recommendation.model.DailyRecommendationTag
+import com.firstpenguin.app.domain.recommendation.repository.table.DailyRecommendationTagTable
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.impl.DSL
+import org.springframework.stereotype.Repository
+
+@Repository
+class DailyRecommendationTagRepository(
+    private val dsl: DSLContext,
+) {
+    fun insertDailyRecommendationTag(
+        dailyRecommendationId: Long,
+        tagIds: List<Long>,
+    ) {
+        if (tagIds.isEmpty()) return
+
+        val rows =
+            tagIds
+                .distinct()
+                .map { tagId -> DSL.row(dailyRecommendationId, tagId) }
+        val insertStep =
+            dsl.insertInto(
+                DailyRecommendationTagTable.DAILY_RECOMMENDATION_TAGS,
+                DailyRecommendationTagTable.DAILY_RECOMMENDATION_ID,
+                DailyRecommendationTagTable.TAG_ID,
+            )
+
+        insertStep
+            .valuesOfRows(rows)
+            .onConflictDoNothing()
+            .execute()
+    }
+
+    fun findByDailyRecommendationId(dailyRecommendationId: Long): List<DailyRecommendationTag> =
+        dsl
+            .select(DAILY_RECOMMENDATION_TAG_FIELDS)
+            .from(DailyRecommendationTagTable.DAILY_RECOMMENDATION_TAGS)
+            .where(DailyRecommendationTagTable.DAILY_RECOMMENDATION_ID.eq(dailyRecommendationId))
+            .fetch(::toDailyRecommendationTag)
+
+    private fun toDailyRecommendationTag(record: Record): DailyRecommendationTag =
+        DailyRecommendationTag(
+            id = record[DailyRecommendationTagTable.ID]!!,
+            dailyRecommendationId = record[DailyRecommendationTagTable.DAILY_RECOMMENDATION_ID]!!,
+            tagId = record[DailyRecommendationTagTable.TAG_ID]!!,
+            createdAt = record[DailyRecommendationTagTable.CREATED_AT]!!,
+        )
+
+    private companion object {
+        val DAILY_RECOMMENDATION_TAG_FIELDS: List<Field<*>> =
+            listOf(
+                DailyRecommendationTagTable.ID,
+                DailyRecommendationTagTable.DAILY_RECOMMENDATION_ID,
+                DailyRecommendationTagTable.TAG_ID,
+                DailyRecommendationTagTable.CREATED_AT,
+            )
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/table/DailyRecommendationTagTable.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/table/DailyRecommendationTagTable.kt
@@ -1,0 +1,13 @@
+package com.firstpenguin.app.domain.recommendation.repository.table
+
+import org.jooq.impl.DSL
+import java.time.LocalDateTime
+
+internal object DailyRecommendationTagTable {
+    val DAILY_RECOMMENDATION_TAGS = DSL.table(DSL.name("daily_recommendation_tags"))
+    val ID = DSL.field(DSL.name("daily_recommendation_tags", "id"), Long::class.java)
+    val DAILY_RECOMMENDATION_ID =
+        DSL.field(DSL.name("daily_recommendation_tags", "daily_recommendation_id"), Long::class.java)
+    val TAG_ID = DSL.field(DSL.name("daily_recommendation_tags", "tag_id"), Long::class.java)
+    val CREATED_AT = DSL.field(DSL.name("daily_recommendation_tags", "created_at"), LocalDateTime::class.java)
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationService.kt
@@ -90,9 +90,14 @@ class RecommendationService(
     fun validateDailyRecommendation(
         userId: Long,
         dailyRecommendationId: Long,
+        lockForUpdate: Boolean = true,
     ): DailyRecommendation {
         val dailyRecommendation =
-            dailyRecommendationRepository.findDailyRecommendationByPkForUpdate(dailyRecommendationId)
+            if (lockForUpdate) {
+                dailyRecommendationRepository.findDailyRecommendationByPkForUpdate(dailyRecommendationId)
+            } else {
+                dailyRecommendationRepository.findDailyRecommendationById(dailyRecommendationId)
+            }
                 ?: notFound()
 
         if (dailyRecommendation.userId != userId) {

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationService.kt
@@ -2,8 +2,10 @@ package com.firstpenguin.app.domain.recommendation.service
 
 import com.firstpenguin.app.domain.recommendation.model.DailyRecommendation
 import com.firstpenguin.app.domain.recommendation.model.DailyRecommendationQuote
+import com.firstpenguin.app.domain.recommendation.model.DailyRecommendationTag
 import com.firstpenguin.app.domain.recommendation.repository.DailyRecommendationQuoteRepository
 import com.firstpenguin.app.domain.recommendation.repository.DailyRecommendationRepository
+import com.firstpenguin.app.domain.recommendation.repository.DailyRecommendationTagRepository
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.stereotype.Service
@@ -15,6 +17,7 @@ private const val MAX_RECOMMENDATION_QUOTE_COUNT = 10
 class RecommendationService(
     private val dailyRecommendationRepository: DailyRecommendationRepository,
     private val dailyRecommendationQuoteRepository: DailyRecommendationQuoteRepository,
+    private val dailyRecommendationTagRepository: DailyRecommendationTagRepository,
 ) {
     fun createDailyRecommendation(
         userId: Long,
@@ -42,9 +45,15 @@ class RecommendationService(
         )
     }
 
-    fun getDailyRecommendation(id: Long) =
-        dailyRecommendationRepository.findDailyRecommendationByPkForUpdate(id)
-            ?: throw CustomException(ErrorCode.DAILY_RECOMMENDATION_NOT_FOUND)
+    fun createDailyRecommendationTags(
+        dailyRecommendationId: Long,
+        tagIds: List<Long>,
+    ) {
+        dailyRecommendationTagRepository.insertDailyRecommendationTag(
+            dailyRecommendationId = dailyRecommendationId,
+            tagIds = tagIds,
+        )
+    }
 
     fun getRecommendationHistory(dailyRecommendationId: Long): List<DailyRecommendationQuote> =
         dailyRecommendationQuoteRepository
@@ -54,6 +63,47 @@ class RecommendationService(
         val today = LocalDate.now()
 
         return dailyRecommendationRepository.findByUserIdAndRecommendationDate(userId, today)
+    }
+
+    fun getRecommendationTags(dailyRecommendationId: Long): List<DailyRecommendationTag> =
+        dailyRecommendationTagRepository.findByDailyRecommendationId(dailyRecommendationId)
+
+    fun validateDailyRecommendationQuote(
+        userId: Long,
+        dailyRecommendationId: Long,
+        quoteId: Long,
+    ): DailyRecommendation {
+        val dailyRecommendation = validateDailyRecommendation(userId, dailyRecommendationId)
+        val isRecommendedQuote =
+            dailyRecommendationQuoteRepository.existsByDailyRecommendationIdAndQuoteId(
+                dailyRecommendationId = dailyRecommendationId,
+                quoteId = quoteId,
+            )
+
+        if (!isRecommendedQuote) {
+            throw CustomException(ErrorCode.INVALID_RECOMMENDATION_QUOTE)
+        }
+
+        return dailyRecommendation
+    }
+
+    fun validateDailyRecommendation(
+        userId: Long,
+        dailyRecommendationId: Long,
+    ): DailyRecommendation {
+        val dailyRecommendation =
+            dailyRecommendationRepository.findDailyRecommendationByPkForUpdate(dailyRecommendationId)
+                ?: notFound()
+
+        if (dailyRecommendation.userId != userId) {
+            forbidden()
+        }
+
+        if (dailyRecommendation.recommendationDate != LocalDate.now()) {
+            invalidDate()
+        }
+
+        return dailyRecommendation
     }
 
     fun validateRecommendationAvailable(userId: Long) {
@@ -71,27 +121,6 @@ class RecommendationService(
         }
     }
 
-    fun validateTodayRecommendation(dailyRecommendationDate: LocalDate) {
-        if (dailyRecommendationDate != LocalDate.now()) {
-            throw CustomException(ErrorCode.INVALID_DAILY_RECOMMENDATION)
-        }
-    }
-
-    fun validateRecommendedQuote(
-        dailyRecommendationId: Long,
-        quoteId: Long,
-    ) {
-        val isRecommendedQuote =
-            dailyRecommendationQuoteRepository.existsByDailyRecommendationIdAndQuoteId(
-                dailyRecommendationId = dailyRecommendationId,
-                quoteId = quoteId,
-            )
-
-        if (!isRecommendedQuote) {
-            throw CustomException(ErrorCode.INVALID_RECOMMENDATION_QUOTE)
-        }
-    }
-
     fun validateSelectedEmotionRange(
         dailyRecommendation: DailyRecommendation,
         emotionRangeId: Long,
@@ -100,13 +129,10 @@ class RecommendationService(
             throw CustomException(ErrorCode.INVALID_DIARY_EMOTION_VALUE)
         }
     }
-
-    fun validateOwner(
-        userId: Long,
-        dailyRecommendation: DailyRecommendation,
-    ) {
-        if (dailyRecommendation.userId != userId) {
-            throw CustomException(ErrorCode.FORBIDDEN_DAILY_RECOMMENDATION)
-        }
-    }
 }
+
+private fun notFound(): Nothing = throw CustomException(ErrorCode.DAILY_RECOMMENDATION_NOT_FOUND)
+
+private fun forbidden(): Nothing = throw CustomException(ErrorCode.FORBIDDEN_DAILY_RECOMMENDATION)
+
+private fun invalidDate(): Nothing = throw CustomException(ErrorCode.INVALID_DAILY_RECOMMENDATION)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationUseCase.kt
@@ -1,11 +1,15 @@
 package com.firstpenguin.app.domain.recommendation.useCase
 
 import com.firstpenguin.app.domain.book.service.BookService
+import com.firstpenguin.app.domain.emotion.dto.TagDto
 import com.firstpenguin.app.domain.emotion.service.EmotionService
 import com.firstpenguin.app.domain.quote.dto.QuoteResponse
+import com.firstpenguin.app.domain.quote.model.Quote
 import com.firstpenguin.app.domain.quote.service.QuoteService
+import com.firstpenguin.app.domain.recommendation.dto.DailyRecommendationResponse
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationRequest
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationResponse
+import com.firstpenguin.app.domain.recommendation.model.DailyRecommendationTag
 import com.firstpenguin.app.domain.recommendation.service.RecommendationService
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
@@ -28,22 +32,19 @@ class RecommendationUseCase(
     ): RecommendationResponse {
         recommendationService.validateRecommendationAvailable(userId)
 
-        val selectEmotionTags = emotionService.selectEmotionTags(request.emotionTagIds)
-        val selectToneTags = emotionService.selectToneTags(request.toneTagIds)
-
-        val randomQuote = quoteService.getRandomQuote()
-
+        val selectedEmotionTags = emotionService.selectEmotionTags(request.emotionTagIds)
+        emotionService.selectToneTags(request.toneTagIds)
         val selectedEmotionRangeId =
-            selectEmotionTags.first().emotionRangeId
+            selectedEmotionTags.first().emotionRangeId
                 ?: throw CustomException(ErrorCode.INVALID_EMOTION_TAG)
 
-        val userContext = request.userContext.takeIf { it.isNotBlank() }
+        val randomQuote = quoteService.getRandomQuote()
 
         val dailyRecommendationId =
             recommendationService.createDailyRecommendation(
                 userId = userId,
                 quoteId = randomQuote.id,
-                userContext = userContext,
+                userContext = request.userContext.takeIf { it.isNotBlank() },
                 selectedEmotionRangeId = selectedEmotionRangeId,
             )
 
@@ -52,11 +53,37 @@ class RecommendationUseCase(
             quoteIds = listOf(randomQuote.id),
         )
 
+        recommendationService.createDailyRecommendationTags(
+            dailyRecommendationId = dailyRecommendationId,
+            tagIds = request.emotionTagIds + request.toneTagIds,
+        )
+
         return RecommendationResponse(
             dailyRecommendationId = dailyRecommendationId,
             quote = toQuoteResponse(randomQuote),
-            emotionTags = selectEmotionTags,
-            toneTags = selectToneTags,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getDailyRecommendationDetail(
+        userId: Long,
+        dailyRecommendationId: Long,
+    ): DailyRecommendationResponse {
+        val dailyRecommendation =
+            recommendationService.validateDailyRecommendation(
+                userId = userId,
+                dailyRecommendationId = dailyRecommendationId,
+            )
+
+        val quote = quoteService.findQuoteById(dailyRecommendation.quoteId)
+        val recommendationTags = recommendationService.getRecommendationTags(dailyRecommendationId)
+        val (emotionTags, toneTags) = toTagDtos(recommendationTags)
+
+        return DailyRecommendationResponse(
+            dailyRecommendationId = dailyRecommendationId,
+            quote = toQuoteResponse(quote),
+            emotionTags = emotionTags,
+            toneTags = toneTags,
         )
     }
 
@@ -65,12 +92,9 @@ class RecommendationUseCase(
         userId: Long,
         dailyRecommendationId: Long,
     ): List<QuoteResponse> {
-        val dailyRecommendation = recommendationService.getDailyRecommendation(dailyRecommendationId)
+        recommendationService.validateDailyRecommendation(userId, dailyRecommendationId)
 
-        recommendationService.validateOwner(userId, dailyRecommendation)
-        recommendationService.validateTodayRecommendation(dailyRecommendation.recommendationDate)
-
-        val recommendationHistory = recommendationService.getRecommendationHistory(dailyRecommendation.id)
+        val recommendationHistory = recommendationService.getRecommendationHistory(dailyRecommendationId)
 
         recommendationService.validateRecommendationCount(
             currentCount = recommendationHistory.size,
@@ -92,16 +116,19 @@ class RecommendationUseCase(
         return nextQuotes.map(::toQuoteResponse)
     }
 
-    private fun toQuoteResponse(quote: com.firstpenguin.app.domain.quote.model.Quote): QuoteResponse {
+    private fun toQuoteResponse(quote: Quote): QuoteResponse {
         val book = bookService.findBookById(quote.bookId)
 
-        return QuoteResponse(
-            quoteId = quote.id,
-            bookId = book.id,
-            content = quote.content,
-            title = book.title,
-            author = book.author,
-            image = book.coverImageUrl,
+        return QuoteResponse.from(
+            quote = quote,
+            book = book,
         )
+    }
+
+    private fun toTagDtos(recommendationTags: List<DailyRecommendationTag>): Pair<List<TagDto>, List<TagDto>> {
+        val tagIds = recommendationTags.map { recommendationTag -> recommendationTag.tagId }
+        val (emotionTags, toneTags) = emotionService.getTagsByIds(tagIds)
+
+        return emotionTags.map(TagDto::from) to toneTags.map(TagDto::from)
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationUseCase.kt
@@ -73,6 +73,7 @@ class RecommendationUseCase(
             recommendationService.validateDailyRecommendation(
                 userId = userId,
                 dailyRecommendationId = dailyRecommendationId,
+                lockForUpdate = false,
             )
 
         val quote = quoteService.findQuoteById(dailyRecommendation.quoteId)

--- a/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
@@ -62,6 +62,7 @@ enum class ErrorCode(
 
     // Quote
     NOT_ENOUGH_QUOTES(HttpStatus.CONFLICT, "추천 가능한 문장이 부족합니다."),
+    QUOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "문장을 찾을 수 없습니다."),
 
     // Image
     INVALID_IMAGE_OWNER_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 주인 타입이 올바르지 않습니다."),

--- a/app/src/main/resources/db/migration/V29__create_daily_recommendation_tags.sql
+++ b/app/src/main/resources/db/migration/V29__create_daily_recommendation_tags.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS daily_recommendation_tags (
+     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+     daily_recommendation_id BIGINT NOT NULL,
+     tag_id BIGINT NOT NULL,
+     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS daily_recommendation_tags_recommendation_tag_uidx
+    ON daily_recommendation_tags (daily_recommendation_id, tag_id);


### PR DESCRIPTION
## 📢 요약
- `daily_recommendation_tags` 테이블을 추가해 추천 당시 사용자가 선택한 감정/톤 태그를 저장하도록 구현했습니다.
- `dailyRecommendationId` 기반 일일 추천 상세 조회 API를 추가했습니다.
- 추천 상세 조회 응답에 추천 문장 정보와 추천 당시 선택한 감정/톤 태그를 함께 내려주도록 했습니다.
- 추천 생성 API 응답은 `dailyRecommendationId`와 추천 문장 정보만 내려주도록 단순화했습니다.
- 일기 생성 시 클라이언트가 태그를 다시 보내지 않고, 저장된 일일 추천 태그를 `diary_tags`로 복사하도록 변경했습니다.
- 상세 조회처럼 읽기 전용 트랜잭션에서 `SELECT FOR UPDATE`가 실행되지 않도록 조회/잠금 흐름을 분리했습니다.

🔗 연관 이슈: Resolves #이슈번호

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
```bash
./gradlew testClasses
./gradlew lintKotlin
./gradlew detekt
./gradlew test
```

성공했습니다.

### 추천 생성 응답 예시
```json
{
  "dailyRecommendationId": 1,
  "quote": {
    "quoteId": 10,
    "bookId": 3,
    "content": "문장 내용",
    "title": "책 제목",
    "author": "저자",
    "image": "https://example.com/book-cover.jpg"
  }
}
```

### 일일 추천 상세 조회 응답 예시
```json
{
  "dailyRecommendationId": 1,
  "quote": {
    "quoteId": 10,
    "bookId": 3,
    "content": "문장 내용",
    "title": "책 제목",
    "author": "저자",
    "image": "https://example.com/book-cover.jpg"
  },
  "emotionTags": [
    {
      "id": 1,
      "label": "지쳐있는 순간",
      "type": "EMOTION",
      "emotionRangeId": 1
    }
  ],
  "toneTags": [
    {
      "id": 50,
      "label": "위로가 되는 문장",
      "type": "TONE",
      "emotionRangeId": null
    }
  ]
}
```

## 📜 기타
- 일기 생성 요청에서 태그 ID를 다시 받지 않고, 추천 당시 저장된 태그를 기준으로 일기 태그를 생성합니다.
- 문장 더보기/일기 작성처럼 동시성 제어가 필요한 흐름은 기존처럼 `FOR UPDATE`를 사용하고, 상세 조회는 잠금 없는 조회를 사용합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일일 추천 상세 정보 조회 엔드포인트 추가 (감정 태그, 톤 태그 포함)

* **개선 사항**
  * 일기 작성 시 추천 기반 태그 자동 할당 (수동 태그 지정 제거)
  * 인증 처리 강화

* **제거됨**
  * 오늘의 일기 존재 여부 확인 API 엔드포인트 제거

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team1-BE/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->