### PR TITLE
refactor: OAuth 사용자 로그인 흐름 분리

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,252 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# CodeRabbit 리뷰와 채팅 답변 언어입니다.
+language: "ko-KR"
+
+# 조직이나 중앙 설정에서 정의한 값 중 이 파일에 없는 값을 상속할지 여부입니다.
+# 레포별 리뷰 정책을 명확히 적용하기 위해 false로 둡니다.
+inheritance: false
+
+# CodeRabbit의 실험 기능은 리뷰 결과가 바뀔 수 있어 기본적으로 끕니다.
+early_access: false
+
+# 유료 플랜 사용자가 아니어도 기본 기능은 사용할 수 있게 둡니다.
+enable_free_tier: true
+
+# 리뷰 톤입니다. 취향성 코멘트보다 실제 장애와 결함 가능성을 우선하도록 지시합니다.
+tone_instructions: "시니어 백엔드 개발자처럼 간결하고 근거 중심으로 리뷰하세요. 사소한 취향보다 로직 오류, 데이터 정합성, 보안, 트랜잭션, 장애 가능성을 우선하세요."
+
+reviews:
+  # chill은 실제 결함 가능성이 높은 코멘트를 우선해 초기 도입 시 잡음을 줄입니다.
+  profile: "chill"
+
+  # CodeRabbit이 남긴 코멘트가 해결되고 pre-merge check가 실패하지 않으면 approve합니다.
+  request_changes_workflow: true
+
+  # PR 변경 요약을 생성합니다.
+  high_level_summary: true
+
+  # PR 본문을 직접 수정하기보다 walkthrough 코멘트 안에 요약을 넣습니다.
+  high_level_summary_in_walkthrough: true
+
+  # 요약에 포함할 내용입니다.
+  high_level_summary_instructions: >
+    변경 의도, 주요 영향, API/DB/인프라 변경 여부, 테스트 확인 포인트를 한국어 bullet로 간결히 정리하세요.
+    릴리스 노트식 과장 표현은 피하고 실제 리뷰에 필요한 정보만 남기세요.
+
+  # 리뷰 진행 상태와 스킵 사유를 walkthrough에 표시합니다.
+  review_status: true
+
+  # 무시된 파일, 사용한 추가 컨텍스트 같은 상세 정보는 일상 PR에서 숨깁니다.
+  review_details: false
+
+  # 리뷰 중/완료 상태를 GitHub commit status로 표시합니다.
+  commit_status: true
+
+  # CodeRabbit이 리뷰 자체를 수행하지 못하면 commit status를 failure로 표시합니다.
+  fail_commit_status: true
+
+  # walkthrough를 접힌 영역으로 표시해 PR 화면을 덜 복잡하게 만듭니다.
+  collapse_walkthrough: true
+
+  # 변경 파일 요약, 시퀀스 다이어그램, 리뷰 노력 추정치를 표시합니다.
+  changed_files_summary: true
+  sequence_diagrams: true
+  estimate_code_review_effort: true
+
+  # 연결된 이슈/관련 PR/라벨/리뷰어 제안을 표시하되 자동 적용은 하지 않습니다.
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+
+  # 리뷰 중 운세 문구와 시는 끕니다.
+  in_progress_fortune: false
+  poem: false
+
+  # inline comment에 AI agent용 프롬프트 섹션을 붙이지 않습니다.
+  enable_prompt_for_ai_agents: false
+
+  # 리뷰 대상에서 제외할 경로입니다.
+  path_filters:
+    - "!**/build/**"
+    - "!**/.gradle/**"
+    - "!app/src/main/resources/fonts/**"
+    - "!secret/**"
+    - "!**/terraform.tfstate*"
+
+  # 자동 리뷰 대상입니다. 이 레포는 PR 대상이 dev이므로 dev를 명시합니다.
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 5
+    base_branches:
+      - "dev"
+      - "main"
+    ignore_title_keywords:
+      - "wip"
+      - "do not review"
+
+  # CodeRabbit이 추가로 사용할 정적 분석 도구입니다.
+  tools:
+    github-checks:
+      enabled: true
+      timeout_ms: 300000
+    detekt:
+      enabled: true
+      config_file: "detekt.yml"
+    actionlint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    hadolint:
+      enabled: true
+    checkov:
+      enabled: true
+    tflint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    trufflehog:
+      enabled: true
+    yamllint:
+      enabled: false
+    markdownlint:
+      enabled: true
+
+  # PR 머지 전 점검입니다. error는 request_changes_workflow에서 approve를 막을 수 있습니다.
+  pre_merge_checks:
+    override_requested_reviewers_only: true
+    title:
+      mode: "warning"
+      requirements: >
+        PR 제목은 Conventional Commits 형식을 따르세요.
+        예: feat: 회원가입 API 추가, fix: 토큰 만료 처리 수정
+    description:
+      mode: "warning"
+    issue_assessment:
+      mode: "warning"
+    docstrings:
+      mode: "off"
+    custom_checks:
+      - name: "Layer and transaction rules"
+        mode: "warning"
+        instructions: >
+          변경된 Kotlin 코드에서 프로젝트 계층 규칙을 위반하면 실패로 판단하세요.
+          @Transactional은 usecase 계층에만 있어야 합니다.
+          controller -> usecase -> service -> repository 흐름을 우선해야 합니다.
+          repository는 쿼리 작성과 실행만 담당하고 트랜잭션 경계를 만들면 안 됩니다.
+          service에는 도메인 정책과 검증 로직을 두되 @Transactional을 선언하면 안 됩니다.
+          외부 API 호출과 DB 트랜잭션이 같은 경계에 묶이면 실패로 판단하세요.
+      - name: "Secret and config rules"
+        mode: "error"
+        instructions: >
+          변경 사항에 DB 접속 정보, OAuth secret, JWT secret, .env, terraform.tfstate,
+          환경별 민감 설정이 추가되면 실패로 판단하세요.
+          app/src/main/resources/application.yml에는 공통 설정만 있어야 합니다.
+          환경별 설정과 민감 정보는 secret submodule의 profile yml에서 관리해야 합니다.
+      - name: "Flyway and DB rules"
+        mode: "warning"
+        instructions: >
+          Flyway migration에서 명시적 요청이나 팀 합의 없이 Foreign Key 같은 DB 레벨 연관관계 제약을 추가하면 실패로 판단하세요.
+          migration은 필요한 테이블, 컬럼, 인덱스, 체크 제약처럼 필요한 스키마 중심이어야 합니다.
+          jOOQ를 ORM 연관관계 매핑처럼 사용하거나 repository/usecase의 명시적 조회 흐름을 우회하면 실패로 판단하세요.
+      - name: "Terraform rules"
+        mode: "warning"
+        instructions: >
+          Terraform 변경에서 terraform.tfstate를 포함하거나 리소스 네이밍 규칙을 위반하면 실패로 판단하세요.
+          인프라 리소스는 {env}-{service}-{resource} 형식을 따르고,
+          GCP 리전은 asia-northeast3, 프로젝트는 project-10e57bb0-e960-4b16-9fa 기준이어야 합니다.
+
+  # 경로별 리뷰 지시입니다. 취향보다 실제 결함 가능성에 집중하게 만듭니다.
+  path_instructions:
+    - path: "app/src/main/kotlin/**/*.kt"
+      instructions: >
+        Kotlin/Spring Boot 백엔드 시니어 리뷰어 관점으로 검토하세요.
+        로직 오류, 잘못된 상태 전이, nullability, edge case, 인증/인가 누락, 데이터 정합성,
+        동시성, 트랜잭션 경계, 장애 복구 가능성, 성능 문제, 테스트 공백을 우선 지적하세요.
+        단순 취향이나 포맷팅만의 코멘트는 detekt나 기존 컨벤션 위반이 명확할 때만 남기세요.
+        DTO는 data class를 우선하고, else/else-if보다 early return을 선호하는 프로젝트 규칙을 고려하세요.
+    - path: "app/src/main/kotlin/**/controller/**/*.kt"
+      instructions: >
+        controller는 요청/응답 매핑, 인증 사용자 처리, 입력 검증, HTTP status, usecase 위임 책임에 집중해야 합니다.
+        도메인 정책, DB 접근, 외부 API 호출이 controller에 들어오면 지적하세요.
+    - path: "app/src/main/kotlin/**/usecase/**/*.kt"
+      instructions: >
+        usecase는 트랜잭션 경계와 작업 흐름을 책임집니다.
+        여러 repository 호출이 하나의 작업으로 묶이는지, @Transactional 위치가 적절한지,
+        외부 API 호출이 DB 트랜잭션 안에서 실행되는지 확인하세요.
+    - path: "app/src/main/kotlin/**/useCase/**/*.kt"
+      instructions: >
+        usecase는 트랜잭션 경계와 작업 흐름을 책임집니다.
+        여러 repository 호출이 하나의 작업으로 묶이는지, @Transactional 위치가 적절한지,
+        외부 API 호출이 DB 트랜잭션 안에서 실행되는지 확인하세요.
+    - path: "app/src/main/kotlin/**/service/**/*.kt"
+      instructions: >
+        service는 도메인 정책과 검증 로직을 담당합니다.
+        @Transactional, HTTP 세부사항, repository orchestration 과다, 외부 연동과 DB 상태 변경의 결합을 지적하세요.
+    - path: "app/src/main/kotlin/**/repository/**/*.kt"
+      instructions: >
+        repository는 jOOQ 쿼리 작성과 실행만 담당합니다.
+        잘못된 where 조건, 누락된 정렬/limit, N+1 위험, 잘못된 nullable 처리,
+        트랜잭션 경계 선언, 도메인 정책 누수를 우선 검토하세요.
+    - path: "app/src/main/resources/db/migration/**/*.sql"
+      instructions: >
+        Flyway migration은 운영 DB에 적용되는 변경으로 보고 리뷰하세요.
+        중복 migration 번호, destructive change, 불필요한 Foreign Key,
+        기존 데이터와 호환되지 않는 NOT NULL/타입 변경, 인덱스 누락 가능성을 확인하세요.
+    - path: "app/src/main/resources/application*.yml"
+      instructions: >
+        application.yml에는 공통 설정만 있어야 합니다.
+        DB 접속 정보, OAuth secret, JWT secret, 운영/개발 환경별 민감 값이 들어오면 반드시 지적하세요.
+    - path: "infra/terraform/**/*.tf"
+      instructions: >
+        Terraform은 GCP dev/prod 분리, state GCS 백엔드, 서울 리전,
+        프로젝트 리소스 네이밍 규칙, 방화벽 태그 규칙을 기준으로 검토하세요.
+        apply 전 plan 확인이 필요한 위험 변경이면 명확히 지적하세요.
+    - path: ".github/workflows/**/*.yml"
+      instructions: >
+        GitHub Actions는 PR 대상 dev 브랜치, 빌드/테스트 검증, 민감 정보 노출,
+        불필요한 권한, 캐시 키 안정성, --no-verify 사용 여부를 중점적으로 확인하세요.
+
+  # CodeRabbit finishing touch 기능입니다. 필요할 때 명령으로 실행할 수 있는 항목만 열어둡니다.
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: true
+    simplify:
+      enabled: false
+
+# CodeRabbit이 리뷰 때 참고할 지식 베이스입니다.
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: false
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "docs/**/*.md"
+      - ".github/pull_request_template.md"
+      - "detekt.yml"
+  learnings:
+    scope: "local"
+  issues:
+    scope: "local"
+  pull_requests:
+    scope: "local"
+
+# CodeRabbit에게 테스트 생성을 요청할 때 적용되는 지시입니다.
+code_generation:
+  unit_tests:
+    path_instructions:
+      - path: "app/src/main/kotlin/**/*.kt"
+        instructions: >
+          Kotlin/JUnit 테스트는 실제 실패 가능성이 있는 도메인 로직과 edge case를 우선 검증하세요.
+          단순 getter/setter나 프레임워크 wiring만 검증하는 낮은 가치의 테스트는 만들지 마세요.

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/CustomOAuth2UserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/CustomOAuth2UserService.kt
@@ -21,7 +21,7 @@ class CustomOAuth2UserService(
         val oAuth2User = delegate.loadUser(userRequest)
         val registrationId = userRequest.clientRegistration.registrationId.lowercase()
         val profile = toUserProfile(registrationId, oAuth2User.attributes)
-        val user = oAuthUserUseCase.upsertOAuthUser(profile)
+        val user = oAuthUserUseCase.loginOAuthUser(profile)
 
         return OAuth2AuthenticatedUser(user = user, attributes = oAuth2User.attributes)
     }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/CustomOidcUserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/oauth/CustomOidcUserService.kt
