### PR TITLE
feat: 발견탭 커서 페이지네이션 및 장르 필터 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/book/repository/BookTable.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/book/repository/BookTable.kt
@@ -11,6 +11,7 @@ internal object BookTable {
     val ISBN13 = DSL.field(DSL.name("books", "isbn13"), String::class.java)
     val ALADIN_LINK = DSL.field(DSL.name("books", "aladin_link"), String::class.java)
     val COVER_IMAGE_URL = DSL.field(DSL.name("books", "cover_image_url"), String::class.java)
+    val CATEGORY = DSL.field(DSL.name("books", "category"), String::class.java)
     val CREATED_AT = DSL.field(DSL.name("books", "created_at"), LocalDateTime::class.java)
     val UPDATED_AT = DSL.field(DSL.name("books", "updated_at"), LocalDateTime::class.java)
     val DELETED_AT = DSL.field(DSL.name("books", "deleted_at"), LocalDateTime::class.java)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
@@ -5,11 +5,13 @@ import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuotesResponse
 import com.firstpenguin.app.domain.discovery.usecase.DiscoveryUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -19,13 +21,46 @@ class DiscoveryController(
     private val discoveryUseCase: DiscoveryUseCase,
 ) {
     @Operation(
-        summary = "발견탭 랜덤 문장 조회 API",
-        description = "누군가에게 한 번이라도 추천된 문장을 랜덤으로 10개까지 조회한다.",
+        summary = "발견탭 문장 목록 조회 API",
+        description =
+            "누군가에게 한 번이라도 추천된 문장을 최신 추천 이력 순으로 10개씩 조회한다. " +
+                "`cursor`는 응답의 `nextCursor` 값을 그대로 전달하고, " +
+                "`genre`는 생략하거나 `전체`이면 전체 장르를 조회한다.",
         security = [SecurityRequirement(name = "bearerAuth")],
     )
     @GetMapping("/quotes")
     fun getDiscoveryQuotes(
         @Parameter(hidden = true)
         @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
-    ): DiscoveryQuotesResponse = discoveryUseCase.getDiscoveryQuotes(authenticatedUser.id)
+        @Parameter(
+            description = "다음 페이지 조회 커서. 첫 페이지에서는 전달하지 않는다.",
+            example = "MjAyNi0wNi0wNVQxMjozNDo1NnwxMA",
+        )
+        @RequestParam(required = false) cursor: String?,
+        @Parameter(
+            description = "책 장르 필터. 생략하거나 `전체`이면 전체 장르를 조회한다.",
+            example = "한국소설",
+            schema =
+                Schema(
+                    allowableValues = [
+                        "전체",
+                        "한국소설",
+                        "일본소설",
+                        "영미소설",
+                        "판타지",
+                        "고전문학",
+                        "인문",
+                        "철학",
+                        "에세이•시",
+                        "영화•드라마 원작",
+                    ],
+                ),
+        )
+        @RequestParam(required = false) genre: String?,
+    ): DiscoveryQuotesResponse =
+        discoveryUseCase.getDiscoveryQuotes(
+            userId = authenticatedUser.id,
+            cursor = cursor,
+            genre = genre,
+        )
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
@@ -21,6 +21,8 @@ data class DiscoveryQuoteResponse(
     val author: String,
     @field:Schema(description = "책 표지 이미지 URL", example = "https://cdn.example.com/book-cover-placeholder.png")
     val bookCoverImageUrl: String,
+    @field:Schema(description = "책 장르", example = "한국소설", nullable = true)
+    val genre: String?,
     @field:Schema(description = "문장이 추천 이력에 등록된 시각", example = "2026-06-05T12:34:56")
     val recommendedAt: LocalDateTime,
     @get:JsonProperty("isScrapped")
@@ -37,6 +39,7 @@ data class DiscoveryQuoteResponse(
                 title = quote.title,
                 author = quote.author,
                 bookCoverImageUrl = quote.bookCoverImageUrl,
+                genre = quote.genre,
                 recommendedAt = quote.recommendedAt,
                 isScrapped = quote.isScrapped,
             )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuotesResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuotesResponse.kt
@@ -4,6 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "발견탭 문장 목록 응답")
 data class DiscoveryQuotesResponse(
-    @field:Schema(description = "랜덤 발견탭 문장 목록")
+    @field:Schema(description = "발견탭 문장 목록")
     val quotes: List<DiscoveryQuoteResponse>,
+    @field:Schema(
+        description = "다음 페이지 조회 커서. `hasNext`가 true이면 다음 요청의 `cursor`로 그대로 전달한다.",
+        example = "MjAyNi0wNi0wNVQxMjozNDo1NnwxMA",
+        nullable = true,
+    )
+    val nextCursor: String?,
+    @field:Schema(description = "다음 페이지 존재 여부", example = "true")
+    val hasNext: Boolean,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryCursor.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryCursor.kt
@@ -1,0 +1,57 @@
+package com.firstpenguin.app.domain.discovery.model
+
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Base64
+
+data class DiscoveryCursor(
+    val recommendedAt: LocalDateTime,
+    val quoteId: Long,
+) {
+    fun encode(): String {
+        val rawCursor =
+            listOf(
+                DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(recommendedAt),
+                quoteId,
+            ).joinToString(DELIMITER)
+
+        return encoder.encodeToString(rawCursor.toByteArray(Charsets.UTF_8))
+    }
+
+    companion object {
+        fun from(quote: DiscoveryQuote): DiscoveryCursor =
+            DiscoveryCursor(
+                recommendedAt = quote.recommendedAt,
+                quoteId = quote.quoteId,
+            )
+
+        fun parse(cursor: String?): DiscoveryCursor? {
+            if (cursor.isNullOrBlank()) return null
+
+            return runCatching { decode(cursor) }
+                .getOrElse { throw CustomException(ErrorCode.INVALID_INPUT) }
+        }
+
+        private fun decode(cursor: String): DiscoveryCursor {
+            val parts = String(decoder.decode(cursor), Charsets.UTF_8).split(DELIMITER)
+            if (parts.size != CURSOR_PART_COUNT) {
+                throw IllegalArgumentException("Invalid discovery cursor format")
+            }
+
+            return DiscoveryCursor(
+                recommendedAt = LocalDateTime.parse(parts[RECOMMENDED_AT_INDEX], DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                quoteId = parts[QUOTE_ID_INDEX].toLong(),
+            )
+        }
+
+        private const val DELIMITER = "|"
+        private const val CURSOR_PART_COUNT = 2
+        private const val RECOMMENDED_AT_INDEX = 0
+        private const val QUOTE_ID_INDEX = 1
+
+        private val encoder = Base64.getUrlEncoder().withoutPadding()
+        private val decoder = Base64.getUrlDecoder()
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryGenre.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryGenre.kt
@@ -1,0 +1,31 @@
+package com.firstpenguin.app.domain.discovery.model
+
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+
+enum class DiscoveryGenre(
+    val value: String,
+) {
+    KOREAN_NOVEL("한국소설"),
+    JAPANESE_NOVEL("일본소설"),
+    ENGLISH_NOVEL("영미소설"),
+    FANTASY("판타지"),
+    CLASSIC_LITERATURE("고전문학"),
+    HUMANITIES("인문"),
+    PHILOSOPHY("철학"),
+    ESSAY_POETRY("에세이•시"),
+    MOVIE_DRAMA_ORIGINAL("영화•드라마 원작"),
+    ;
+
+    companion object {
+        fun parse(genre: String?): DiscoveryGenre? {
+            val normalizedGenre = genre?.trim()
+            if (normalizedGenre.isNullOrBlank() || normalizedGenre == ALL_GENRE) return null
+
+            return entries.find { entry -> entry.value == normalizedGenre }
+                ?: throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+
+        private const val ALL_GENRE = "전체"
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
@@ -10,6 +10,7 @@ data class DiscoveryQuote(
     val title: String,
     val author: String,
     val bookCoverImageUrl: String,
+    val genre: String?,
     val recommendedAt: LocalDateTime,
     val isScrapped: Boolean,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
@@ -1,11 +1,14 @@
 package com.firstpenguin.app.domain.discovery.repository
 
 import com.firstpenguin.app.domain.book.repository.BookTable
+import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
 import com.firstpenguin.app.domain.quote.repository.QuoteScrapTable
 import com.firstpenguin.app.domain.quote.repository.QuoteTable
 import com.firstpenguin.app.domain.recommendation.repository.table.DailyRecommendationQuoteTable
 import com.firstpenguin.app.domain.recommendation.repository.table.DailyRecommendationTable
+import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
@@ -18,8 +21,10 @@ import java.time.LocalDateTime
 class DiscoveryRepository(
     private val dsl: DSLContext,
 ) {
-    fun findRandomRecommendedQuotes(
+    fun findRecommendedQuotes(
         userId: Long,
+        cursor: DiscoveryCursor?,
+        genre: DiscoveryGenre?,
         limit: Int,
     ): List<DiscoveryQuote> {
         if (limit <= 0) return emptyList()
@@ -38,13 +43,32 @@ class DiscoveryRepository(
             .leftJoin(QuoteScrapTable.QUOTE_SCRAPS)
             .on(QuoteScrapTable.QUOTE_ID.eq(QuoteTable.ID))
             .and(QuoteScrapTable.USER_ID.eq(userId))
-            .where(recommendationRank(rankedRecommendationEvents).eq(LATEST_RECOMMENDATION_RANK))
+            .where(latestRecommendedQuoteCondition(rankedRecommendationEvents, cursor))
             .and(QuoteTable.DELETED_AT.isNull)
             .and(BookTable.DELETED_AT.isNull)
-            .orderBy(DSL.function("random", Double::class.java))
+            .and(genre?.let { selectedGenre -> BookTable.CATEGORY.eq(selectedGenre.value) } ?: DSL.noCondition())
+            .orderBy(at(rankedRecommendationEvents).desc(), QuoteTable.ID.desc())
             .limit(limit)
             .fetch(::toDiscoveryQuote)
     }
+
+    private fun latestRecommendedQuoteCondition(
+        rankedRecommendationEvents: Table<*>,
+        cursor: DiscoveryCursor?,
+    ): Condition {
+        val latestCondition = recommendationRank(rankedRecommendationEvents).eq(LATEST_RECOMMENDATION_RANK)
+        if (cursor == null) return latestCondition
+
+        return latestCondition.and(cursorCondition(rankedRecommendationEvents, cursor))
+    }
+
+    private fun cursorCondition(
+        rankedRecommendationEvents: Table<*>,
+        cursor: DiscoveryCursor,
+    ): Condition =
+        at(rankedRecommendationEvents)
+            .lt(cursor.recommendedAt)
+            .or(at(rankedRecommendationEvents).eq(cursor.recommendedAt).and(QuoteTable.ID.lt(cursor.quoteId)))
 
     private fun toDiscoveryQuote(record: Record): DiscoveryQuote =
         DiscoveryQuote(
@@ -55,6 +79,7 @@ class DiscoveryRepository(
             title = record.get(BookTable.TITLE),
             author = record.get(BookTable.AUTHOR),
             bookCoverImageUrl = record.get(BookTable.COVER_IMAGE_URL),
+            genre = record.get(BookTable.CATEGORY),
             recommendedAt = record.get(RECOMMENDED_AT_FIELD),
             isScrapped = record.get(IS_SCRAPPED_FIELD),
         )
@@ -101,6 +126,7 @@ class DiscoveryRepository(
             BookTable.TITLE,
             BookTable.AUTHOR,
             BookTable.COVER_IMAGE_URL,
+            BookTable.CATEGORY,
             at(rankedRecommendationEvents),
             IS_SCRAPPED_FIELD,
         )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/service/DiscoveryService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/service/DiscoveryService.kt
@@ -1,5 +1,7 @@
 package com.firstpenguin.app.domain.discovery.service
 
+import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
 import com.firstpenguin.app.domain.discovery.repository.DiscoveryRepository
 import org.springframework.stereotype.Service
@@ -8,8 +10,16 @@ import org.springframework.stereotype.Service
 class DiscoveryService(
     private val discoveryRepository: DiscoveryRepository,
 ) {
-    fun getRandomQuotes(
+    fun getRecommendedQuotes(
         userId: Long,
+        cursor: DiscoveryCursor?,
+        genre: DiscoveryGenre?,
         limit: Int,
-    ): List<DiscoveryQuote> = discoveryRepository.findRandomRecommendedQuotes(userId, limit)
+    ): List<DiscoveryQuote> =
+        discoveryRepository.findRecommendedQuotes(
+            userId = userId,
+            cursor = cursor,
+            genre = genre,
+            limit = limit,
+        )
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCase.kt
@@ -2,22 +2,48 @@ package com.firstpenguin.app.domain.discovery.usecase
 
 import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuoteResponse
 import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuotesResponse
+import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
 import com.firstpenguin.app.domain.discovery.service.DiscoveryService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 private const val DISCOVERY_QUOTE_COUNT = 10
+private const val NEXT_PAGE_CHECK_COUNT = 1
 
 @Service
 class DiscoveryUseCase(
     private val discoveryService: DiscoveryService,
 ) {
     @Transactional(readOnly = true)
-    fun getDiscoveryQuotes(userId: Long): DiscoveryQuotesResponse {
-        val quotes = discoveryService.getRandomQuotes(userId, DISCOVERY_QUOTE_COUNT)
+    fun getDiscoveryQuotes(
+        userId: Long,
+        cursor: String?,
+        genre: String?,
+    ): DiscoveryQuotesResponse {
+        val quotes =
+            discoveryService.getRecommendedQuotes(
+                userId = userId,
+                cursor = DiscoveryCursor.parse(cursor),
+                genre = DiscoveryGenre.parse(genre),
+                limit = DISCOVERY_QUOTE_COUNT + NEXT_PAGE_CHECK_COUNT,
+            )
+        val pageQuotes = quotes.take(DISCOVERY_QUOTE_COUNT)
 
         return DiscoveryQuotesResponse(
-            quotes = quotes.map(DiscoveryQuoteResponse::from),
+            quotes = pageQuotes.map(DiscoveryQuoteResponse::from),
+            nextCursor = nextCursor(pageQuotes, quotes),
+            hasNext = quotes.size > DISCOVERY_QUOTE_COUNT,
         )
+    }
+
+    private fun nextCursor(
+        pageQuotes: List<DiscoveryQuote>,
+        quotes: List<DiscoveryQuote>,
+    ): String? {
+        if (quotes.size <= DISCOVERY_QUOTE_COUNT) return null
+
+        return pageQuotes.lastOrNull()?.let { quote -> DiscoveryCursor.from(quote).encode() }
     }
 }

--- a/app/src/main/resources/db/migration/V41__add_books_category.sql
+++ b/app/src/main/resources/db/migration/V41__add_books_category.sql
@@ -1,0 +1,15 @@
+ALTER TABLE books
+    ADD COLUMN IF NOT EXISTS category VARCHAR(50);
+
+CREATE INDEX IF NOT EXISTS books_category_idx
+    ON books (category);
+
+UPDATE books
+SET category = '고전문학'
+WHERE category IS NULL
+  AND title IN ('데미안', '어린 왕자');
+
+UPDATE books
+SET category = '한국소설'
+WHERE category IS NULL
+  AND title = '모순';

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
@@ -1,6 +1,8 @@
 package com.firstpenguin.app.domain.discovery.repository
 
 import com.firstpenguin.app.domain.book.repository.BookTable
+import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.quote.repository.QuoteScrapTable
 import com.firstpenguin.app.domain.quote.repository.QuoteTable
 import org.jooq.DSLContext
@@ -16,10 +18,15 @@ import kotlin.test.assertTrue
 
 class DiscoveryRepositoryTest {
     @Test
-    fun `추천 이력 테이블을 합쳐 랜덤 문장을 조회한다`() {
+    fun `추천 이력 테이블을 합쳐 최신순 문장을 조회한다`() {
         val capturedSql =
             captureSql { dsl ->
-                DiscoveryRepository(dsl).findRandomRecommendedQuotes(USER_ID, DISCOVERY_QUOTE_COUNT)
+                DiscoveryRepository(dsl).findRecommendedQuotes(
+                    userId = USER_ID,
+                    cursor = null,
+                    genre = null,
+                    limit = DISCOVERY_QUOTE_FETCH_COUNT,
+                )
             }
         val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
 
@@ -32,11 +39,50 @@ class DiscoveryRepositoryTest {
         assertTrue(normalizedSql.contains("\"quote_scraps\".\"user_id\" = ?"), normalizedSql)
         assertTrue(normalizedSql.contains("row_number()"), normalizedSql)
         assertTrue(normalizedSql.contains(" union all "), normalizedSql)
-        assertTrue(normalizedSql.contains("random()"), normalizedSql)
+        assertTrue(
+            normalizedSql.contains(
+                "order by \"ranked_recommendation_events\".\"recommended_at\" desc, \"quotes\".\"id\" desc",
+            ),
+            normalizedSql,
+        )
         assertTrue(normalizedSql.contains("fetch next ? rows only"), normalizedSql)
         assertTrue(normalizedSql.contains("\"recommendation_rank\" = ?"), normalizedSql)
         assertTrue(normalizedSql.contains("\"quotes\".\"deleted_at\" is null"), normalizedSql)
         assertTrue(normalizedSql.contains("\"books\".\"deleted_at\" is null"), normalizedSql)
+    }
+
+    @Test
+    fun `커서가 있으면 다음 페이지 조건을 추가한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                DiscoveryRepository(dsl).findRecommendedQuotes(
+                    userId = USER_ID,
+                    cursor = DiscoveryCursor(RECOMMENDED_AT, QUOTE_ID),
+                    genre = null,
+                    limit = DISCOVERY_QUOTE_FETCH_COUNT,
+                )
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("\"recommended_at\" < cast(? as timestamp)"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"recommended_at\" = cast(? as timestamp)"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"quotes\".\"id\" < ?"), normalizedSql)
+    }
+
+    @Test
+    fun `장르가 있으면 책 카테고리 조건을 추가한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                DiscoveryRepository(dsl).findRecommendedQuotes(
+                    userId = USER_ID,
+                    cursor = null,
+                    genre = DiscoveryGenre.KOREAN_NOVEL,
+                    limit = DISCOVERY_QUOTE_FETCH_COUNT,
+                )
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("\"books\".\"category\" = ?"), normalizedSql)
     }
 
     private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {
@@ -56,7 +102,9 @@ class DiscoveryRepositoryTest {
 
     private companion object {
         const val USER_ID = 1L
-        const val DISCOVERY_QUOTE_COUNT = 10
+        const val DISCOVERY_QUOTE_FETCH_COUNT = 11
+        const val QUOTE_ID = 10L
+        val RECOMMENDED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 5, 12, 34, 56)
         val DISCOVERY_QUOTE_FIELDS: Array<Field<*>> =
             arrayOf(
                 QuoteTable.ID,
@@ -66,6 +114,7 @@ class DiscoveryRepositoryTest {
                 BookTable.TITLE,
                 BookTable.AUTHOR,
                 BookTable.COVER_IMAGE_URL,
+                BookTable.CATEGORY,
                 DSL.field("recommended_at", LocalDateTime::class.java),
                 QuoteScrapTable.ID.isNotNull.`as`("is_scrapped"),
             )

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
@@ -2,12 +2,15 @@ package com.firstpenguin.app.domain.discovery.usecase
 
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
 import com.firstpenguin.app.domain.discovery.service.DiscoveryService
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 
 class DiscoveryUseCaseTest {
     private lateinit var discoveryService: DiscoveryService
@@ -22,24 +25,77 @@ class DiscoveryUseCaseTest {
     @Test
     fun `로그인 사용자의 추천 이력 정보와 스크랩 여부를 응답한다`() {
         val quote = discoveryQuote(QUOTE_ID)
-        Mockito.`when`(discoveryService.getRandomQuotes(USER_ID, DISCOVERY_QUOTE_COUNT)).thenReturn(listOf(quote))
+        Mockito
+            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, null, DISCOVERY_QUOTE_FETCH_COUNT))
+            .thenReturn(listOf(quote))
 
-        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID)
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = null)
 
         assertEquals(1, response.quotes.size)
         assertEquals(RECOMMENDED_USER_ID, response.quotes.first().recommendedUserId)
         assertEquals(RECOMMENDED_AT, response.quotes.first().recommendedAt)
+        assertEquals(GENRE, response.quotes.first().genre)
         assertFalse(response.quotes.first().isScrapped)
+        assertFalse(response.hasNext)
+        assertNull(response.nextCursor)
     }
 
     @Test
     fun `조회된 스크랩 여부가 true면 응답도 true다`() {
         val quote = discoveryQuote(QUOTE_ID, isScrapped = true)
-        Mockito.`when`(discoveryService.getRandomQuotes(USER_ID, DISCOVERY_QUOTE_COUNT)).thenReturn(listOf(quote))
+        Mockito
+            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, null, DISCOVERY_QUOTE_FETCH_COUNT))
+            .thenReturn(listOf(quote))
 
-        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID)
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = null)
 
         assertEquals(true, response.quotes.first().isScrapped)
+    }
+
+    @Test
+    fun `조회 결과가 11개면 10개만 응답하고 다음 커서를 만든다`() {
+        val quotes = (1L..DISCOVERY_QUOTE_FETCH_COUNT).map { quoteId -> discoveryQuote(quoteId) }
+        Mockito
+            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, null, DISCOVERY_QUOTE_FETCH_COUNT))
+            .thenReturn(quotes)
+
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = null)
+
+        assertEquals(DISCOVERY_QUOTE_COUNT, response.quotes.size)
+        assertEquals(true, response.hasNext)
+        assertEquals(EXPECTED_NEXT_CURSOR, response.nextCursor)
+    }
+
+    @Test
+    fun `장르가 전체면 전체 장르를 조회한다`() {
+        Mockito
+            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, null, DISCOVERY_QUOTE_FETCH_COUNT))
+            .thenReturn(emptyList())
+
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = "전체")
+
+        assertEquals(emptyList(), response.quotes)
+        assertFalse(response.hasNext)
+    }
+
+    @Test
+    fun `유효하지 않은 장르가 들어오면 예외가 발생한다`() {
+        val exception =
+            org.junit.jupiter.api.assertThrows<CustomException> {
+                discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = "미지원")
+            }
+
+        assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
+    }
+
+    @Test
+    fun `잘못된 커서가 들어오면 예외가 발생한다`() {
+        val exception =
+            org.junit.jupiter.api.assertThrows<CustomException> {
+                discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = "invalid", genre = null)
+            }
+
+        assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
     }
 
     private fun discoveryQuote(
@@ -54,16 +110,20 @@ class DiscoveryUseCaseTest {
             title = "데미안",
             author = "헤르만 헤세",
             bookCoverImageUrl = "https://cdn.example.com/book-cover-placeholder.png",
+            genre = GENRE,
             recommendedAt = RECOMMENDED_AT,
             isScrapped = isScrapped,
         )
 
     private companion object {
         const val DISCOVERY_QUOTE_COUNT = 10
+        const val DISCOVERY_QUOTE_FETCH_COUNT = 11
         const val USER_ID = 1L
         const val QUOTE_ID = 10L
         const val BOOK_ID = 100L
         const val RECOMMENDED_USER_ID = 200L
+        const val GENRE = "한국소설"
         val RECOMMENDED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 5, 12, 34, 56)
+        const val EXPECTED_NEXT_CURSOR = "MjAyNi0wNi0wNVQxMjozNDo1NnwxMA"
     }
 }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
@@ -1,5 +1,7 @@
 package com.firstpenguin.app.domain.discovery.usecase
 
+import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
 import com.firstpenguin.app.domain.discovery.service.DiscoveryService
 import com.firstpenguin.app.global.exception.CustomException
@@ -76,6 +78,42 @@ class DiscoveryUseCaseTest {
 
         assertEquals(emptyList(), response.quotes)
         assertFalse(response.hasNext)
+    }
+
+    @Test
+    fun `유효한 커서로 조회하면 파싱된 커서가 서비스에 전달된다`() {
+        val quote = discoveryQuote(QUOTE_ID)
+        Mockito
+            .`when`(
+                discoveryService.getRecommendedQuotes(
+                    USER_ID,
+                    DiscoveryCursor(RECOMMENDED_AT, QUOTE_ID),
+                    null,
+                    DISCOVERY_QUOTE_FETCH_COUNT,
+                ),
+            ).thenReturn(listOf(quote))
+
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = EXPECTED_NEXT_CURSOR, genre = null)
+
+        assertEquals(1, response.quotes.size)
+    }
+
+    @Test
+    fun `유효한 장르로 조회하면 파싱된 장르가 서비스에 전달된다`() {
+        val quote = discoveryQuote(QUOTE_ID)
+        Mockito
+            .`when`(
+                discoveryService.getRecommendedQuotes(
+                    USER_ID,
+                    null,
+                    DiscoveryGenre.KOREAN_NOVEL,
+                    DISCOVERY_QUOTE_FETCH_COUNT,
+                ),
+            ).thenReturn(listOf(quote))
+
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = GENRE)
+
+        assertEquals(1, response.quotes.size)
     }
 
     @Test


### PR DESCRIPTION
## 📢 요약
- 발견탭 문장 조회를 랜덤 조회에서 최신 추천 이력 기준 커서 페이지네이션으로 변경했습니다.
- `cursor`, `genre`, `nextCursor`, `hasNext` 기준으로 Swagger 설명과 응답 스키마를 정리했습니다.
- `genre` 요청 파라미터는 프론트 API 명칭으로 사용하고, 현재 DB 구조에 맞춰 `books.category`로 필터링합니다.
- `books.category` 컬럼/인덱스 보강 마이그레이션과 발견탭 테스트를 추가했습니다.

🔗 연관 이슈: Resolves #98, Resolves #108

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
- `./gradlew test --tests 'com.firstpenguin.app.domain.discovery.*'`\n- `./gradlew formatKotlin lintKotlin detekt`\n- push hook: `./gradlew clean test`\n\n## 📜 기타\n- 첫 페이지는 `cursor` 없이 요청하고, 다음 페이지는 응답의 `nextCursor`를 그대로 전달합니다.\n- `genre`는 생략하거나 `전체`이면 전체 장르를 조회합니다.\n- 지원 장르: 전체, 한국소설, 일본소설, 영미소설, 판타지, 고전문학, 인문, 철학, 에세이•시, 영화•드라마 원작\n