### PR TITLE
feat: 발견탭 API 추가

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: ko-KR
+
+reviews:
+  profile: chill
+  path_filters:
+    - "!docs/**/*.md"
+
+knowledge_base:
+  code_guidelines:
+    enabled: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ docs/                 — 프로젝트 문서 (convention.md, husky.md)
 - 커밋: Conventional Commits — 이모지는 commit-msg 훅이 자동 삽입
 - PR 대상: `dev` 브랜치
 - 머지 순서: feature → dev → main(배포)
+- PR은 draft가 아닌 ready 상태로 생성한다.
 - `dev` 브랜치에 직접 커밋하거나 push하지 않는다. 모든 변경은 작업 브랜치에서 커밋하고 PR로 반영한다.
 
 ## 설정 파일 규칙

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
@@ -1,0 +1,31 @@
+package com.firstpenguin.app.domain.discovery.controller
+
+import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
+import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuotesResponse
+import com.firstpenguin.app.domain.discovery.usecase.DiscoveryUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/discovery")
+@Tag(name = "발견탭", description = "추천 이력 기반 발견탭 API")
+class DiscoveryController(
+    private val discoveryUseCase: DiscoveryUseCase,
+) {
+    @Operation(
+        summary = "발견탭 랜덤 문장 조회 API",
+        description = "누군가에게 한 번이라도 추천된 문장을 랜덤으로 10개까지 조회한다.",
+        security = [SecurityRequirement(name = "bearerAuth")],
+    )
+    @GetMapping("/quotes")
+    fun getDiscoveryQuotes(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
+    ): DiscoveryQuotesResponse = discoveryUseCase.getDiscoveryQuotes(authenticatedUser.id)
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
@@ -1,0 +1,44 @@
+package com.firstpenguin.app.domain.discovery.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "발견탭 문장 응답")
+data class DiscoveryQuoteResponse(
+    @field:Schema(description = "문장 ID", example = "1")
+    val quoteId: Long,
+    @field:Schema(description = "책 ID", example = "1")
+    val bookId: Long,
+    @field:Schema(description = "이 문장을 추천받은 사용자 ID", example = "1")
+    val recommendedUserId: Long,
+    @field:Schema(description = "문장 내용", example = "새는 알에서 나오려고 투쟁한다.")
+    val content: String,
+    @field:Schema(description = "책 제목", example = "데미안")
+    val title: String,
+    @field:Schema(description = "저자", example = "헤르만 헤세")
+    val author: String,
+    @field:Schema(description = "책 표지 이미지 URL", example = "https://cdn.example.com/book-cover-placeholder.png")
+    val bookCoverImageUrl: String,
+    @field:Schema(description = "문장이 추천 이력에 등록된 시각", example = "2026-06-05T12:34:56")
+    val recommendedAt: LocalDateTime,
+    @get:JsonProperty("isScrapped")
+    @field:Schema(description = "로그인 사용자의 스크랩 여부", example = "false")
+    val isScrapped: Boolean,
+) {
+    companion object {
+        fun from(quote: DiscoveryQuote): DiscoveryQuoteResponse =
+            DiscoveryQuoteResponse(
+                quoteId = quote.quoteId,
+                bookId = quote.bookId,
+                recommendedUserId = quote.recommendedUserId,
+                content = quote.content,
+                title = quote.title,
+                author = quote.author,
+                bookCoverImageUrl = quote.bookCoverImageUrl,
+                recommendedAt = quote.recommendedAt,
+                isScrapped = quote.isScrapped,
+            )
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuotesResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuotesResponse.kt
@@ -1,0 +1,9 @@
+package com.firstpenguin.app.domain.discovery.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "발견탭 문장 목록 응답")
+data class DiscoveryQuotesResponse(
+    @field:Schema(description = "랜덤 발견탭 문장 목록")
+    val quotes: List<DiscoveryQuoteResponse>,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
@@ -1,0 +1,15 @@
+package com.firstpenguin.app.domain.discovery.model
+
+import java.time.LocalDateTime
+
+data class DiscoveryQuote(
+    val quoteId: Long,
+    val bookId: Long,
+    val recommendedUserId: Long,
+    val content: String,
+    val title: String,
+    val author: String,
+    val bookCoverImageUrl: String,
+    val recommendedAt: LocalDateTime,
+    val isScrapped: Boolean,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
@@ -1,0 +1,129 @@
+package com.firstpenguin.app.domain.discovery.repository
+
+import com.firstpenguin.app.domain.book.repository.BookTable
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.quote.repository.QuoteScrapTable
+import com.firstpenguin.app.domain.quote.repository.QuoteTable
+import com.firstpenguin.app.domain.recommendation.repository.table.DailyRecommendationQuoteTable
+import com.firstpenguin.app.domain.recommendation.repository.table.DailyRecommendationTable
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.Table
+import org.jooq.impl.DSL
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+class DiscoveryRepository(
+    private val dsl: DSLContext,
+) {
+    fun findRandomRecommendedQuotes(
+        userId: Long,
+        limit: Int,
+    ): List<DiscoveryQuote> {
+        if (limit <= 0) return emptyList()
+
+        val recommendationEvents = recommendationEvents()
+        val rankedRecommendationEvents = rankedRecommendationEvents(recommendationEvents)
+        val recommendedQuoteId = recommendedQuoteId(rankedRecommendationEvents)
+
+        return dsl
+            .select(discoveryQuoteFields(rankedRecommendationEvents))
+            .from(rankedRecommendationEvents)
+            .join(QuoteTable.QUOTES)
+            .on(QuoteTable.ID.eq(recommendedQuoteId))
+            .join(BookTable.BOOKS)
+            .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+            .leftJoin(QuoteScrapTable.QUOTE_SCRAPS)
+            .on(QuoteScrapTable.QUOTE_ID.eq(QuoteTable.ID))
+            .and(QuoteScrapTable.USER_ID.eq(userId))
+            .where(recommendationRank(rankedRecommendationEvents).eq(LATEST_RECOMMENDATION_RANK))
+            .and(QuoteTable.DELETED_AT.isNull)
+            .and(BookTable.DELETED_AT.isNull)
+            .orderBy(DSL.function("random", Double::class.java))
+            .limit(limit)
+            .fetch(::toDiscoveryQuote)
+    }
+
+    private fun toDiscoveryQuote(record: Record): DiscoveryQuote =
+        DiscoveryQuote(
+            quoteId = record.get(QuoteTable.ID),
+            bookId = record.get(BookTable.ID),
+            recommendedUserId = record.get(RECOMMENDED_USER_ID_FIELD),
+            content = record.get(QuoteTable.CONTENT),
+            title = record.get(BookTable.TITLE),
+            author = record.get(BookTable.AUTHOR),
+            bookCoverImageUrl = record.get(BookTable.COVER_IMAGE_URL),
+            recommendedAt = record.get(RECOMMENDED_AT_FIELD),
+            isScrapped = record.get(IS_SCRAPPED_FIELD),
+        )
+
+    private fun recommendationEvents(): Table<*> =
+        DSL
+            .select(
+                DailyRecommendationTable.QUOTE_ID.`as`(RECOMMENDED_QUOTE_ID),
+                DailyRecommendationTable.USER_ID.`as`(RECOMMENDED_USER_ID),
+                DailyRecommendationTable.CREATED_AT.`as`(RECOMMENDED_AT),
+            ).from(DailyRecommendationTable.DAILY_RECOMMENDATIONS)
+            .unionAll(
+                DSL
+                    .select(
+                        DailyRecommendationQuoteTable.QUOTE_ID.`as`(RECOMMENDED_QUOTE_ID),
+                        DailyRecommendationTable.USER_ID.`as`(RECOMMENDED_USER_ID),
+                        DailyRecommendationQuoteTable.CREATED_AT.`as`(RECOMMENDED_AT),
+                    ).from(DailyRecommendationQuoteTable.DAILY_RECOMMENDATION_QUOTES)
+                    .join(DailyRecommendationTable.DAILY_RECOMMENDATIONS)
+                    .on(DailyRecommendationTable.ID.eq(DailyRecommendationQuoteTable.DAILY_RECOMMENDATION_ID)),
+            ).asTable(RECOMMENDATION_EVENTS)
+
+    private fun rankedRecommendationEvents(recommendationEvents: Table<*>): Table<*> =
+        DSL
+            .select(
+                recommendedQuoteId(recommendationEvents),
+                recommendedUserId(recommendationEvents),
+                at(recommendationEvents),
+                DSL
+                    .rowNumber()
+                    .over()
+                    .partitionBy(recommendedQuoteId(recommendationEvents))
+                    .orderBy(at(recommendationEvents).desc())
+                    .`as`(RECOMMENDATION_RANK),
+            ).from(recommendationEvents)
+            .asTable(RANKED_RECOMMENDATION_EVENTS)
+
+    private fun discoveryQuoteFields(rankedRecommendationEvents: Table<*>): List<Field<*>> =
+        listOf(
+            QuoteTable.ID,
+            BookTable.ID,
+            recommendedUserId(rankedRecommendationEvents),
+            QuoteTable.CONTENT,
+            BookTable.TITLE,
+            BookTable.AUTHOR,
+            BookTable.COVER_IMAGE_URL,
+            at(rankedRecommendationEvents),
+            IS_SCRAPPED_FIELD,
+        )
+
+    private fun recommendedQuoteId(table: Table<*>): Field<Long> = table.field(RECOMMENDED_QUOTE_ID, Long::class.java)!!
+
+    private fun recommendedUserId(table: Table<*>): Field<Long> = table.field(RECOMMENDED_USER_ID, Long::class.java)!!
+
+    private fun at(table: Table<*>): Field<LocalDateTime> = table.field(RECOMMENDED_AT, LocalDateTime::class.java)!!
+
+    private fun recommendationRank(table: Table<*>): Field<Int> = table.field(RECOMMENDATION_RANK, Int::class.java)!!
+
+    private companion object {
+        const val RECOMMENDATION_EVENTS = "recommendation_events"
+        const val RANKED_RECOMMENDATION_EVENTS = "ranked_recommendation_events"
+        const val RECOMMENDED_QUOTE_ID = "quote_id"
+        const val RECOMMENDED_USER_ID = "recommended_user_id"
+        const val RECOMMENDED_AT = "recommended_at"
+        const val RECOMMENDATION_RANK = "recommendation_rank"
+        const val LATEST_RECOMMENDATION_RANK = 1
+
+        val RECOMMENDED_USER_ID_FIELD: Field<Long> = DSL.field(RECOMMENDED_USER_ID, Long::class.java)
+        val RECOMMENDED_AT_FIELD: Field<LocalDateTime> = DSL.field(RECOMMENDED_AT, LocalDateTime::class.java)
+        val IS_SCRAPPED_FIELD: Field<Boolean> = QuoteScrapTable.ID.isNotNull.`as`("is_scrapped")
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/service/DiscoveryService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/service/DiscoveryService.kt
@@ -1,0 +1,15 @@
+package com.firstpenguin.app.domain.discovery.service
+
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.discovery.repository.DiscoveryRepository
+import org.springframework.stereotype.Service
+
+@Service
+class DiscoveryService(
+    private val discoveryRepository: DiscoveryRepository,
+) {
+    fun getRandomQuotes(
+        userId: Long,
+        limit: Int,
+    ): List<DiscoveryQuote> = discoveryRepository.findRandomRecommendedQuotes(userId, limit)
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCase.kt
@@ -1,0 +1,23 @@
+package com.firstpenguin.app.domain.discovery.usecase
+
+import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuoteResponse
+import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuotesResponse
+import com.firstpenguin.app.domain.discovery.service.DiscoveryService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private const val DISCOVERY_QUOTE_COUNT = 10
+
+@Service
+class DiscoveryUseCase(
+    private val discoveryService: DiscoveryService,
+) {
+    @Transactional(readOnly = true)
+    fun getDiscoveryQuotes(userId: Long): DiscoveryQuotesResponse {
+        val quotes = discoveryService.getRandomQuotes(userId, DISCOVERY_QUOTE_COUNT)
+
+        return DiscoveryQuotesResponse(
+            quotes = quotes.map(DiscoveryQuoteResponse::from),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quote/repository/QuoteScrapTable.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quote/repository/QuoteScrapTable.kt
@@ -1,0 +1,12 @@
+package com.firstpenguin.app.domain.quote.repository
+
+import org.jooq.impl.DSL
+import java.time.LocalDateTime
+
+internal object QuoteScrapTable {
+    val QUOTE_SCRAPS = DSL.table(DSL.name("quote_scraps"))
+    val ID = DSL.field(DSL.name("quote_scraps", "id"), Long::class.java)
+    val USER_ID = DSL.field(DSL.name("quote_scraps", "user_id"), Long::class.java)
+    val QUOTE_ID = DSL.field(DSL.name("quote_scraps", "quote_id"), Long::class.java)
+    val CREATED_AT = DSL.field(DSL.name("quote_scraps", "created_at"), LocalDateTime::class.java)
+}

--- a/app/src/main/resources/db/migration/V40__create_quote_scraps_and_discovery_indexes.sql
+++ b/app/src/main/resources/db/migration/V40__create_quote_scraps_and_discovery_indexes.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS quote_scraps (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    quote_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS quote_scraps_user_quote_uidx
+    ON quote_scraps (user_id, quote_id);
+
+CREATE INDEX IF NOT EXISTS quote_scraps_quote_id_idx
+    ON quote_scraps (quote_id);
+
+CREATE INDEX IF NOT EXISTS daily_recommendations_quote_id_idx
+    ON daily_recommendations (quote_id);
+
+CREATE INDEX IF NOT EXISTS daily_recommendation_quotes_quote_id_idx
+    ON daily_recommendation_quotes (quote_id);

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
@@ -1,0 +1,73 @@
+package com.firstpenguin.app.domain.discovery.repository
+
+import com.firstpenguin.app.domain.book.repository.BookTable
+import com.firstpenguin.app.domain.quote.repository.QuoteScrapTable
+import com.firstpenguin.app.domain.quote.repository.QuoteTable
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.jooq.tools.jdbc.MockConnection
+import org.jooq.tools.jdbc.MockDataProvider
+import org.jooq.tools.jdbc.MockResult
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import kotlin.test.assertTrue
+
+class DiscoveryRepositoryTest {
+    @Test
+    fun `추천 이력 테이블을 합쳐 랜덤 문장을 조회한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                DiscoveryRepository(dsl).findRandomRecommendedQuotes(USER_ID, DISCOVERY_QUOTE_COUNT)
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("daily_recommendations"), normalizedSql)
+        assertTrue(normalizedSql.contains("daily_recommendation_quotes"), normalizedSql)
+        assertTrue(normalizedSql.contains("recommended_user_id"), normalizedSql)
+        assertTrue(normalizedSql.contains("recommended_at"), normalizedSql)
+        assertTrue(normalizedSql.contains("quote_scraps"), normalizedSql)
+        assertTrue(normalizedSql.contains("is_scrapped"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"quote_scraps\".\"user_id\" = ?"), normalizedSql)
+        assertTrue(normalizedSql.contains("row_number()"), normalizedSql)
+        assertTrue(normalizedSql.contains(" union all "), normalizedSql)
+        assertTrue(normalizedSql.contains("random()"), normalizedSql)
+        assertTrue(normalizedSql.contains("fetch next ? rows only"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"recommendation_rank\" = ?"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"quotes\".\"deleted_at\" is null"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"books\".\"deleted_at\" is null"), normalizedSql)
+    }
+
+    private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {
+        var capturedSql = ""
+        lateinit var dsl: DSLContext
+        val connection =
+            MockConnection(
+                MockDataProvider { context ->
+                    capturedSql = context.sql()
+                    arrayOf(MockResult(0, dsl.newResult(*DISCOVERY_QUOTE_FIELDS)))
+                },
+            )
+        dsl = DSL.using(connection, SQLDialect.POSTGRES)
+        repositoryCall(dsl)
+        return capturedSql
+    }
+
+    private companion object {
+        const val USER_ID = 1L
+        const val DISCOVERY_QUOTE_COUNT = 10
+        val DISCOVERY_QUOTE_FIELDS: Array<Field<*>> =
+            arrayOf(
+                QuoteTable.ID,
+                BookTable.ID,
+                DSL.field("recommended_user_id", Long::class.java),
+                QuoteTable.CONTENT,
+                BookTable.TITLE,
+                BookTable.AUTHOR,
+                BookTable.COVER_IMAGE_URL,
+                DSL.field("recommended_at", LocalDateTime::class.java),
+                QuoteScrapTable.ID.isNotNull.`as`("is_scrapped"),
+            )
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
@@ -1,0 +1,69 @@
+package com.firstpenguin.app.domain.discovery.usecase
+
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.discovery.service.DiscoveryService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DiscoveryUseCaseTest {
+    private lateinit var discoveryService: DiscoveryService
+    private lateinit var discoveryUseCase: DiscoveryUseCase
+
+    @BeforeEach
+    fun setUp() {
+        discoveryService = Mockito.mock(DiscoveryService::class.java)
+        discoveryUseCase = DiscoveryUseCase(discoveryService)
+    }
+
+    @Test
+    fun `로그인 사용자의 추천 이력 정보와 스크랩 여부를 응답한다`() {
+        val quote = discoveryQuote(QUOTE_ID)
+        Mockito.`when`(discoveryService.getRandomQuotes(USER_ID, DISCOVERY_QUOTE_COUNT)).thenReturn(listOf(quote))
+
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID)
+
+        assertEquals(1, response.quotes.size)
+        assertEquals(RECOMMENDED_USER_ID, response.quotes.first().recommendedUserId)
+        assertEquals(RECOMMENDED_AT, response.quotes.first().recommendedAt)
+        assertFalse(response.quotes.first().isScrapped)
+    }
+
+    @Test
+    fun `조회된 스크랩 여부가 true면 응답도 true다`() {
+        val quote = discoveryQuote(QUOTE_ID, isScrapped = true)
+        Mockito.`when`(discoveryService.getRandomQuotes(USER_ID, DISCOVERY_QUOTE_COUNT)).thenReturn(listOf(quote))
+
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID)
+
+        assertEquals(true, response.quotes.first().isScrapped)
+    }
+
+    private fun discoveryQuote(
+        quoteId: Long,
+        isScrapped: Boolean = false,
+    ): DiscoveryQuote =
+        DiscoveryQuote(
+            quoteId = quoteId,
+            bookId = BOOK_ID,
+            recommendedUserId = RECOMMENDED_USER_ID,
+            content = "새는 알에서 나오려고 투쟁한다.",
+            title = "데미안",
+            author = "헤르만 헤세",
+            bookCoverImageUrl = "https://cdn.example.com/book-cover-placeholder.png",
+            recommendedAt = RECOMMENDED_AT,
+            isScrapped = isScrapped,
+        )
+
+    private companion object {
+        const val DISCOVERY_QUOTE_COUNT = 10
+        const val USER_ID = 1L
+        const val QUOTE_ID = 10L
+        const val BOOK_ID = 100L
+        const val RECOMMENDED_USER_ID = 200L
+        val RECOMMENDED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 5, 12, 34, 56)
+    }
+}

--- a/docs/discovery-tab-plan.md
+++ b/docs/discovery-tab-plan.md
@@ -1,0 +1,218 @@
+# 발견탭 API 구현 계획
+
+## 목표
+
+발견탭은 로그인 사용자가 추천받은 문장을 다시 탐색할 수 있는 목록 API다.
+목록에는 누군가에게 한 번이라도 추천된 문장만 노출한다.
+
+첫 구현 범위는 랜덤 문장 10개 조회까지다.
+스크랩 생성/삭제 API와 페이지네이션은 후속 작업으로 분리한다.
+
+관련 이슈: #96
+
+## API
+
+아래 API 경로는 서버 context-path `/api`를 포함한 공개 경로로 표기한다.
+
+```text
+GET /api/discovery/quotes
+Authorization: Bearer {accessToken}
+```
+
+### 인증 정책
+
+이 API는 로그인한 사용자만 호출할 수 있다.
+access token이 없거나 만료/조작된 경우 기존 인증 에러 응답을 사용한다.
+비로그인 요청에 대한 `isScrapped=false` 응답은 지원하지 않는다.
+응답의 `isScrapped`는 요청한 로그인 사용자를 기준으로 계산한다.
+
+### 응답
+
+```json
+{
+  "quotes": [
+    {
+      "quoteId": 1,
+      "bookId": 1,
+      "recommendedUserId": 1,
+      "content": "새는 알에서 나오려고 투쟁한다.",
+      "title": "데미안",
+      "author": "헤르만 헤세",
+      "bookCoverImageUrl": "https://cdn.example.com/book-cover-placeholder.png",
+      "recommendedAt": "2026-06-05T12:34:56",
+      "isScrapped": false
+    }
+  ]
+}
+```
+
+| 필드 | 설명 |
+|------|------|
+| `quoteId` | 문장 ID. 문장 상세 또는 스크랩 API에서 사용할 값 |
+| `bookId` | 책 ID. 책 상세 화면으로 확장할 때 사용할 값 |
+| `recommendedUserId` | 이 문장을 추천받은 사용자 ID |
+| `content` | 문장 내용 |
+| `title` | 책 제목 |
+| `author` | 저자 |
+| `bookCoverImageUrl` | 책 표지 이미지 URL |
+| `recommendedAt` | 문장이 추천 이력에 등록된 시각 |
+| `isScrapped` | 로그인 사용자가 해당 문장을 스크랩했는지 여부 |
+
+## DB
+
+발견탭 후보 문장 전용 테이블은 만들지 않는다.
+기존 추천 이력 테이블을 기준으로 후보를 만든다.
+
+```sql
+SELECT
+    quote_id,
+    user_id AS recommended_user_id,
+    created_at AS recommended_at
+FROM daily_recommendations
+
+UNION ALL
+
+SELECT
+    daily_recommendation_quotes.quote_id,
+    daily_recommendations.user_id AS recommended_user_id,
+    daily_recommendation_quotes.created_at AS recommended_at
+FROM daily_recommendation_quotes
+JOIN daily_recommendations
+    ON daily_recommendations.id = daily_recommendation_quotes.daily_recommendation_id
+```
+
+같은 문장이 여러 번 추천된 경우에는 최신 추천 이력 1개를 대표로 사용한다.
+삭제된 문장이나 삭제된 책은 응답에서 제외한다.
+
+### 신규 테이블
+
+스크랩 여부 조회 기반으로 `quote_scraps` 테이블을 추가한다.
+이번 작업에서는 조회만 사용하고, 생성/삭제 API는 만들지 않는다.
+
+```sql
+CREATE TABLE IF NOT EXISTS quote_scraps (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    quote_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS quote_scraps_user_quote_uidx
+    ON quote_scraps (user_id, quote_id);
+
+CREATE INDEX IF NOT EXISTS quote_scraps_quote_id_idx
+    ON quote_scraps (quote_id);
+```
+
+프로젝트 DB 규칙에 따라 Foreign Key는 추가하지 않는다.
+
+### 신규 인덱스
+
+추천 이력에서 `quote_id` 기준 후보를 모으므로 다음 인덱스를 추가한다.
+
+```sql
+CREATE INDEX IF NOT EXISTS daily_recommendations_quote_id_idx
+    ON daily_recommendations (quote_id);
+
+CREATE INDEX IF NOT EXISTS daily_recommendation_quotes_quote_id_idx
+    ON daily_recommendation_quotes (quote_id);
+```
+
+## 구현 순서
+
+1. Flyway migration을 추가한다.
+   - `quote_scraps` 테이블 생성
+   - 추천 이력 `quote_id` 조회 인덱스 추가
+2. 스크랩 테이블 매핑을 만든다.
+   - `QuoteScrapTable`
+   - 발견탭에서는 별도 스크랩 service/repository를 호출하지 않는다.
+   - `DiscoveryRepository`에서 `quote_scraps`를 직접 left join해 `isScrapped`를 계산한다.
+3. 발견탭 조회 repository를 만든다.
+   - 추천 이력에서 후보 `quote_id`, 추천받은 `user_id`, 추천 이력 `created_at`을 조회한다.
+   - 같은 문장이 여러 번 추천됐으면 최신 추천 이력 1개를 대표로 사용한다.
+   - `quotes`, `books`를 join한다.
+   - `quote_scraps`를 로그인 사용자 ID 기준으로 left join하고 `quote_scraps.id IS NOT NULL`을 `isScrapped`로 변환한다.
+   - `ORDER BY random()`과 `LIMIT 10`으로 랜덤 목록을 가져온다.
+4. usecase와 service를 구성한다.
+   - `DiscoveryUseCase`에 `@Transactional(readOnly = true)`를 선언한다.
+   - `DiscoveryService`는 발견탭 조회 정책만 맡는다.
+5. controller를 추가한다.
+   - `DiscoveryController`
+   - `GET /api/discovery/quotes`
+   - `@AuthenticationPrincipal AuthenticatedUser`로 인증 사용자를 받는다.
+6. OpenAPI 설명과 DTO를 추가한다.
+   - `DiscoveryQuoteResponse`
+   - `DiscoveryQuotesResponse`
+
+## 예외와 경계 조건
+
+추천 이력이 없으면 빈 목록을 반환한다.
+추천된 문장이 10개 미만이면 가능한 개수만 반환한다.
+같은 문장이 여러 추천 이력에 있어도 한 번만 반환한다.
+
+인증 실패 처리 방식은 기존 JWT 필터와 security entry point를 따른다.
+
+## 테스트
+
+단위 테스트는 다음 시나리오를 검증한다.
+
+- 로그인 사용자는 스크랩한 문장만 `isScrapped=true`로 응답한다.
+- 후보 문장이 중복되어도 응답에는 중복 문장이 없다.
+- 추천 이력이 없으면 빈 목록을 반환한다.
+- 응답에 `recommendedUserId`, `recommendedAt`이 포함된다.
+
+repository SQL은 jOOQ `MockConnection`으로 핵심 쿼리 형태를 검증한다.
+최종 검증은 다음 명령으로 수행한다.
+
+```bash
+cd app && ./gradlew testClasses
+cd app && ./gradlew test
+cd app && ./gradlew lintKotlin
+cd app && ./gradlew detekt
+```
+
+포맷 수정이 필요한 경우 push 전에 `cd app && ./gradlew formatKotlin`을 실행한다.
+
+## 후속 작업
+
+발견탭 페이지네이션 또는 커서 기반 무한스크롤을 추가한다.
+스크랩 생성/삭제 API를 추가한다.
+마이페이지에서 내가 스크랩한 문장 목록 API를 추가한다.
+
+```text
+POST /api/quotes/{quoteId}/scraps
+DELETE /api/quotes/{quoteId}/scraps
+GET /api/my-page/scrapped-quotes
+```
+
+페이지네이션을 추가할 때는 응답에 `nextCursor` 같은 필드를 포함하는 방식으로 확장한다.
+
+## PR 설명에 포함할 내용
+
+API 응답 예시는 이 문서의 `응답` 섹션 JSON을 사용한다.
+`users`, `quotes`, `quote_scraps`의 개념 관계는 다음 Mermaid를 사용한다.
+
+```mermaid
+erDiagram
+    USERS ||--o{ QUOTE_SCRAPS : scraps
+    QUOTES ||--o{ QUOTE_SCRAPS : scrapped_by
+
+    USERS {
+        bigint id PK
+    }
+
+    QUOTES {
+        bigint id PK
+        text content
+        timestamp created_at
+    }
+
+    QUOTE_SCRAPS {
+        bigint id PK
+        bigint user_id
+        bigint quote_id
+        timestamp created_at
+    }
+```
+
+이 관계도는 DB Foreign Key가 아니라 애플리케이션에서 ID로 연결하는 개념 관계다.


### PR DESCRIPTION
## 작업 내용

- 로그인 사용자가 호출하는 발견탭 랜덤 문장 조회 API를 추가했습니다.
- 누군가에게 한 번이라도 추천된 문장을 `daily_recommendations`, `daily_recommendation_quotes` 기준으로 조회합니다.
- 같은 문장이 여러 추천 이력에 포함된 경우 최신 추천 이력 1개를 대표로 사용합니다.
- `quote_scraps` 테이블을 추가하고, 로그인 사용자 기준 `isScrapped`를 `LEFT JOIN`으로 계산합니다.
- 발견탭 구현 계획과 후속 작업 범위를 문서화했습니다.

Closes #96

## API

```text
GET /api/discovery/quotes
Authorization: Bearer {accessToken}
```

## API 응답 예시

```json
{
  "quotes": [
    {
      "quoteId": 1,
      "bookId": 1,
      "recommendedUserId": 1,
      "content": "새는 알에서 나오려고 투쟁한다.",
      "title": "데미안",
      "author": "헤르만 헤세",
      "bookCoverImageUrl": "https://cdn.example.com/book-cover-placeholder.png",
      "recommendedAt": "2026-06-05T12:34:56",
      "isScrapped": false
    }
  ]
}
```

이 관계도는 DB Foreign Key가 아니라 애플리케이션에서 ID로 연결하는 개념 관계입니다.

## 후속 작업

- 발견탭 중복 방지 및 페이지네이션 개선: #98
- 스크랩 생성/삭제 API
- 마이페이지 내가 스크랩한 문장 목록 API

## 검증

- `./gradlew testClasses`
- `./gradlew test`
- `./gradlew lintKotlin`
- `./gradlew detekt`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Discovery 탭용 추천 인용문 조회 API 추가 (로그인 사용자 대상, 최대 10건 무작위)
  * 각 인용문에 사용자 스크랩 여부(isScrapped) 표시

* **데이터베이스**
  * 스크랩 조회를 위한 quote_scraps 테이블 및 관련 인덱스 추가

* **문서**
  * Discovery 탭 구현 계획 문서 추가

* **테스트**
  * 쿼리 및 응답 매핑 관련 단위/통합 테스트 추가

* **기타**
  * 개발 규칙·설정 파일 소소한 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->