@@ -24,7 +24,7 @@ class CustomOidcUserService(
                 email = oidcUser.email,
                 providerDisplayName = providerDisplayName(nickname, externalId),
             )
-        val user = oAuthUserUseCase.upsertOAuthUser(profile)
+        val user = oAuthUserUseCase.loginOAuthUser(profile)
 
         return OidcAuthenticatedUser(user = user, idToken = oidcUser.idToken, userInfo = oidcUser.userInfo)
     }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCase.kt
@@ -4,17 +4,38 @@ import com.firstpenguin.app.domain.auth.dto.AccessTokenResponse
 import com.firstpenguin.app.domain.auth.token.JwtTokenProvider
 import com.firstpenguin.app.domain.user.model.OAuthUserProfile
 import com.firstpenguin.app.domain.user.model.Provider
-import com.firstpenguin.app.domain.user.repository.UserRepository
+import com.firstpenguin.app.domain.user.model.User
+import com.firstpenguin.app.domain.user.service.UserService
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class DevAuthUseCase(
-    private val userRepository: UserRepository,
+    private val userService: UserService,
     private val jwtTokenProvider: JwtTokenProvider,
 ) {
+    @Transactional
     fun issueDevToken(): AccessTokenResponse {
-        val devUser = userRepository.upsertOAuthUser(DEV_USER_PROFILE, DEV_USER_NICKNAME)
+        val devUser = findOrCreateDevUser()
         return AccessTokenResponse(jwtTokenProvider.createAccessToken(devUser))
+    }
+
+    private fun findOrCreateDevUser(): User {
+        val user = userService.findOAuthUser(DEV_USER_PROFILE)
+        if (user != null) {
+            return userService.updateOAuthLogin(user, DEV_USER_PROFILE)
+        }
+
+        return userService.createOAuthUser(DEV_USER_PROFILE, DEV_USER_NICKNAME)
+            ?: findConcurrentDevUser()
+            ?: throw CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS)
+    }
+
+    private fun findConcurrentDevUser(): User? {
+        val user = userService.findOAuthUser(DEV_USER_PROFILE) ?: return null
+        return userService.updateOAuthLogin(user, DEV_USER_PROFILE)
     }
 
     private companion object {

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/controller/UserController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/controller/UserController.kt
@@ -82,7 +82,9 @@ class UserController(
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "nickname과 profileImageId가 모두 null이거나, nickname이 빈 문자열이거나, profileImageId가 존재하지 않습니다.",
+                description =
+                    "nickname과 profileImageId가 모두 null이거나, nickname이 빈 문자열 또는 예약 닉네임이거나, " +
+                        "profileImageId가 존재하지 않습니다.",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/dto/UpdateUserRequest.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/dto/UpdateUserRequest.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "프로필 수정 요청. nickname, profileImageId 중 하나 이상 필수. null 필드는 변경하지 않습니다.")
 data class UpdateUserRequest(
-    @field:Schema(description = "변경할 닉네임. null이면 변경하지 않음", example = "새닉네임")
+    @field:Schema(description = "변경할 닉네임. null이면 변경하지 않음. 예약 닉네임은 사용할 수 없음", example = "새닉네임")
     val nickname: String?,
     @field:Schema(description = "변경할 프로필 이미지 ID. null이면 변경하지 않음. 이미지 제거는 현재 미지원", example = "42")
     val profileImageId: Long?,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserRepository.kt
@@ -7,7 +7,7 @@ import com.firstpenguin.app.domain.user.model.UserStatus
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
-import org.jooq.impl.DSL
+import org.jooq.UpdateSetMoreStep
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
@@ -22,10 +22,21 @@ class UserRepository(
             .where(UserTable.ID.eq(id))
             .fetchOne(::toUser)
 
-    fun upsertOAuthUser(
+    fun findByProviderAndProviderId(
+        provider: Provider,
+        providerId: String,
+    ): User? =
+        dsl
+            .select(USER_FIELDS)
+            .from(UserTable.USERS)
+            .where(UserTable.PROVIDER.eq(provider.name))
+            .and(UserTable.PROVIDER_ID.eq(providerId))
+            .fetchOne(::toUser)
+
+    fun createOAuthUser(
         profile: OAuthUserProfile,
         nickname: String,
-    ): User {
+    ): User? {
         val now = LocalDateTime.now()
 
         return dsl
@@ -39,18 +50,40 @@ class UserRepository(
             .set(UserTable.LAST_LOGIN_AT, now)
             .set(UserTable.CREATED_AT, now)
             .set(UserTable.UPDATED_AT, now)
-            .onConflict(PROVIDER_CONFLICT_TARGET, PROVIDER_ID_CONFLICT_TARGET)
-            .doUpdate()
-            .set(UserTable.EMAIL, DSL.coalesce(DSL.excluded(UserTable.EMAIL), UserTable.EMAIL))
-            .set(UserTable.PROVIDER_DISPLAY_NAME, DSL.excluded(UserTable.PROVIDER_DISPLAY_NAME))
+            .onConflictDoNothing()
+            .returningResult(USER_FIELDS)
+            .fetchOne(::toUser)
+    }
+
+    fun updateOAuthLogin(profile: OAuthUserProfile): User? {
+        val now = LocalDateTime.now()
+        return oauthLoginUpdateStep(profile, now)
+            .where(UserTable.PROVIDER.eq(profile.provider.name))
+            .and(UserTable.PROVIDER_ID.eq(profile.providerId))
+            .returningResult(USER_FIELDS)
+            .fetchOne(::toUser)
+    }
+
+    private fun oauthLoginUpdateStep(
+        profile: OAuthUserProfile,
+        now: LocalDateTime,
+    ): UpdateSetMoreStep<Record> {
+        var step = baseOAuthLoginUpdateStep(profile, now)
+        profile.email?.let { step = step.set(UserTable.EMAIL, it) }
+        return step
+    }
+
+    private fun baseOAuthLoginUpdateStep(
+        profile: OAuthUserProfile,
+        now: LocalDateTime,
+    ): UpdateSetMoreStep<Record> =
+        dsl
+            .update(UserTable.USERS)
+            .set(UserTable.PROVIDER_DISPLAY_NAME, profile.providerDisplayName)
             .set(UserTable.STATUS, UserStatus.ACTIVE.name)
             .set(UserTable.DELETED_AT, null as LocalDateTime?)
             .set(UserTable.LAST_LOGIN_AT, now)
             .set(UserTable.UPDATED_AT, now)
-            .returningResult(USER_FIELDS)
-            .fetchOne(::toUser)
-            ?: error("Failed to upsert OAuth user")
-    }
 
     fun update(
         id: Long,
@@ -94,9 +127,6 @@ class UserRepository(
         )
 
     private companion object {
-        val PROVIDER_CONFLICT_TARGET = DSL.field(DSL.name("provider"), String::class.java)
-        val PROVIDER_ID_CONFLICT_TARGET = DSL.field(DSL.name("provider_id"), String::class.java)
-
         val USER_FIELDS: List<Field<*>> =
             listOf(
                 UserTable.ID,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
@@ -62,8 +62,7 @@ class UserService(
         userId: Long,
         nickname: String,
     ) {
-        if (nickname.isBlank()) throw CustomException(ErrorCode.INVALID_INPUT)
-        if (nickname in RESERVED_NICKNAMES) throw CustomException(ErrorCode.INVALID_INPUT)
+        if (nickname.isBlank() || nickname in RESERVED_NICKNAMES) throw CustomException(ErrorCode.INVALID_INPUT)
         if (userRepository.existsByNickname(nickname, userId)) throw CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS)
     }
 

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
@@ -63,6 +63,7 @@ class UserService(
         nickname: String,
     ) {
         if (nickname.isBlank()) throw CustomException(ErrorCode.INVALID_INPUT)
+        if (nickname in RESERVED_NICKNAMES) throw CustomException(ErrorCode.INVALID_INPUT)
         if (userRepository.existsByNickname(nickname, userId)) throw CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS)
     }
 
@@ -90,4 +91,8 @@ class UserService(
             UserStatus.BLOCKED -> ErrorCode.AUTH_USER_BLOCKED
             UserStatus.DELETED -> ErrorCode.AUTH_USER_DELETED
         }
+
+    private companion object {
+        val RESERVED_NICKNAMES = setOf("개발자")
+    }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
@@ -20,10 +20,28 @@ class UserService(
         validateAuthenticatableStatus(user)
     }
 
-    fun upsertOAuthUser(
+    fun findOAuthUser(profile: OAuthUserProfile): User? =
+        userRepository.findByProviderAndProviderId(
+            profile.provider,
+            profile.providerId,
+        )
+
+    fun createOAuthUser(
         profile: OAuthUserProfile,
         nickname: String,
-    ): User = userRepository.upsertOAuthUser(profile, nickname)
+    ): User? = userRepository.createOAuthUser(profile, nickname)
+
+    fun updateOAuthLogin(
+        user: User,
+        profile: OAuthUserProfile,
+    ): User {
+        validateOAuthUserMatchesProfile(user, profile)
+        validateAuthenticatableStatus(user)
+        return updateOAuthLogin(profile)
+    }
+
+    private fun updateOAuthLogin(profile: OAuthUserProfile): User =
+        userRepository.updateOAuthLogin(profile) ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
     fun updateProfile(
         userId: Long,
@@ -46,6 +64,14 @@ class UserService(
     ) {
         if (nickname.isBlank()) throw CustomException(ErrorCode.INVALID_INPUT)
         if (userRepository.existsByNickname(nickname, userId)) throw CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS)
+    }
+
+    private fun validateOAuthUserMatchesProfile(
+        user: User,
+        profile: OAuthUserProfile,
+    ) {
+        if (user.provider == profile.provider && user.providerId == profile.providerId) return
+        throw CustomException(ErrorCode.INTERNAL_SERVER_ERROR)
     }
 
     private fun validateAuthenticatableStatus(user: User) {

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/usecase/OAuthUserUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/usecase/OAuthUserUseCase.kt
@@ -6,7 +6,6 @@ import com.firstpenguin.app.domain.user.service.UserNicknameGenerator
 import com.firstpenguin.app.domain.user.service.UserService
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
-import org.springframework.dao.DuplicateKeyException
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -16,23 +15,25 @@ class OAuthUserUseCase(
     private val userService: UserService,
 ) {
     @Transactional
-    fun upsertOAuthUser(profile: OAuthUserProfile): User {
+    fun loginOAuthUser(profile: OAuthUserProfile): User {
+        val user = userService.findOAuthUser(profile)
+        if (user != null) {
+            return userService.updateOAuthLogin(user, profile)
+        }
+
+        return createOAuthUser(profile)
+    }
+
+    private fun createOAuthUser(profile: OAuthUserProfile): User {
         repeat(NICKNAME_GENERATION_MAX_ATTEMPT_COUNT) {
-            try {
-                return userService.upsertOAuthUser(profile, userNicknameGenerator.generate())
-            } catch (e: DuplicateKeyException) {
-                if (!e.isNicknameConflict()) throw e
-            }
+            userService.createOAuthUser(profile, userNicknameGenerator.generate())?.let { return it }
+            val user = userService.findOAuthUser(profile)
+            if (user != null) return userService.updateOAuthLogin(user, profile)
         }
         throw CustomException(ErrorCode.NICKNAME_GENERATION_FAILED)
     }
 
-    private fun DuplicateKeyException.isNicknameConflict(): Boolean =
-        listOfNotNull(message, rootCause?.message, mostSpecificCause.message)
-            .any { it.contains(USER_NICKNAME_UNIQUE_INDEX_NAME) }
-
     private companion object {
         const val NICKNAME_GENERATION_MAX_ATTEMPT_COUNT = 10
-        const val USER_NICKNAME_UNIQUE_INDEX_NAME = "users_nickname_unique_idx"
     }
 }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/repository/UserRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/repository/UserRepositoryTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertTrue
 
 class UserRepositoryTest {
     @Test
-    fun `OAuth 사용자 upsert는 ON CONFLICT에 테이블 한정자를 사용하지 않는다`() {
+    fun `OAuth 사용자 생성은 conflict 발생 시 update하지 않는다`() {
         var capturedSql = ""
         lateinit var dsl: DSLContext
         val connection =
@@ -30,17 +30,55 @@ class UserRepositoryTest {
             )
         dsl = DSL.using(connection, SQLDialect.POSTGRES)
 
-        UserRepository(dsl).upsertOAuthUser(OAUTH_USER_PROFILE, OAUTH_USER_NICKNAME)
+        UserRepository(dsl).createOAuthUser(OAUTH_USER_PROFILE, OAUTH_USER_NICKNAME)
 
         val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
         assertTrue(
-            normalizedSql.contains("""on conflict ("provider", "provider_id")"""),
+            normalizedSql.contains("""on conflict do nothing"""),
             normalizedSql,
         )
         assertFalse(
-            normalizedSql.contains("""on conflict ("users"."provider", "users"."provider_id")"""),
+            normalizedSql.contains("""do update"""),
             normalizedSql,
         )
+    }
+
+    @Test
+    fun `OAuth 로그인 정보 갱신은 닉네임을 변경하지 않는다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                UserRepository(dsl).updateOAuthLogin(OAUTH_USER_PROFILE)
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.startsWith("""update "users" set"""), normalizedSql)
+        assertFalse(normalizedSql.contains("\"users\".\"nickname\" ="), normalizedSql)
+    }
+
+    @Test
+    fun `OAuth 로그인 정보 갱신은 이메일이 null이면 기존 이메일을 유지한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                UserRepository(dsl).updateOAuthLogin(OAUTH_USER_PROFILE.copy(email = null))
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertFalse(normalizedSql.contains("\"users\".\"email\" ="), normalizedSql)
+    }
+
+    private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {
+        var capturedSql = ""
+        lateinit var dsl: DSLContext
+        val connection =
+            MockConnection(
+                MockDataProvider { context ->
+                    capturedSql = context.sql()
+                    arrayOf(MockResult(1, userResult(dsl)))
+                },
+            )
+        dsl = DSL.using(connection, SQLDialect.POSTGRES)
+        repositoryCall(dsl)
+        return capturedSql
     }
 
     private fun userResult(dsl: DSLContext) =

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
@@ -1,5 +1,6 @@
 package com.firstpenguin.app.domain.user.service
 
+import com.firstpenguin.app.domain.user.model.OAuthUserProfile
 import com.firstpenguin.app.domain.user.model.Provider
 import com.firstpenguin.app.domain.user.model.User
 import com.firstpenguin.app.domain.user.model.UserStatus
@@ -66,6 +67,64 @@ class UserServiceTest {
         Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(user())
 
         userService.validateAuthenticatableUser(USER_ID)
+    }
+
+    @Test
+    fun `활성 OAuth 사용자는 로그인 정보를 갱신한다`() {
+        val user = user()
+        Mockito.`when`(userRepository.updateOAuthLogin(OAUTH_USER_PROFILE)).thenReturn(user)
+
+        val result = userService.updateOAuthLogin(user, OAUTH_USER_PROFILE)
+
+        assertEquals(user, result)
+        Mockito.verify(userRepository).updateOAuthLogin(OAUTH_USER_PROFILE)
+    }
+
+    @Test
+    fun `OAuth 사용자와 프로필이 일치하지 않으면 로그인 정보를 갱신하지 않는다`() {
+        val otherProfile = OAUTH_USER_PROFILE.copy(providerId = "other-provider-id")
+
+        val exception =
+            assertFailsWith<CustomException> {
+                userService.updateOAuthLogin(user(), otherProfile)
+            }
+
+        assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.errorCode)
+        Mockito.verify(userRepository, Mockito.never()).updateOAuthLogin(otherProfile)
+    }
+
+    @Test
+    fun `OAuth 로그인 정보 갱신 대상이 없으면 실패한다`() {
+        Mockito.`when`(userRepository.updateOAuthLogin(OAUTH_USER_PROFILE)).thenReturn(null)
+
+        val exception =
+            assertFailsWith<CustomException> {
+                userService.updateOAuthLogin(user(), OAUTH_USER_PROFILE)
+            }
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    fun `차단 OAuth 사용자는 로그인 정보를 갱신하지 않는다`() {
+        val exception =
+            assertFailsWith<CustomException> {
+                userService.updateOAuthLogin(user(status = UserStatus.BLOCKED), OAUTH_USER_PROFILE)
+            }
+
+        assertEquals(ErrorCode.AUTH_USER_BLOCKED, exception.errorCode)
+        Mockito.verify(userRepository, Mockito.never()).updateOAuthLogin(OAUTH_USER_PROFILE)
+    }
+
+    @Test
+    fun `삭제된 OAuth 사용자는 로그인 정보를 갱신하지 않는다`() {
+        val exception =
+            assertFailsWith<CustomException> {
+                userService.updateOAuthLogin(user(status = UserStatus.DELETED), OAUTH_USER_PROFILE)
+            }
+
+        assertEquals(ErrorCode.AUTH_USER_DELETED, exception.errorCode)
+        Mockito.verify(userRepository, Mockito.never()).updateOAuthLogin(OAUTH_USER_PROFILE)
     }
 
     @Test
@@ -138,5 +197,12 @@ class UserServiceTest {
         const val PROFILE_IMAGE_ID = 10L
         const val DUPLICATE_NICKNAME = "조용한토끼"
         const val USER_NICKNAME_UNIQUE_INDEX_NAME = "users_nickname_unique_idx"
+        val OAUTH_USER_PROFILE =
+            OAuthUserProfile(
+                provider = Provider.KAKAO,
+                providerId = "provider-id",
+                email = "user@example.com",
+                providerDisplayName = "provider user",
+            )
     }
 }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
@@ -141,6 +141,18 @@ class UserServiceTest {
     }
 
     @Test
+    fun `프로필 수정 시 예약 닉네임이면 실패한다`() {
+        val exception =
+            assertFailsWith<CustomException> {
+                userService.updateProfile(USER_ID, DEV_USER_NICKNAME, null)
+            }
+
+        assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
+        Mockito.verify(userRepository, Mockito.never()).existsByNickname(DEV_USER_NICKNAME, USER_ID)
+        Mockito.verify(userRepository, Mockito.never()).update(USER_ID, DEV_USER_NICKNAME, null)
+    }
+
+    @Test
     fun `프로필 수정 중 닉네임 unique 충돌이 발생하면 닉네임 중복 예외로 변환한다`() {
         Mockito
             .doThrow(nicknameDuplicateException())
@@ -195,6 +207,7 @@ class UserServiceTest {
     private companion object {
         const val USER_ID = 1L
         const val PROFILE_IMAGE_ID = 10L
+        const val DEV_USER_NICKNAME = "개발자"
         const val DUPLICATE_NICKNAME = "조용한토끼"
         const val USER_NICKNAME_UNIQUE_INDEX_NAME = "users_nickname_unique_idx"
         val OAUTH_USER_PROFILE =

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/OAuthUserUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/OAuthUserUseCaseTest.kt
@@ -11,7 +11,6 @@ import com.firstpenguin.app.global.exception.ErrorCode
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import org.springframework.dao.DuplicateKeyException
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -29,56 +28,79 @@ class OAuthUserUseCaseTest {
     }
 
     @Test
-    fun `닉네임 중복이면 닉네임을 다시 생성해 OAuth 사용자를 upsert 한다`() {
-        val user = user(nickname = SECOND_NICKNAME)
-        Mockito.`when`(userNicknameGenerator.generate()).thenReturn(FIRST_NICKNAME, SECOND_NICKNAME)
-        Mockito
-            .`when`(userService.upsertOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME))
-            .thenThrow(nicknameDuplicateException())
-        Mockito.`when`(userService.upsertOAuthUser(OAUTH_USER_PROFILE, SECOND_NICKNAME)).thenReturn(user)
+    fun `기존 OAuth 사용자는 닉네임 생성 없이 로그인 정보만 갱신한다`() {
+        val user = user()
+        Mockito.`when`(userService.findOAuthUser(OAUTH_USER_PROFILE)).thenReturn(user)
+        Mockito.`when`(userService.updateOAuthLogin(user, OAUTH_USER_PROFILE)).thenReturn(user)
 
-        val result = oAuthUserUseCase.upsertOAuthUser(OAUTH_USER_PROFILE)
+        val result = oAuthUserUseCase.loginOAuthUser(OAUTH_USER_PROFILE)
 
         assertEquals(user, result)
-        Mockito.verify(userService).upsertOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME)
-        Mockito.verify(userService).upsertOAuthUser(OAUTH_USER_PROFILE, SECOND_NICKNAME)
+        Mockito.verify(userService).updateOAuthLogin(user, OAUTH_USER_PROFILE)
+        Mockito.verifyNoInteractions(userNicknameGenerator)
     }
 
     @Test
-    fun `닉네임 중복이 아니면 재시도하지 않는다`() {
-        Mockito.`when`(userNicknameGenerator.generate()).thenReturn(FIRST_NICKNAME)
+    fun `신규 OAuth 사용자는 닉네임을 생성해 저장한다`() {
+        val user = user(nickname = FIRST_NICKNAME)
+        Mockito.`when`(userNicknameGenerator.generate()).thenReturn(FIRST_NICKNAME, SECOND_NICKNAME)
+        Mockito.`when`(userService.findOAuthUser(OAUTH_USER_PROFILE)).thenReturn(null)
+        Mockito.`when`(userService.createOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME)).thenReturn(user)
+
+        val result = oAuthUserUseCase.loginOAuthUser(OAUTH_USER_PROFILE)
+
+        assertEquals(user, result)
+        Mockito.verify(userService).createOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME)
+        Mockito.verify(userService, Mockito.never()).updateOAuthLogin(user, OAUTH_USER_PROFILE)
+    }
+
+    @Test
+    fun `닉네임 중복이면 닉네임을 다시 생성해 OAuth 사용자를 생성한다`() {
+        val user = user(nickname = SECOND_NICKNAME)
+        Mockito.`when`(userNicknameGenerator.generate()).thenReturn(FIRST_NICKNAME, SECOND_NICKNAME)
+        Mockito.`when`(userService.findOAuthUser(OAUTH_USER_PROFILE)).thenReturn(null)
+        Mockito.`when`(userService.createOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME)).thenReturn(null)
+        Mockito.`when`(userService.createOAuthUser(OAUTH_USER_PROFILE, SECOND_NICKNAME)).thenReturn(user)
+
+        val result = oAuthUserUseCase.loginOAuthUser(OAUTH_USER_PROFILE)
+
+        assertEquals(user, result)
+        Mockito.verify(userService).createOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME)
+        Mockito.verify(userService).createOAuthUser(OAUTH_USER_PROFILE, SECOND_NICKNAME)
+    }
+
+    @Test
+    fun `동시 첫 로그인으로 provider unique 충돌이 발생하면 재조회 후 로그인 정보 갱신으로 수렴한다`() {
+        val user = user()
         Mockito
-            .`when`(userService.upsertOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME))
-            .thenThrow(DuplicateKeyException("users_provider_provider_id_unique"))
+            .`when`(userService.findOAuthUser(OAUTH_USER_PROFILE))
+            .thenReturn(null, user)
+        Mockito.`when`(userNicknameGenerator.generate()).thenReturn(FIRST_NICKNAME)
+        Mockito.`when`(userService.createOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME)).thenReturn(null)
+        Mockito.`when`(userService.updateOAuthLogin(user, OAUTH_USER_PROFILE)).thenReturn(user)
 
-        assertFailsWith<DuplicateKeyException> {
-            oAuthUserUseCase.upsertOAuthUser(OAUTH_USER_PROFILE)
-        }
+        val result = oAuthUserUseCase.loginOAuthUser(OAUTH_USER_PROFILE)
 
-        Mockito.verify(userService).upsertOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME)
-        Mockito.verifyNoMoreInteractions(userService)
+        assertEquals(user, result)
+        Mockito.verify(userService).updateOAuthLogin(user, OAUTH_USER_PROFILE)
     }
 
     @Test
     fun `닉네임 생성 재시도 횟수를 초과하면 실패한다`() {
         Mockito.`when`(userNicknameGenerator.generate()).thenReturn(FIRST_NICKNAME)
-        Mockito
-            .`when`(userService.upsertOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME))
-            .thenThrow(nicknameDuplicateException())
+        Mockito.`when`(userService.findOAuthUser(OAUTH_USER_PROFILE)).thenReturn(null)
+        Mockito.`when`(userService.createOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME)).thenReturn(null)
 
         val exception =
             assertFailsWith<CustomException> {
-                oAuthUserUseCase.upsertOAuthUser(OAUTH_USER_PROFILE)
+                oAuthUserUseCase.loginOAuthUser(OAUTH_USER_PROFILE)
             }
 
         assertEquals(ErrorCode.NICKNAME_GENERATION_FAILED, exception.errorCode)
-        Mockito.verify(userService, Mockito.times(10)).upsertOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME)
+        Mockito.verify(userService, Mockito.times(10)).createOAuthUser(OAUTH_USER_PROFILE, FIRST_NICKNAME)
     }
 
-    private fun nicknameDuplicateException(): DuplicateKeyException =
-        DuplicateKeyException("duplicate key value violates unique constraint \"$USER_NICKNAME_UNIQUE_INDEX_NAME\"")
-
-    private fun user(nickname: String): User {
+    private fun user(nickname: String = FIRST_NICKNAME): User {
         val now = LocalDateTime.now()
 
         return User(
@@ -101,7 +123,6 @@ class OAuthUserUseCaseTest {
         const val USER_ID = 1L
         const val FIRST_NICKNAME = "조용한토끼"
         const val SECOND_NICKNAME = "책읽는펭귄"
-        const val USER_NICKNAME_UNIQUE_INDEX_NAME = "users_nickname_unique_idx"
         val OAUTH_USER_PROFILE =
             OAuthUserProfile(
                 provider = Provider.KAKAO,


### PR DESCRIPTION
## 작업 내용

- OAuth 사용자 저장 흐름을 단일 upsert에서 기존 사용자 재로그인과 신규 가입 분기로 분리했습니다.
- 기존 OAuth 사용자는 상태 검증 후 ACTIVE일 때만 로그인 정보를 갱신합니다.
- 신규 OAuth 사용자는 랜덤 닉네임 생성 후 insert하고, unique 충돌 시 예외 대신 `ON CONFLICT DO NOTHING` 결과로 재시도합니다.
- 같은 OAuth 계정의 동시 첫 로그인 충돌은 insert 실패 후 재조회하여 기존 사용자 로그인 갱신 흐름으로 수렴시켰습니다.
- 개발 토큰 사용자도 repository 직접 upsert 대신 usecase/service 흐름을 따르도록 정리했습니다.
- CodeRabbit 리뷰 설정을 추가했습니다.

Closes #92

## OAuth 사용자 처리 흐름

```mermaid
flowchart LR
    A["OAuth 로그인 요청"] --> B["loginOAuthUser(profile)<br/>@Transactional"]
    B --> C["findOAuthUser(provider, providerId)"]

    subgraph LEFT["실패 흐름"]
        X1["AUTH_USER_BLOCKED"]
        X2["AUTH_USER_DELETED"]
        X3["NICKNAME_GENERATION_FAILED"]
    end

    subgraph CENTER["분기"]
        D{"validateAuthenticatableStatus(user)"}
        L{"재시도 10회 초과?"}
    end

    subgraph RIGHT["성공 흐름"]
        E["updateOAuthLogin(profile)"]
        F["email 있으면 갱신<br/>providerDisplayName 갱신<br/>lastLoginAt 갱신"]
        Z["User 반환"]
    end

    C -->|"기존 사용자 있음"| D
    D -->|"ACTIVE"| E
    E --> F
    F --> Z

    D -->|"BLOCKED"| X1
    D -->|"DELETED 또는 deletedAt 존재"| X2

    C -->|"기존 사용자 없음"| G["닉네임 생성"]
    G --> H["createOAuthUser(profile, nickname)<br/>INSERT ... ON CONFLICT DO NOTHING"]

    H -->|"생성 성공"| Z
    H -->|"생성 실패 null"| I["findOAuthUser(provider, providerId) 재조회"]

    I -->|"사용자 있음"| J["동시 첫 로그인으로 판단"]
    J --> D

    I -->|"사용자 없음"| K["닉네임 충돌로 판단"]
    K --> L

    L -->|"아니오"| G
    L -->|"예"| X3
```

## 검증

- `./gradlew testClasses`
- `./gradlew test --tests com.firstpenguin.app.domain.user.service.UserServiceTest --tests com.firstpenguin.app.domain.user.usecase.OAuthUserUseCaseTest --tests com.firstpenguin.app.domain.user.repository.UserRepositoryTest`
- `./gradlew lintKotlin detekt`
- `./gradlew test`
- `coderabbit review --agent -t uncommitted -c .coderabbit.yaml AGENTS.md CLAUDE.md` 결과 finding 0건


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * OAuth 사용자 흐름을 생성(create)과 로그인 정보 갱신(login)으로 분리하고 닉네임 충돌/동시성 처리 강화
  * 개발 계정 토큰 발급에 트랜잭션 적용 및 사용자 서비스 연계 변경

* **Tests**
  * OAuth 생성·로그인·충돌 재시도·예외 시나리오 등 관련 테스트 대폭 추가/갱신

* **Chores**
  * 코드리뷰 자동화 설정 추가 및 검사/경고 정책 구성

* **Documentation**
  * 사용자 업데이트 API 응답 메시지 및 요청 필드 설명(예약 닉네임 안내) 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->