### PR TITLE
feat: 발견탭 장르 필터 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/book/repository/BookTable.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/book/repository/BookTable.kt
@@ -11,6 +11,7 @@ internal object BookTable {
     val ISBN13 = DSL.field(DSL.name("books", "isbn13"), String::class.java)
     val ALADIN_LINK = DSL.field(DSL.name("books", "aladin_link"), String::class.java)
     val COVER_IMAGE_URL = DSL.field(DSL.name("books", "cover_image_url"), String::class.java)
+    val CATEGORY = DSL.field(DSL.name("books", "category"), String::class.java)
     val CREATED_AT = DSL.field(DSL.name("books", "created_at"), LocalDateTime::class.java)
     val UPDATED_AT = DSL.field(DSL.name("books", "updated_at"), LocalDateTime::class.java)
     val DELETED_AT = DSL.field(DSL.name("books", "deleted_at"), LocalDateTime::class.java)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
@@ -5,6 +5,7 @@ import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuotesResponse
 import com.firstpenguin.app.domain.discovery.usecase.DiscoveryUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -24,7 +25,8 @@ class DiscoveryController(
         description =
             "누군가에게 한 번이라도 추천된 문장을 최신 추천 이력 순으로 10개씩 조회한다. " +
                 "첫 페이지는 `cursor` 없이 요청하고, 다음 페이지는 직전 응답의 `nextCursor` 값을 그대로 전달한다. " +
-                "`cursor`는 서버가 발급하는 URL-safe Base64 인코딩 문자열이며 클라이언트에서 직접 생성하거나 해석하지 않는다.",
+                "`cursor`는 서버가 발급하는 URL-safe Base64 인코딩 문자열이며 클라이언트에서 직접 생성하거나 해석하지 않는다. " +
+                "`genre`는 생략하거나 `전체`이면 전체 장르를 조회한다.",
         security = [SecurityRequirement(name = "bearerAuth")],
     )
     @GetMapping("/quotes")
@@ -38,9 +40,30 @@ class DiscoveryController(
             example = "MjAyNi0wNi0wNVQxMjozNDo1NnwxMA",
         )
         @RequestParam(required = false) cursor: String?,
+        @Parameter(
+            description = "책 장르 필터. 생략하거나 `전체`이면 전체 장르를 조회한다.",
+            example = "한국소설",
+            schema =
+                Schema(
+                    allowableValues = [
+                        "전체",
+                        "한국소설",
+                        "일본소설",
+                        "영미소설",
+                        "판타지",
+                        "고전문학",
+                        "인문",
+                        "철학",
+                        "에세이•시",
+                        "영화•드라마 원작",
+                    ],
+                ),
+        )
+        @RequestParam(required = false) genre: String?,
     ): DiscoveryQuotesResponse =
         discoveryUseCase.getDiscoveryQuotes(
             userId = authenticatedUser.id,
             cursor = cursor,
+            genre = genre,
         )
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
@@ -21,6 +21,8 @@ data class DiscoveryQuoteResponse(
     val author: String,
     @field:Schema(description = "책 표지 이미지 URL", example = "https://cdn.example.com/book-cover-placeholder.png")
     val bookCoverImageUrl: String,
+    @field:Schema(description = "책 장르", example = "한국소설", nullable = true)
+    val genre: String?,
     @field:Schema(description = "문장이 추천 이력에 등록된 시각", example = "2026-06-05T12:34:56")
     val recommendedAt: LocalDateTime,
     @get:JsonProperty("isScrapped")
@@ -37,6 +39,7 @@ data class DiscoveryQuoteResponse(
                 title = quote.title,
                 author = quote.author,
                 bookCoverImageUrl = quote.bookCoverImageUrl,
+                genre = quote.genre,
                 recommendedAt = quote.recommendedAt,
                 isScrapped = quote.isScrapped,
             )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryGenre.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryGenre.kt
@@ -1,0 +1,31 @@
+package com.firstpenguin.app.domain.discovery.model
+
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+
+enum class DiscoveryGenre(
+    val value: String,
+) {
+    KOREAN_NOVEL("한국소설"),
+    JAPANESE_NOVEL("일본소설"),
+    ENGLISH_NOVEL("영미소설"),
+    FANTASY("판타지"),
+    CLASSIC_LITERATURE("고전문학"),
+    HUMANITIES("인문"),
+    PHILOSOPHY("철학"),
+    ESSAY_POETRY("에세이•시"),
+    MOVIE_DRAMA_ORIGINAL("영화•드라마 원작"),
+    ;
+
+    companion object {
+        fun parse(genre: String?): DiscoveryGenre? {
+            val normalizedGenre = genre?.trim()
+            if (normalizedGenre.isNullOrBlank() || normalizedGenre == ALL_GENRE) return null
+
+            return entries.find { entry -> entry.value == normalizedGenre }
+                ?: throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+
+        private const val ALL_GENRE = "전체"
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
@@ -10,6 +10,7 @@ data class DiscoveryQuote(
     val title: String,
     val author: String,
     val bookCoverImageUrl: String,
+    val genre: String?,
     val recommendedAt: LocalDateTime,
     val isScrapped: Boolean,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
@@ -2,6 +2,7 @@ package com.firstpenguin.app.domain.discovery.repository
 
 import com.firstpenguin.app.domain.book.repository.BookTable
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
 import com.firstpenguin.app.domain.quote.repository.QuoteScrapTable
 import com.firstpenguin.app.domain.quote.repository.QuoteTable
@@ -23,6 +24,7 @@ class DiscoveryRepository(
     fun findRecommendedQuotes(
         userId: Long,
         cursor: DiscoveryCursor?,
+        genre: DiscoveryGenre?,
         limit: Int,
     ): List<DiscoveryQuote> {
         if (limit <= 0) return emptyList()
@@ -44,6 +46,7 @@ class DiscoveryRepository(
             .where(latestRecommendedQuoteCondition(rankedRecommendationEvents, cursor))
             .and(QuoteTable.DELETED_AT.isNull)
             .and(BookTable.DELETED_AT.isNull)
+            .and(genre?.let { selectedGenre -> BookTable.CATEGORY.eq(selectedGenre.value) } ?: DSL.noCondition())
             .orderBy(at(rankedRecommendationEvents).desc(), QuoteTable.ID.desc())
             .limit(limit)
             .fetch(::toDiscoveryQuote)
@@ -76,6 +79,7 @@ class DiscoveryRepository(
             title = record.get(BookTable.TITLE),
             author = record.get(BookTable.AUTHOR),
             bookCoverImageUrl = record.get(BookTable.COVER_IMAGE_URL),
+            genre = record.get(BookTable.CATEGORY),
             recommendedAt = record.get(RECOMMENDED_AT_FIELD),
             isScrapped = record.get(IS_SCRAPPED_FIELD),
         )
@@ -122,6 +126,7 @@ class DiscoveryRepository(
             BookTable.TITLE,
             BookTable.AUTHOR,
             BookTable.COVER_IMAGE_URL,
+            BookTable.CATEGORY,
             at(rankedRecommendationEvents),
             IS_SCRAPPED_FIELD,
         )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/service/DiscoveryService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/service/DiscoveryService.kt
@@ -1,6 +1,7 @@
 package com.firstpenguin.app.domain.discovery.service
 
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
 import com.firstpenguin.app.domain.discovery.repository.DiscoveryRepository
 import org.springframework.stereotype.Service
@@ -12,11 +13,13 @@ class DiscoveryService(
     fun getRecommendedQuotes(
         userId: Long,
         cursor: DiscoveryCursor?,
+        genre: DiscoveryGenre?,
         limit: Int,
     ): List<DiscoveryQuote> =
         discoveryRepository.findRecommendedQuotes(
             userId = userId,
             cursor = cursor,
+            genre = genre,
             limit = limit,
         )
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCase.kt
@@ -3,6 +3,7 @@ package com.firstpenguin.app.domain.discovery.usecase
 import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuoteResponse
 import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuotesResponse
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
 import com.firstpenguin.app.domain.discovery.service.DiscoveryService
 import org.springframework.stereotype.Service
@@ -19,18 +20,21 @@ class DiscoveryUseCase(
     fun getDiscoveryQuotes(
         userId: Long,
         cursor: String?,
+        genre: String?,
     ): DiscoveryQuotesResponse {
-        val quotes = fetchQuotesWithNextPageCheck(userId, cursor)
+        val quotes = fetchQuotesWithNextPageCheck(userId, cursor, genre)
         return toDiscoveryQuotesResponse(quotes)
     }
 
     private fun fetchQuotesWithNextPageCheck(
         userId: Long,
         cursor: String?,
+        genre: String?,
     ): List<DiscoveryQuote> =
         discoveryService.getRecommendedQuotes(
             userId = userId,
             cursor = DiscoveryCursor.parse(cursor),
+            genre = DiscoveryGenre.parse(genre),
             limit = DISCOVERY_QUOTE_COUNT + NEXT_PAGE_CHECK_COUNT,
         )
 

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.firstpenguin.app.domain.discovery.repository
 
 import com.firstpenguin.app.domain.book.repository.BookTable
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.quote.repository.QuoteScrapTable
 import com.firstpenguin.app.domain.quote.repository.QuoteTable
 import org.jooq.DSLContext
@@ -23,6 +24,7 @@ class DiscoveryRepositoryTest {
                 DiscoveryRepository(dsl).findRecommendedQuotes(
                     userId = USER_ID,
                     cursor = null,
+                    genre = null,
                     limit = DISCOVERY_QUOTE_FETCH_COUNT,
                 )
             }
@@ -56,6 +58,7 @@ class DiscoveryRepositoryTest {
                 DiscoveryRepository(dsl).findRecommendedQuotes(
                     userId = USER_ID,
                     cursor = DiscoveryCursor(RECOMMENDED_AT, QUOTE_ID),
+                    genre = null,
                     limit = DISCOVERY_QUOTE_FETCH_COUNT,
                 )
             }
@@ -64,6 +67,22 @@ class DiscoveryRepositoryTest {
         assertTrue(normalizedSql.contains("\"recommended_at\" < cast(? as timestamp)"), normalizedSql)
         assertTrue(normalizedSql.contains("\"recommended_at\" = cast(? as timestamp)"), normalizedSql)
         assertTrue(normalizedSql.contains("\"quotes\".\"id\" < ?"), normalizedSql)
+    }
+
+    @Test
+    fun `장르가 있으면 책 카테고리 조건을 추가한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                DiscoveryRepository(dsl).findRecommendedQuotes(
+                    userId = USER_ID,
+                    cursor = null,
+                    genre = DiscoveryGenre.KOREAN_NOVEL,
+                    limit = DISCOVERY_QUOTE_FETCH_COUNT,
+                )
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("\"books\".\"category\" = ?"), normalizedSql)
     }
 
     private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {
@@ -95,6 +114,7 @@ class DiscoveryRepositoryTest {
                 BookTable.TITLE,
                 BookTable.AUTHOR,
                 BookTable.COVER_IMAGE_URL,
+                BookTable.CATEGORY,
                 DSL.field("recommended_at", LocalDateTime::class.java),
                 QuoteScrapTable.ID.isNotNull.`as`("is_scrapped"),
             )

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.firstpenguin.app.domain.discovery.usecase
 
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
 import com.firstpenguin.app.domain.discovery.service.DiscoveryService
 import com.firstpenguin.app.global.exception.CustomException
@@ -27,14 +28,15 @@ class DiscoveryUseCaseTest {
     fun `로그인 사용자의 추천 이력 정보와 스크랩 여부를 응답한다`() {
         val quote = discoveryQuote(QUOTE_ID)
         Mockito
-            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, DISCOVERY_QUOTE_FETCH_COUNT))
+            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, null, DISCOVERY_QUOTE_FETCH_COUNT))
             .thenReturn(listOf(quote))
 
-        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null)
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = null)
 
         assertEquals(1, response.quotes.size)
         assertEquals(RECOMMENDED_USER_ID, response.quotes.first().recommendedUserId)
         assertEquals(RECOMMENDED_AT, response.quotes.first().recommendedAt)
+        assertEquals(GENRE, response.quotes.first().genre)
         assertFalse(response.quotes.first().isScrapped)
         assertFalse(response.hasNext)
         assertNull(response.nextCursor)
@@ -44,10 +46,10 @@ class DiscoveryUseCaseTest {
     fun `조회된 스크랩 여부가 true면 응답도 true다`() {
         val quote = discoveryQuote(QUOTE_ID, isScrapped = true)
         Mockito
-            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, DISCOVERY_QUOTE_FETCH_COUNT))
+            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, null, DISCOVERY_QUOTE_FETCH_COUNT))
             .thenReturn(listOf(quote))
 
-        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null)
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = null)
 
         assertEquals(true, response.quotes.first().isScrapped)
     }
@@ -56,10 +58,10 @@ class DiscoveryUseCaseTest {
     fun `조회 결과가 11개면 10개만 응답하고 다음 커서를 만든다`() {
         val quotes = (1L..DISCOVERY_QUOTE_FETCH_COUNT).map { quoteId -> discoveryQuote(quoteId) }
         Mockito
-            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, DISCOVERY_QUOTE_FETCH_COUNT))
+            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, null, DISCOVERY_QUOTE_FETCH_COUNT))
             .thenReturn(quotes)
 
-        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null)
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = null)
 
         assertEquals(DISCOVERY_QUOTE_COUNT, response.quotes.size)
         assertEquals(true, response.hasNext)
@@ -74,20 +76,79 @@ class DiscoveryUseCaseTest {
                 discoveryService.getRecommendedQuotes(
                     USER_ID,
                     DiscoveryCursor(RECOMMENDED_AT, QUOTE_ID),
+                    null,
                     DISCOVERY_QUOTE_FETCH_COUNT,
                 ),
             ).thenReturn(listOf(quote))
 
-        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = EXPECTED_NEXT_CURSOR)
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = EXPECTED_NEXT_CURSOR, genre = null)
 
         assertEquals(1, response.quotes.size)
+    }
+
+    @Test
+    fun `장르가 전체면 전체 장르를 조회한다`() {
+        Mockito
+            .`when`(discoveryService.getRecommendedQuotes(USER_ID, null, null, DISCOVERY_QUOTE_FETCH_COUNT))
+            .thenReturn(emptyList())
+
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = "전체")
+
+        assertEquals(emptyList(), response.quotes)
+        assertFalse(response.hasNext)
+    }
+
+    @Test
+    fun `유효한 장르로 조회하면 파싱된 장르가 서비스에 전달된다`() {
+        val quote = discoveryQuote(QUOTE_ID)
+        Mockito
+            .`when`(
+                discoveryService.getRecommendedQuotes(
+                    USER_ID,
+                    null,
+                    DiscoveryGenre.KOREAN_NOVEL,
+                    DISCOVERY_QUOTE_FETCH_COUNT,
+                ),
+            ).thenReturn(listOf(quote))
+
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = GENRE)
+
+        assertEquals(1, response.quotes.size)
+    }
+
+    @Test
+    fun `유효한 커서와 장르로 조회하면 둘 다 파싱되어 서비스에 전달된다`() {
+        val quote = discoveryQuote(QUOTE_ID)
+        Mockito
+            .`when`(
+                discoveryService.getRecommendedQuotes(
+                    USER_ID,
+                    DiscoveryCursor(RECOMMENDED_AT, QUOTE_ID),
+                    DiscoveryGenre.KOREAN_NOVEL,
+                    DISCOVERY_QUOTE_FETCH_COUNT,
+                ),
+            ).thenReturn(listOf(quote))
+
+        val response = discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = EXPECTED_NEXT_CURSOR, genre = GENRE)
+
+        assertEquals(1, response.quotes.size)
+    }
+
+    @Test
+    fun `유효하지 않은 장르가 들어오면 예외가 발생한다`() {
+        val exception =
+            org.junit.jupiter.api.assertThrows<CustomException> {
+                discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = null, genre = "미지원")
+            }
+
+        assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
     }
 
     @Test
     fun `잘못된 커서가 들어오면 예외가 발생한다`() {
         val exception =
             org.junit.jupiter.api.assertThrows<CustomException> {
-                discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = "invalid")
+                discoveryUseCase.getDiscoveryQuotes(USER_ID, cursor = "invalid", genre = null)
             }
 
         assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
@@ -105,6 +166,7 @@ class DiscoveryUseCaseTest {
             title = "데미안",
             author = "헤르만 헤세",
             bookCoverImageUrl = "https://cdn.example.com/book-cover-placeholder.png",
+            genre = GENRE,
             recommendedAt = RECOMMENDED_AT,
             isScrapped = isScrapped,
         )
@@ -116,6 +178,7 @@ class DiscoveryUseCaseTest {
         const val QUOTE_ID = 10L
         const val BOOK_ID = 100L
         const val RECOMMENDED_USER_ID = 200L
+        const val GENRE = "한국소설"
         val RECOMMENDED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 5, 12, 34, 56)
         const val EXPECTED_NEXT_CURSOR = "MjAyNi0wNi0wNVQxMjozNDo1NnwxMA"
     }

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -1,0 +1,73 @@
+# API 문서와 Swagger
+
+## 목표
+
+Springdoc OpenAPI를 사용해 백엔드 API를 Swagger UI에서 확인하고 테스트한다.
+모든 공개 API 경로는 서버 context-path `/api`를 포함한다.
+
+관련 이슈: #18
+
+## 접근 경로
+
+```text
+Swagger UI: /api/swagger-ui.html
+Swagger UI: /api/swagger-ui/index.html
+OpenAPI JSON: /api/v3/api-docs
+```
+
+prefix 없는 루트 경로는 사용하지 않는다.
+
+```text
+/v3/api-docs        -> 사용하지 않음
+/swagger-ui.html    -> 사용하지 않음
+```
+
+## 서버 prefix
+
+애플리케이션은 공통 context-path를 사용한다.
+
+```yaml
+server:
+  servlet:
+    context-path: /api
+```
+
+OpenAPI server URL도 `/api`로 설정한다.
+Swagger에서 보이는 API path는 context-path 내부 경로를 기준으로 표시될 수 있으므로, 외부에서 직접 호출할 때는 `/api` prefix를 포함한다.
+
+## 인증
+
+OpenAPI에는 HTTP Bearer JWT 인증 스키마를 등록한다.
+
+```text
+Authorization: Bearer {accessToken}
+```
+
+Swagger UI에서 보호 API를 테스트할 때는 우상단 Authorize 버튼에 access token을 입력한다.
+dev 환경에서는 `GET /api/auth/dev-token`으로 개발용 access token을 발급받을 수 있다.
+
+## OAuth 로그인 시작 경로
+
+OAuth 로그인 시작 경로는 Spring Security가 제공한다.
+
+```text
+GET /api/oauth2/authorization/kakao
+GET /api/oauth2/authorization/google
+```
+
+현재 OpenAPI customizer는 Kakao 로그인 시작 경로를 명시적으로 문서에 추가한다.
+Google 로그인 흐름과 callback 정책은 `docs/auth-flow.md`를 기준으로 관리한다.
+
+## 정렬과 노출
+
+Swagger UI는 operation과 tag를 알파벳순으로 정렬한다.
+
+```yaml
+springdoc:
+  swagger-ui:
+    operations-sorter: alpha
+    tags-sorter: alpha
+```
+
+환경별 Swagger 노출 여부는 profile 설정에서 `springdoc.api-docs.enabled`, `springdoc.swagger-ui.enabled`로 제어한다.
+운영 환경에서 Swagger를 닫아야 하면 prod profile에서 두 값을 `false`로 둔다.

--- a/docs/auth-flow.md
+++ b/docs/auth-flow.md
@@ -6,25 +6,27 @@
 첫 OAuth 로그인 성공 시 URL에 access token을 붙이지 않고, HttpOnly refresh token 쿠키만 내려준다.
 프론트는 로그인 callback 화면에서 refresh API를 호출해 access token을 발급받는다.
 
-1. 프론트 카카오 로그인 버튼은 백엔드 OAuth 시작 URL로 브라우저를 이동시킨다.
+1. 프론트 OAuth 로그인 버튼은 백엔드 OAuth 시작 URL로 브라우저를 이동시킨다.
 
 ```text
 GET /api/oauth2/authorization/kakao
+GET /api/oauth2/authorization/google
 ```
 
-2. 백엔드는 카카오 로그인 페이지로 redirect한다.
-3. 카카오는 로그인 성공 후 백엔드 callback URL로 redirect한다.
+2. 백엔드는 provider 로그인 페이지로 redirect한다.
+3. provider는 로그인 성공 후 백엔드 callback URL로 redirect한다.
 
 ```text
 /api/login/oauth2/code/kakao
+/api/login/oauth2/code/google
 ```
 
 4. 백엔드는 OAuth 사용자 정보를 조회하고 사용자를 생성하거나 갱신한다.
 5. 백엔드는 refresh token을 발급해 `Set-Cookie`로 내려주고, 프론트 callback URL로 redirect한다.
 
 ```text
-local: http://localhost:3000/login/kakao/callback
-dev:   https://hiking.monster/login/kakao/callback
+local: http://localhost:3000/login/callback
+dev:   https://hiking.monster/login/callback
 ```
 
 6. 프론트 callback 화면은 refresh API를 호출한다.
@@ -50,17 +52,41 @@ Authorization: Bearer {accessToken}
 
 ```ts
 window.location.href = "/api/oauth2/authorization/kakao";
+window.location.href = "/api/oauth2/authorization/google";
 ```
 
 로컬에서 백엔드와 프론트를 각각 띄우면 백엔드 origin을 직접 지정한다.
 
 ```ts
 window.location.href = "http://localhost:8080/api/oauth2/authorization/kakao";
+window.location.href = "http://localhost:8080/api/oauth2/authorization/google";
 ```
 
-## 카카오 개발자 Redirect URI
+## 개발용 토큰
 
-카카오 개발자 페이지에는 프론트 callback URL이 아니라 카카오가 백엔드로 돌아올 URL을 등록한다.
+개발 환경에서는 Swagger로 보호 API를 테스트할 수 있도록 개발용 access token 발급 API를 제공한다.
+
+```text
+GET /api/auth/dev-token
+```
+
+이 API는 `app.token.enabled=true`일 때만 bean으로 등록된다.
+dev 환경에서는 활성화하고, prod 환경에서는 비활성화한다.
+
+응답:
+
+```json
+{
+  "accessToken": "..."
+}
+```
+
+개발용 토큰은 고정 더미 사용자를 생성하거나 갱신한 뒤 access token을 발급한다.
+refresh token 쿠키를 발급하는 OAuth 로그인 흐름과는 별개의 Swagger 테스트 편의 기능이다.
+
+## OAuth Redirect URI
+
+OAuth provider 개발자 페이지에는 프론트 callback URL이 아니라 provider가 백엔드로 돌아올 URL을 등록한다.
 
 경로 기반 라우팅을 사용하는 dev 환경:
 
@@ -72,6 +98,14 @@ https://hiking.monster/api/login/oauth2/code/kakao
 
 ```text
 http://localhost:8080/api/login/oauth2/code/kakao
+```
+
+Google OAuth2도 동일하게 백엔드 callback URL을 등록한다.
+Google은 `openid` scope가 포함되면 OIDC 플로우로 처리되므로, Spring Security의 `oidcUserService`에서 사용자를 로드한다.
+
+```text
+https://hiking.monster/api/login/oauth2/code/google
+http://localhost:8080/api/login/oauth2/code/google
 ```
 
 ## refresh token 쿠키
@@ -150,13 +184,62 @@ refresh token payload:
 인증 principal은 사용자 ID만 가진다.
 DB에는 refresh token 원문을 저장하지 않고 SHA-256 hash만 저장한다.
 
-## OAuth 사용자 식별자 저장 정책
+## OAuth provider 처리
+
+Kakao는 일반 OAuth2 사용자 정보 플로우를 사용한다.
+Google은 `openid` scope 포함 시 OIDC 사용자 플로우를 사용한다.
+
+| Provider | Spring principal | 처리 컴포넌트 |
+|----------|------------------|---------------|
+| Kakao | `OAuth2AuthenticatedUser` | `CustomOAuth2UserService` |
+| Google | `OidcAuthenticatedUser` | `CustomOidcUserService` |
+
+로그인 성공 후 `JwtIssueSuccessHandler`는 두 principal 타입을 모두 처리한다.
+공통적으로 서비스 사용자 정보를 꺼낸 뒤 refresh token을 발급하고, refresh token cookie와 함께 프론트 callback URL로 redirect한다.
+
+## OAuth 사용자 저장 정책
 
 `users.provider_id`에는 Kakao, Google이 내려준 외부 사용자 ID 원문을 저장한다.
 즉 `kakao_...`, `google_...`처럼 provider prefix를 붙이지 않는다.
 
 provider 구분은 별도 `users.provider` 컬럼으로 관리하고, 중복 방지는 `(provider, provider_id)` 복합 unique 제약으로 처리한다.
 따라서 서로 다른 provider에서 같은 외부 ID 문자열을 내려주더라도 DB 레벨에서 충돌하지 않는다.
+
+신규 OAuth 사용자는 provider 표시 이름을 서비스 닉네임으로 사용하지 않는다.
+서비스 닉네임은 랜덤 닉네임 생성기로 만들고, provider 표시 이름은 `provider_display_name`에 별도로 저장한다.
+
+기존 OAuth 사용자가 다시 로그인하면 다음 값만 갱신한다.
+
+- provider에서 이메일을 제공한 경우 `email`
+- `provider_display_name`
+- `last_login_at`
+- `updated_at`
+
+재로그인 시 `users.nickname`은 덮어쓰지 않는다.
+서비스 닉네임 변경은 `PATCH /api/users/me`에서만 수행한다.
+
+## OAuth 생성과 재로그인 흐름
+
+OAuth 로그인은 `find -> create/update` 흐름으로 처리한다.
+
+1. `(provider, provider_id)`로 기존 사용자를 조회한다.
+2. 기존 사용자가 있으면 인증 가능한 상태인지 검증한다.
+3. `ACTIVE` 사용자면 OAuth 로그인 정보를 갱신하고 사용자 정보를 반환한다.
+4. 기존 사용자가 없으면 랜덤 닉네임을 생성해 신규 사용자를 insert한다.
+5. insert는 `ON CONFLICT DO NOTHING`을 사용한다.
+6. insert 결과가 없으면 같은 OAuth 계정의 동시 첫 로그인 가능성이 있으므로 다시 조회한다.
+7. 재조회된 사용자가 있으면 기존 사용자 로그인 흐름으로 수렴한다.
+8. 재조회된 사용자가 없으면 닉네임 충돌로 보고 최대 10회까지 닉네임을 다시 생성한다.
+
+10회 안에 사용 가능한 닉네임을 만들지 못하면 `NICKNAME_GENERATION_FAILED`로 처리한다.
+
+OAuth 로그인 시 인증 가능한 사용자 상태는 다음과 같다.
+
+| 사용자 상태 | 처리 |
+|-------------|------|
+| `ACTIVE` | 로그인 가능 |
+| `BLOCKED` | `AUTH_USER_BLOCKED` |
+| `DELETED` 또는 `deleted_at` 존재 | `AUTH_USER_DELETED` |
 
 ## 인증 에러 응답
 
@@ -171,9 +254,15 @@ provider 구분은 별도 `users.provider` 컬럼으로 관리하고, 중복 방
 | refresh token 쿠키 없음 | `401` | `Refresh Token이 필요합니다` |
 | refresh token 만료 | `401` | `Refresh Token이 만료되었습니다` |
 | refresh token 형식 이상, 서명 불일치, type 불일치, DB hash 없음 | `401` | `유효하지 않은 Refresh Token입니다` |
+| access token의 사용자 ID가 DB에 없음 | `401` | `인증된 사용자를 찾을 수 없습니다` |
+| access token의 사용자가 차단됨 | `401` | `차단된 사용자입니다` |
+| access token의 사용자가 탈퇴됨 | `401` | `탈퇴한 사용자입니다` |
 
 `/api/auth/refresh`는 refresh token 쿠키로 access token을 재발급하는 공개 auth API다.
 따라서 만료된 access token 헤더가 같이 오더라도 access token 오류로 먼저 차단하지 않고, refresh token 검증을 진행한다.
+
+JWT 자체가 유효하더라도 claims의 사용자 ID가 실제 인증 가능한 사용자라는 보장은 없다.
+따라서 보호 API 진입 전 `JwtAuthenticator`가 사용자 존재 여부와 상태를 중앙에서 검증한다.
 
 ## Nginx 경로 기반 라우팅
 
@@ -208,17 +297,19 @@ server {
 백엔드는 `server.servlet.context-path: /api`를 사용하므로 `/api` prefix가 유지되어야 한다.
 
 `location /`의 `try_files` 설정은 SPA 라우팅을 위해 필요하다.
-이 설정이 없으면 `/login/kakao/callback`에 직접 진입하거나 redirect 되었을 때 Nginx가 정적 파일을 찾지 못해 404를 반환할 수 있다.
+이 설정이 없으면 `/login/callback`에 직접 진입하거나 redirect 되었을 때 Nginx가 정적 파일을 찾지 못해 404를 반환할 수 있다.
 
 이 백엔드 repo에는 프론트 Nginx 설정 파일이 없다.
 따라서 현재 repo 변경만으로 Nginx가 설정된 것은 아니며, 프론트 인스턴스의 Nginx 설정에 위 `/api/` proxy와 SPA fallback이 적용되어야 한다.
 
 ## 서버 설정 체크리스트
 
-- 프론트 버튼은 `/api/oauth2/authorization/kakao`로 브라우저 이동을 수행한다.
-- 카카오 개발자 Redirect URI는 `https://hiking.monster/api/login/oauth2/code/kakao`로 등록한다.
-- 백엔드 `auth.oauth2.success-redirect-url`은 `https://hiking.monster/login/kakao/callback`이다.
+- 프론트 버튼은 `/api/oauth2/authorization/{provider}`로 브라우저 이동을 수행한다.
+- Kakao Redirect URI는 `https://hiking.monster/api/login/oauth2/code/kakao`로 등록한다.
+- Google Redirect URI는 `https://hiking.monster/api/login/oauth2/code/google`로 등록한다.
+- 백엔드 `auth.oauth2.success-redirect-url`은 `https://hiking.monster/login/callback`이다.
 - 백엔드 dev 설정에는 `server.forward-headers-strategy: framework`가 필요하다.
 - 프론트 Nginx는 `/api/`를 백엔드 `8080`으로 proxy 한다.
-- 프론트 Nginx는 SPA fallback으로 `/login/kakao/callback`을 프론트 앱에 전달한다.
+- 프론트 Nginx는 SPA fallback으로 `/login/callback`을 프론트 앱에 전달한다.
 - callback 화면은 `POST /api/auth/refresh`를 `credentials: "include"`로 호출한다.
+- dev 환경에서 Swagger 테스트가 필요하면 `app.token.enabled=true` 상태에서 `GET /api/auth/dev-token`을 사용한다.

--- a/docs/cd-pipeline.md
+++ b/docs/cd-pipeline.md
@@ -20,7 +20,8 @@ GitHub Actions (cd.yml)
 1. config 레포 pull (설정 파일 최신화)
 2. 최신 이미지 pull
 3. docker compose로 app 컨테이너 재시작 (DB 유지)
-4. 이전 이미지 정리
+4. 30초 내 헬스체크 통과 확인
+5. 이전 이미지 정리
 ```
 
 ## 구성 요소
@@ -29,15 +30,18 @@ GitHub Actions (cd.yml)
 
 ```
 [1단계 - 빌드]                      [2단계 - 실행]
-gradle:8.13-jdk21                   eclipse-temurin:21-jre
+eclipse-temurin:21-jdk              eclipse-temurin:21-jre
 ├── 소스코드 복사                    ├── jar만 복사
 ├── gradle bootJar                  └── java -jar app.jar
 └── jar 생성 (~1GB)                     (~300MB)
 ```
 
 - 빌드 도구, 소스코드는 최종 이미지에 포함되지 않음
-- 테스트는 CI에서 이미 통과했으므로 `-x test`로 스킵
+- Docker 빌드는 Gradle wrapper로 `clean bootJar`만 실행한다
+- 테스트는 CI와 pre-push에서 검증한다
 - yml 파일은 이미지에 포함하지 않음 (서버에서 볼륨 마운트)
+- 런타임 timezone은 `Asia/Seoul`로 고정
+- JVM 기본 인코딩은 `UTF-8`로 고정해 한글 에러 응답 깨짐을 방지
 
 ### 2. 이미지 레지스트리 (GHCR)
 
@@ -51,6 +55,12 @@ gradle:8.13-jdk21                   eclipse-temurin:21-jre
 - GitHub Actions에서 `GITHUB_TOKEN`으로 바로 인증 (별도 설정 불필요)
 - 클라우드 벤더 종속 없음 (OCI 이전 시에도 변경 불필요)
 - public 이미지 저장공간 무제한
+
+워크플로우는 `docker/setup-buildx-action@v3`로 Buildx를 먼저 설정한다.
+GitHub Actions cache export(`cache-from: type=gha`, `cache-to: type=gha`)를 사용하려면 기본 `docker` 드라이버가 아니라 Buildx builder가 필요하다.
+
+이미지 이름은 `${GITHUB_REPOSITORY,,}/api`로 소문자화한다.
+GitHub repository 이름에는 대문자가 포함될 수 있지만 Docker image reference 경로는 소문자 기준으로 맞춰야 한다.
 
 ### 3. GitHub Environment
 
@@ -73,6 +83,9 @@ gradle:8.13-jdk21                   eclipse-temurin:21-jre
 | `SERVER_USER` | SSH 사용자 (ubuntu) |
 | `SERVER_SSH_KEY` | 배포용 SSH 개인키 |
 | `DEPLOY_SCRIPT_PATH` | 배포 스크립트 절대 경로 (dev: `/opt/firstpenguin/scripts/deploy-dev.sh`, prod: `/opt/firstpenguin/scripts/deploy-prod.sh`) |
+
+`DEPLOY_SCRIPT_PATH`는 GitHub Environment variable이 아니라 secret으로 등록한다.
+CD workflow의 SSH step은 `${{ secrets.DEPLOY_SCRIPT_PATH }}`를 실행한다.
 
 ### SSH 키 생성 방법
 
@@ -140,8 +153,11 @@ docker ps --filter "name=firstpenguin"
 docker logs firstpenguin-api
 
 # 헬스 체크
-curl http://localhost:8080/actuator/health
+curl http://localhost:8080/api/actuator/health
 ```
+
+앱은 `server.servlet.context-path: /api`를 사용하므로, 외부 호출 경로에는 `/api` prefix가 포함된다.
+Spring Security permitAll 매칭은 context-path 내부 경로인 `/actuator/health`를 기준으로 설정한다.
 
 ## 롤백
 

--- a/docs/convention.md
+++ b/docs/convention.md
@@ -78,6 +78,8 @@ feat: 회원가입 API 추가
 
 - 최소 **1명 이상 Approve 필요**
 - 리뷰 요청 후 **24시간 내 응답**
+- PR 생성 시 GitHub Actions가 작성자를 제외한 팀원에게 리뷰를 자동 요청
+- PR 작성자는 자동으로 assignee에 등록
 
 ### 예외 (hotfix)
 
@@ -98,8 +100,8 @@ feat: 회원가입 API 추가
 ### 이슈 템플릿
 
 - **Feature** (`.github/ISSUE_TEMPLATE/01-feature.yml`) — 적용 완료
-- **Fix** (`.github/ISSUE_TEMPLATE/02-fix.yml`) — 미적용
-- **Refactor** (`.github/ISSUE_TEMPLATE/03-refactor.yml`) — 미적용
+- **Fix** (`.github/ISSUE_TEMPLATE/02-fix.yml`) — 적용 완료
+- **Refactor** (`.github/ISSUE_TEMPLATE/03-refactor.yml`) — 적용 완료
 
 ### PR 템플릿
 
@@ -189,5 +191,5 @@ Controller → UseCase(Facade) → Service → Repository
 
 ### 도구
 
-- 코드 리뷰: CodeRabbit (미적용)
+- 코드 리뷰: CodeRabbit
 - 모델 활용: HuggingFace (Emotion Classification)

--- a/docs/discovery-genre-filter-implementation.md
+++ b/docs/discovery-genre-filter-implementation.md
@@ -1,0 +1,170 @@
+# 발견탭 장르 필터 구현 정리
+
+관련 이슈: #108
+
+## 배경
+
+발견탭에서 책 장르별로 문장을 필터링해야 한다.
+프론트/API 명칭은 `genre`로 맞추지만, 현재 DB 컬럼은 `books.category`로 존재한다.
+
+따라서 이번 구현은 외부 API에서는 `genre`를 사용하고, 서버 내부 조회에서는 `books.category`에 매핑하는 방식으로 진행했다.
+DB 컬럼 rename이나 신규 migration은 이번 범위에 포함하지 않았다.
+
+## API 계약
+
+```text
+GET /api/discovery/quotes?genre={genre}&cursor={nextCursor}
+Authorization: Bearer {accessToken}
+```
+
+`genre`는 선택 파라미터다.
+
+- 파라미터 없음: 전체 장르 조회
+- `genre=전체`: 전체 장르 조회
+- 그 외 지원 장르: `books.category = genre` 조건으로 필터링
+- 지원하지 않는 값: `INVALID_INPUT`
+
+지원 장르 목록:
+
+```text
+전체
+한국소설
+일본소설
+영미소설
+판타지
+고전문학
+인문
+철학
+에세이•시
+영화•드라마 원작
+```
+
+응답의 각 문장에는 책 장르를 `genre` 필드로 포함한다.
+
+```json
+{
+  "quotes": [
+    {
+      "quoteId": 10,
+      "bookId": 1,
+      "recommendedUserId": 20,
+      "content": "새는 알에서 나오려고 투쟁한다.",
+      "title": "데미안",
+      "author": "헤르만 헤세",
+      "bookCoverImageUrl": "https://cdn.example.com/book-cover-placeholder.png",
+      "genre": "한국소설",
+      "recommendedAt": "2026-06-05T12:34:56",
+      "isScrapped": false
+    }
+  ],
+  "nextCursor": "MjAyNi0wNi0wNVQxMjozNDo1NnwxMA",
+  "hasNext": true
+}
+```
+
+## 페이지네이션과의 관계
+
+장르 필터는 커서 페이지네이션 조회 조건에 함께 들어간다.
+
+클라이언트는 장르가 바뀌면 기존 `cursor`를 재사용하지 않고 첫 페이지부터 다시 요청해야 한다.
+커서는 같은 정렬 조건과 같은 필터 조건 안에서만 의미가 있다.
+
+예시 흐름:
+
+```text
+GET /api/discovery/quotes?genre=한국소설
+GET /api/discovery/quotes?genre=한국소설&cursor={nextCursor}
+
+장르 변경 시:
+GET /api/discovery/quotes?genre=일본소설
+```
+
+## 구현 방식
+
+### DiscoveryGenre
+
+`DiscoveryGenre` enum을 추가해 API에서 허용하는 장르 값을 한 곳에서 관리한다.
+
+`parse` 규칙:
+
+- `null`, blank, `전체`는 `null` 반환
+- 지원 장르는 enum으로 변환
+- 지원하지 않는 값은 `CustomException(ErrorCode.INVALID_INPUT)` 발생
+
+### BookTable
+
+프로젝트는 jOOQ codegen이 아니라 수동 테이블 매핑을 사용한다.
+DB에 `books.category`가 있어도 `BookTable`에 필드가 없으면 Kotlin 코드에서 참조할 수 없다.
+
+그래서 아래 필드를 추가했다.
+
+```kotlin
+val CATEGORY = DSL.field(DSL.name("books", "category"), String::class.java)
+```
+
+### DiscoveryRepository
+
+repository는 `DiscoveryGenre?`를 받아 조건을 선택적으로 추가한다.
+
+```kotlin
+.and(genre?.let { selectedGenre -> BookTable.CATEGORY.eq(selectedGenre.value) } ?: DSL.noCondition())
+```
+
+장르가 없으면 `DSL.noCondition()`으로 전체 장르를 조회한다.
+장르가 있으면 현재 DB 구조에 맞춰 `books.category = selectedGenre.value` 조건을 추가한다.
+
+### DTO와 Swagger
+
+`DiscoveryQuoteResponse`에 `genre`를 추가했다.
+Swagger에는 `genre` request parameter를 추가하고, 고정 허용 값을 `allowableValues`로 명시했다.
+
+## 주요 변경 파일
+
+- `BookTable`
+  - `CATEGORY` 필드 추가
+- `DiscoveryGenre`
+  - 발견탭 장르 enum 및 파싱 규칙 추가
+- `DiscoveryController`
+  - `genre` request parameter 추가
+  - Swagger 허용 장르 목록 추가
+- `DiscoveryUseCase`
+  - `genre` 문자열 파싱 후 service 전달
+- `DiscoveryService`
+  - `DiscoveryGenre?` 전달
+- `DiscoveryRepository`
+  - `books.category` 조건 추가
+  - select 필드에 category 추가
+- `DiscoveryQuote`
+  - `genre` 필드 추가
+- `DiscoveryQuoteResponse`
+  - `genre` 응답 필드 추가
+
+## 테스트
+
+다음 시나리오를 검증했다.
+
+- 장르가 있으면 repository SQL에 `books.category = ?` 조건이 추가된다.
+- 응답 DTO에 `genre`가 매핑된다.
+- `genre=전체`이면 전체 장르 조회로 처리한다.
+- 유효한 장르는 `DiscoveryGenre`로 파싱되어 service에 전달된다.
+- 유효하지 않은 장르는 `INVALID_INPUT`을 발생시킨다.
+- 유효한 `cursor`와 `genre`가 함께 들어와도 둘 다 파싱되어 service에 전달된다.
+
+검증 명령:
+
+```bash
+cd app && ./gradlew test --tests 'com.firstpenguin.app.domain.discovery.*'
+cd app && ./gradlew formatKotlin lintKotlin detekt
+```
+
+## 아직 최적화하지 않은 부분
+
+현재는 `books.category` 문자열을 그대로 비교한다.
+데이터가 많아지거나 장르 정책이 바뀌면 다음을 검토해야 한다.
+
+- `books.category` 인덱스 존재 여부와 실제 실행 계획
+- DB 컬럼명을 `category`에서 `genre`로 rename할지 여부
+- 장르 값 오탈자나 다른 표기법을 DB 입력 단계에서 어떻게 막을지
+- 응답에 `genre`를 반드시 포함해야 하는지, 필터 UI만으로 충분한지
+- 장르 변경 시 기존 cursor 재사용을 클라이언트에서 명확히 막는 UX 처리
+

--- a/docs/discovery-pagination-implementation.md
+++ b/docs/discovery-pagination-implementation.md
@@ -1,0 +1,150 @@
+# 발견탭 커서 페이지네이션 구현 정리
+
+관련 이슈: #98
+
+## 배경
+
+발견탭 첫 구현은 페이지네이션을 바로 넣기 어려워 `ORDER BY random()`으로 최대 10개를 조회했다.
+이 방식은 무한스크롤에서 다음 목록을 안정적으로 이어갈 수 없고, 요청마다 랜덤 순서가 달라져 중복 방지가 어렵다.
+
+따라서 발견탭 조회를 랜덤 방식에서 최신 추천 이력 기준 커서 페이지네이션으로 전환했다.
+
+## API 계약
+
+```text
+GET /api/discovery/quotes?cursor={nextCursor}
+Authorization: Bearer {accessToken}
+```
+
+첫 페이지는 `cursor` 없이 요청한다.
+다음 페이지는 직전 응답의 `nextCursor` 값을 그대로 `cursor`에 전달한다.
+
+응답은 기존 `quotes` 목록에 페이지네이션 메타 정보를 추가했다.
+
+```json
+{
+  "quotes": [
+    {
+      "quoteId": 10,
+      "bookId": 1,
+      "recommendedUserId": 20,
+      "content": "새는 알에서 나오려고 투쟁한다.",
+      "title": "데미안",
+      "author": "헤르만 헤세",
+      "bookCoverImageUrl": "https://cdn.example.com/book-cover-placeholder.png",
+      "recommendedAt": "2026-06-05T12:34:56",
+      "isScrapped": false
+    }
+  ],
+  "nextCursor": "MjAyNi0wNi0wNVQxMjozNDo1NnwxMA",
+  "hasNext": true
+}
+```
+
+`nextCursor`는 서버가 발급한 URL-safe Base64 문자열이다.
+클라이언트는 내부 값을 해석하거나 직접 만들지 않고, 응답 값을 그대로 다음 요청에 전달한다.
+
+## 정렬 기준
+
+발견탭의 최신순은 문장 생성 시각이 아니라 추천 이력의 최신 시각이다.
+
+정렬 기준은 아래 순서다.
+
+```sql
+ORDER BY recommended_at DESC, quote_id DESC
+```
+
+`recommended_at`만 커서로 사용하지 않고 `quote_id`를 함께 넣은 이유는 같은 추천 시각을 가진 문장이 여러 개 있을 수 있기 때문이다.
+복합 커서를 사용해야 같은 시각 데이터에서 누락이나 중복 없이 다음 페이지를 이어갈 수 있다.
+
+## 커서 구조
+
+커서 payload는 아래 값을 조합한다.
+
+```text
+recommendedAt|quoteId
+```
+
+예를 들어 내부 값이 다음과 같다면:
+
+```text
+2026-06-05T12:34:56|10
+```
+
+이를 URL-safe Base64로 인코딩해 클라이언트에는 아래처럼 내려준다.
+
+```text
+MjAyNi0wNi0wNVQxMjozNDo1NnwxMA
+```
+
+커서 파싱에 실패하면 `INVALID_INPUT`으로 처리한다.
+
+## 조회 방식
+
+기존 발견탭 후보 생성 방식은 유지했다.
+
+- `daily_recommendations`
+- `daily_recommendation_quotes`
+
+두 추천 이력 테이블을 `UNION ALL`로 합친 뒤, 같은 문장이 여러 번 추천됐으면 최신 추천 이력 1개를 대표 이벤트로 사용한다.
+삭제된 문장과 삭제된 책은 제외한다.
+로그인 사용자의 스크랩 여부는 `quote_scraps`를 left join해서 계산한다.
+
+커서가 있으면 다음 조건을 추가한다.
+
+```sql
+recommended_at < :recommendedAt
+OR (recommended_at = :recommendedAt AND quote_id < :quoteId)
+```
+
+실제 응답 개수는 10개지만, `hasNext` 판단을 위해 내부에서는 11개를 조회한다.
+11개가 조회되면 10개만 응답하고, 10번째 문장의 `recommendedAt + quoteId`로 `nextCursor`를 만든다.
+
+## 주요 변경 파일
+
+- `DiscoveryController`
+  - `cursor` request parameter 추가
+  - Swagger 설명을 커서 기반 무한스크롤 기준으로 변경
+- `DiscoveryUseCase`
+  - `cursor` 파싱
+  - 11개 조회 후 10개 응답
+  - `nextCursor`, `hasNext` 계산
+- `DiscoveryService`
+  - cursor를 repository로 전달
+- `DiscoveryRepository`
+  - `random()` 제거
+  - 최신순 정렬 추가
+  - 복합 커서 조건 추가
+- `DiscoveryCursor`
+  - `recommendedAt + quoteId` 인코딩/파싱 담당
+- `DiscoveryQuotesResponse`
+  - `nextCursor`, `hasNext` 추가
+
+## 테스트
+
+다음 시나리오를 검증했다.
+
+- 추천 이력 테이블을 합쳐 최신순으로 조회한다.
+- 커서가 있으면 다음 페이지 조건을 추가한다.
+- 응답은 11개 조회 결과 중 10개만 반환한다.
+- 11개가 조회되면 `hasNext=true`, `nextCursor`를 반환한다.
+- 유효한 커서는 파싱되어 service로 전달된다.
+- 잘못된 커서는 `INVALID_INPUT`을 발생시킨다.
+
+검증 명령:
+
+```bash
+cd app && ./gradlew test --tests 'com.firstpenguin.app.domain.discovery.*'
+cd app && ./gradlew formatKotlin lintKotlin detekt
+```
+
+## 아직 최적화하지 않은 부분
+
+현재 쿼리는 추천 이력을 합치고 `row_number()`로 최신 대표 이벤트를 뽑는다.
+데이터가 많아지면 다음 지점을 확인해야 한다.
+
+- `recommended_at`, `quote_id` 기반 정렬/커서 조건에 맞는 인덱스 필요 여부
+- `UNION ALL` 후보 테이블 규모 증가 시 실행 계획
+- 최신 대표 이벤트를 매번 계산하지 않고 별도 materialized view나 캐시로 관리할지 여부
+- `nextCursor`에 서명 값을 붙여 클라이언트 조작을 더 강하게 막을지 여부
+

--- a/docs/discovery-tab-plan.md
+++ b/docs/discovery-tab-plan.md
@@ -5,8 +5,8 @@
 발견탭은 로그인 사용자가 추천받은 문장을 다시 탐색할 수 있는 목록 API다.
 목록에는 누군가에게 한 번이라도 추천된 문장만 노출한다.
 
-첫 구현 범위는 랜덤 문장 10개 조회까지다.
-스크랩 생성/삭제 API와 페이지네이션은 후속 작업으로 분리한다.
+첫 구현 범위는 랜덤 문장 10개 조회까지였다.
+이후 커서 페이지네이션, 장르 필터, 스크랩 생성/삭제 API를 별도 작업으로 확장했다.
 
 관련 이슈: #96
 
@@ -175,13 +175,13 @@ cd app && ./gradlew detekt
 
 ## 후속 작업
 
-발견탭 페이지네이션 또는 커서 기반 무한스크롤을 추가한다.
-스크랩 생성/삭제 API를 추가한다.
-마이페이지에서 내가 스크랩한 문장 목록 API를 추가한다.
+커서 기반 무한스크롤은 `docs/discovery-pagination-implementation.md` 기준으로 정리했다.
+장르 필터는 `docs/discovery-genre-filter-implementation.md` 기준으로 정리했다.
+스크랩 생성/삭제 API는 `docs/quote-scrap-api.md` 기준으로 정리했다.
+
+남은 후속 작업은 마이페이지에서 내가 스크랩한 문장 목록 API를 추가하는 것이다.
 
 ```text
-POST /api/quotes/{quoteId}/scraps
-DELETE /api/quotes/{quoteId}/scraps
 GET /api/my-page/scrapped-quotes
 ```
 

--- a/docs/home-summary-api.md
+++ b/docs/home-summary-api.md
@@ -1,0 +1,93 @@
+# 홈 요약 API
+
+## 목표
+
+홈 화면에서 오늘 일기, 이번 달 일기 목록, 전체 일기 수를 한 번에 조회한다.
+이번 달 일기 항목에는 상세 화면 이동을 위한 `diaryId`를 포함한다.
+
+관련 이슈: #68
+
+## API
+
+아래 API 경로는 서버 context-path `/api`를 포함한 공개 경로로 표기한다.
+
+```text
+GET /api/home/summary
+Authorization: Bearer {accessToken}
+```
+
+로그인 사용자만 호출할 수 있다.
+
+## 응답
+
+```json
+{
+  "todayDiary": {
+    "diaryId": 23,
+    "createdAt": "2026-05-06",
+    "quoteContent": "가장 중요한 것은 보이지 않는다."
+  },
+  "monthlyDiaries": [
+    {
+      "diaryId": 23,
+      "createdAt": "2026-05-06",
+      "quoteContent": "가장 중요한 것은 보이지 않는다."
+    }
+  ],
+  "totalDiaryCount": 42
+}
+```
+
+| 필드 | 설명 |
+|------|------|
+| `todayDiary` | 오늘 작성한 일기. 없으면 `null` |
+| `monthlyDiaries` | 이번 달 일기 목록 |
+| `monthlyDiaries[].diaryId` | 일기 상세 화면 이동에 사용할 일기 ID |
+| `monthlyDiaries[].createdAt` | 일기 작성일. 서울 시간 기준 날짜 |
+| `monthlyDiaries[].quoteContent` | 일기에 저장된 최종 선택 문장 |
+| `totalDiaryCount` | 지금까지 작성한 전체 일기 수 |
+
+## 조회 기준
+
+`monthlyDiaries`는 서버 현재 날짜 기준으로 이번 달 범위를 계산한다.
+
+```text
+start = 이번 달 1일
+end = 이번 달 마지막 날
+```
+
+`todayDiary`는 `monthlyDiaries` 중 `createdAt`이 오늘 날짜와 같은 첫 번째 항목이다.
+오늘 작성한 일기가 없으면 `null`을 반환한다.
+
+`totalDiaryCount`는 사용자 기준 전체 일기 수다.
+이번 달 범위와 무관하게 누적 개수를 반환한다.
+
+## 상세 화면 이동
+
+홈 요약의 이번 달 일기 항목은 상세 화면으로 이어질 수 있어야 한다.
+따라서 각 항목에 `diaryId`를 포함한다.
+
+```text
+GET /api/diaries/{diaryId}
+```
+
+클라이언트는 `monthlyDiaries[].diaryId` 또는 `todayDiary.diaryId`를 사용해 일기 상세 API를 호출한다.
+
+## 예외와 경계 조건
+
+| 상황 | 처리 |
+|------|------|
+| access token 없음, 만료, 위조 | 인증 에러 응답 |
+| 이번 달 일기 없음 | `monthlyDiaries=[]`, `todayDiary=null` |
+| 오늘 일기 없음 | `todayDiary=null` |
+| 전체 일기 없음 | `totalDiaryCount=0` |
+
+## 테스트
+
+다음 시나리오를 검증한다.
+
+- 이번 달 일기 목록을 반환한다.
+- 오늘 작성한 일기가 있으면 `todayDiary`에 포함한다.
+- 오늘 작성한 일기가 없으면 `todayDiary=null`을 반환한다.
+- 각 월간 일기 항목에 `diaryId`가 포함된다.
+- 전체 일기 수는 월 범위와 무관하게 사용자 전체 기준으로 계산한다.

--- a/docs/husky.md
+++ b/docs/husky.md
@@ -59,7 +59,7 @@ git commit -m "feat: 회원가입 API 추가"
 |------|-----|-----------|
 | `git commit` 직전 | `pre-commit` | 비밀키 검사 + 컴파일 검증 |
 | `git commit` 메시지 작성 후 | `commit-msg` | 타입 검증 + 이모지 자동 삽입 |
-| `git push` 직전 | `pre-push` | 전체 테스트 검증 |
+| `git push` 직전 | `pre-push` | submodule 최신 여부 확인 + 전체 테스트 검증 |
 
 ### 3.5. 훅이 실패했을 때
 - **컴파일 에러**: IDE에서 에러를 먼저 해결하고 다시 커밋
@@ -145,22 +145,33 @@ feat: 회원가입 API 추가
 ### 5.3. `pre-push` — 푸시 직전 검증
 
 **역할**
+- `secret` submodule 포인터가 원격 최신 커밋인지 확인
 - 전체 테스트 실행 (`./gradlew clean test`)
 
 **왜 push에만?**
 - 커밋은 자주 한다 → 빠른 피드백 필요
 - 푸시는 덜 한다 → 한 번에 꼼꼼히 검증
 - 원격에 올라가는 순간부터 팀 전체에 영향 → 여기서 막는 게 마지막 방어선
+- submodule 최신 여부는 로컬 커밋보다 원격 반영 시점에 강제하는 것이 개발 흐름을 덜 방해한다.
+
+`secret` submodule이 최신이 아니면 현재 커밋과 원격 최신 커밋을 출력하고 push를 중단한다.
+이 경우 아래 명령으로 submodule을 갱신한 뒤 포인터 변경을 커밋한다.
+
+```bash
+git submodule update --remote --checkout secret
+git add secret
+git commit -m "chore: config submodule 업데이트"
+```
 
 ## 6. 훅 우회가 필요할 때
 
-정말 급할 때는 `--no-verify` 플래그로 우회할 수 있다:
+Git hook은 기술적으로 `--no-verify` 플래그로 우회할 수 있다:
 ```bash
 git commit --no-verify -m "..."
 git push --no-verify
 ```
 
-**하지만 원칙적으로 금지.** 우회가 필요하다는 건 훅 설정이 잘못됐거나, 진짜 문제가 있다는 신호다. 팀 회의에서 논의 후 설정을 조정하는 게 맞다.
+**하지만 프로젝트 규칙상 사용 금지.** 우회가 필요하다는 건 훅 설정이 잘못됐거나, 진짜 문제가 있다는 신호다. 팀 회의에서 논의 후 설정을 조정하는 게 맞다.
 
 ## 7. 주의사항
 

--- a/docs/image-policy.md
+++ b/docs/image-policy.md
@@ -10,7 +10,15 @@ DB에는 최종 조회용 public URL을 저장한다.
 presigned URL은 업로드용 임시 URL이므로 DB에 저장하지 않는다.
 클라이언트는 public URL을 직접 저장 API에 전달하지 않고, 백엔드가 발급한 `imageId`만 도메인 API에 전달한다.
 
-현재 스토리지는 GCP Cloud Storage(dev 환경)를 사용한다.
+스토리지 구현은 `cloud.provider` 설정으로 선택한다.
+
+| `cloud.provider` | 구현체 | 용도 |
+|------------------|--------|------|
+| `gcp` | `GcsStorageService` | dev/prod GCP Cloud Storage |
+| `local` 또는 미설정 | `LocalStorageService` | 로컬 개발용 mock URL |
+
+dev/prod 환경은 GCP Cloud Storage를 사용한다.
+로컬에서 별도 GCP 자격증명 없이 API 흐름만 확인할 때는 local 구현이 mock 업로드 URL과 mock 조회 URL을 반환한다.
 
 ## 업로드 흐름
 
@@ -75,6 +83,35 @@ presigned URL 발급 API에서 사용하는 로직이다.
 3. `image_owners`에는 `image_id`, `owner_type`, `owner_id`, `sort_order`가 저장된다.
 
 `images` row는 presigned URL 발급 시점에 이미 생성되어 있으므로, 도메인 생성 시점에는 `image_owners` 연결만 만든다.
+
+## 스토리지 구현
+
+### GCP
+
+`cloud.provider=gcp`이면 `GcsStorageService`가 활성화된다.
+GCS presigned URL은 Application Default Credentials를 사용해 V4 signed URL로 발급한다.
+
+앱 시작 시점에 `GoogleCredentials.getApplicationDefault()` 결과가 `ServiceAccountSigner`인지 검증한다.
+서명을 지원하지 않는 자격증명이면 앱 시작 단계에서 실패시켜, presigned URL 발급 시점의 403 서명 오류를 늦게 발견하지 않도록 한다.
+
+GCP 환경에서는 다음 조건이 필요하다.
+
+- VM 또는 실행 환경에 서비스 계정 자격증명이 연결되어 있어야 한다.
+- 해당 서비스 계정이 대상 버킷 object 관리 권한을 가져야 한다.
+- IAM Service Account Credentials API가 활성화되어 있어야 한다.
+
+### Local
+
+`cloud.provider=local` 또는 설정이 없으면 `LocalStorageService`가 활성화된다.
+이 구현은 실제 스토리지에 업로드 URL을 만들지 않고 아래 형식의 mock URL을 반환한다.
+
+```text
+presignedUrl: http://localhost:8080/mock-upload/{objectKey}
+publicUrl:    http://localhost:8080/mock-images/{objectKey}
+```
+
+로컬 구현은 API 응답과 DB 저장 흐름을 확인하기 위한 용도다.
+실제 파일 업로드와 조회를 보장하지 않는다.
 
 ## DB 저장 구조
 

--- a/docs/monthly-report-plan.md
+++ b/docs/monthly-report-plan.md
@@ -1,0 +1,318 @@
+# 월간 리포트 구현 계획
+
+## 목표
+
+월간 리포트는 사용자가 일기를 작성할 때 최종 선택한 문장을 월 단위로 회고하는 기능이다.
+리포트에서 말하는 "문장"은 추천 과정에서 노출된 모든 문장이 아니라 `diaries.quote_id`에 저장된 최종 선택 문장이다.
+
+관련 이슈: #103
+
+책 장르 집계는 현재 `books` 테이블에 장르 정보가 없으므로 이번 범위에서 실제 구현하지 않는다.
+책 장르 스키마가 추가되면 후속 이슈 #102에서 리포트 장르 집계를 연결한다.
+
+## 리포트 정책
+
+리포트는 종료된 월만 확정한다.
+매월 1일 스케줄러가 지난달 리포트를 생성하고, 생성된 결과는 스냅샷으로 저장한다.
+
+현재 월과 미래 월은 확정 리포트 대상이 아니다.
+현재 월 데이터를 보여줘야 한다면 월간 리포트가 아니라 별도 실시간 요약 API로 분리한다.
+
+하루 여러 개 일기를 작성하는 기획이 추가되어도 리포트 기준은 바뀌지 않는다.
+일기 row 1개를 사용자가 최종 선택한 문장 1개로 보고 집계한다.
+
+## API
+
+아래 API 경로는 서버 context-path `/api`를 포함한 공개 경로로 표기한다.
+
+```text
+GET /api/reports/monthly?year=2026&month=5
+Authorization: Bearer {accessToken}
+```
+
+### 응답
+
+```json
+{
+  "year": 2026,
+  "month": 5,
+  "monthlyQuoteCount": 7,
+  "totalQuoteCount": 42,
+  "mostFrequentBookGenre": "준비중",
+  "emotionTags": [
+    {
+      "tagId": 1,
+      "label": "기분좋은",
+      "count": 3
+    },
+    {
+      "tagId": 2,
+      "label": "행복한",
+      "count": 2
+    }
+  ],
+  "monthlyBook": {
+    "quoteId": 10,
+    "bookId": 3,
+    "quoteContent": "가장 중요한 것은 보이지 않는다.",
+    "title": "어린 왕자",
+    "author": "생텍쥐페리",
+    "bookCoverImageUrl": "https://cdn.example.com/book-cover-placeholder.png"
+  }
+}
+```
+
+| 필드 | 설명 |
+|------|------|
+| `year` | 리포트 년도 |
+| `month` | 리포트 월 |
+| `monthlyQuoteCount` | 해당 월에 작성한 일기 문장 수 |
+| `totalQuoteCount` | 해당 월 말까지 작성한 전체 일기 문장 수 스냅샷 |
+| `mostFrequentBookGenre` | v1에서는 장르 스키마가 없어 `"준비중"` 반환 |
+| `emotionTags` | 해당 월 일기 문장에 붙은 감정 태그별 개수 |
+| `monthlyBook` | 이 달의 책으로 선정된 문장과 책. 후보가 없으면 `null` |
+
+### 빈 월 응답
+
+해당 월에 작성한 일기가 0개인 사용자는 리포트 row를 저장하지 않는다.
+조회 시에는 DB row 없이 빈 리포트 응답을 조립한다.
+
+```json
+{
+  "year": 2026,
+  "month": 5,
+  "monthlyQuoteCount": 0,
+  "totalQuoteCount": 5,
+  "mostFrequentBookGenre": "준비중",
+  "emotionTags": [],
+  "monthlyBook": null
+}
+```
+
+빈 월이어도 `totalQuoteCount`는 0으로 고정하지 않는다.
+해당 월 말까지 사용자가 작성한 전체 일기 문장 수를 계산한다.
+
+## DB
+
+리포트는 월 단위 확정 결과이므로 별도 테이블에 저장한다.
+프로젝트 DB 규칙에 따라 Foreign Key는 추가하지 않고 애플리케이션에서 ID로 연결한다.
+
+```sql
+CREATE TABLE monthly_reports (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    report_year INT NOT NULL,
+    report_month INT NOT NULL,
+    monthly_quote_count INT NOT NULL,
+    total_quote_count INT NOT NULL,
+    top_emotion_tag_id BIGINT,
+    top_emotion_tag_label VARCHAR(100),
+    selected_quote_id BIGINT,
+    selected_quote_content TEXT,
+    selected_book_id BIGINT,
+    selected_book_title VARCHAR(255),
+    selected_book_author VARCHAR(255),
+    selected_book_cover_image_url TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX monthly_reports_user_month_uidx
+    ON monthly_reports (user_id, report_year, report_month);
+
+CREATE INDEX monthly_reports_user_id_idx
+    ON monthly_reports (user_id);
+```
+
+```sql
+CREATE TABLE monthly_report_emotion_tags (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    monthly_report_id BIGINT NOT NULL,
+    tag_id BIGINT NOT NULL,
+    tag_label VARCHAR(100) NOT NULL,
+    tag_count INT NOT NULL,
+    sort_order INT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX monthly_report_emotion_tags_report_tag_uidx
+    ON monthly_report_emotion_tags (monthly_report_id, tag_id);
+```
+
+## 집계 기준
+
+월 범위는 `YearMonth`로 계산한다.
+
+```text
+start = year-month-01 00:00:00
+end = next-month-01 00:00:00
+```
+
+집계 대상 일기는 다음 조건을 만족해야 한다.
+
+- `diaries.user_id = 요청 사용자 또는 생성 대상 사용자`
+- `diaries.created_at >= start`
+- `diaries.created_at < end`
+- `diaries.deleted_at IS NULL`
+
+### 월 문장 수
+
+`monthlyQuoteCount`는 해당 월 삭제되지 않은 일기 row 수다.
+같은 문장을 여러 일기에 사용했다면 여러 번 만난 것으로 센다.
+
+### 전체 문장 수
+
+`totalQuoteCount`는 해당 월 말까지 삭제되지 않은 일기 row 누적 수다.
+
+```text
+diaries.created_at < next-month-01 00:00:00
+```
+
+### 이 달의 감정태그
+
+감정태그는 문장 메타데이터 기준으로 집계한다.
+사용자가 추천 요청 때 선택한 `daily_recommendation_tags`가 아니라, 최종 선택 문장의 `quote_metadata_tags`를 사용한다.
+
+```text
+diaries.quote_id
+-> quote_metadata.quote_id
+-> quote_metadata_tags.quote_metadata_id
+-> tags.id
+```
+
+`tags.type = 'EMOTION'`인 태그만 집계한다.
+한 문장에 감정태그가 여러 개 있으면 각 태그 count를 1씩 증가시킨다.
+
+정렬 기준은 다음 순서로 고정한다.
+
+```text
+tag_count DESC
+tags.sort_order ASC
+tags.id ASC
+```
+
+### 이 달의 책
+
+이 달의 책은 가장 많이 등장한 감정태그에 해당하는 문장 후보 중 1개를 리포트 생성 시 랜덤으로 선정한다.
+선정된 quote와 book 정보는 `monthly_reports`에 스냅샷으로 저장한다.
+
+리포트를 여러 번 조회하거나 스케줄러가 재실행되어도 이미 저장된 이 달의 책은 바꾸지 않는다.
+감정태그 후보가 없으면 `monthlyBook`은 `null`이다.
+
+## 스케줄러
+
+`@EnableScheduling`을 활성화하고 매월 1일 새벽에 지난달 리포트를 생성한다.
+
+```kotlin
+@Scheduled(cron = "0 0 3 1 * *", zone = "Asia/Seoul")
+```
+
+스케줄러는 다음 순서로 동작한다.
+
+1. 지난달 `YearMonth`를 계산한다.
+2. 월 단위 PostgreSQL advisory lock을 획득한다.
+3. lock 획득에 실패하면 현재 인스턴스는 작업하지 않고 종료한다.
+4. 지난달 일기가 있는 사용자 ID를 page 단위로 조회한다.
+5. 사용자별로 월간 리포트를 생성한다.
+6. 이미 생성된 `(user_id, report_year, report_month)` row는 건너뛴다.
+
+전체 사용자를 하나의 트랜잭션으로 묶지 않는다.
+사용자 1명의 리포트 생성 단위를 하나의 트랜잭션으로 처리해 중간 실패 후 재실행이 가능하게 한다.
+
+## 멱등성과 복구
+
+스케줄러는 여러 번 실행되어도 같은 월 리포트를 중복 생성하면 안 된다.
+이를 위해 `(user_id, report_year, report_month)` unique index를 최종 방어선으로 둔다.
+
+리포트 생성 repository는 이미 존재하는 리포트를 덮어쓰지 않는다.
+`ON CONFLICT DO NOTHING` 또는 사전 존재 확인 후 skip 방식을 사용한다.
+
+스케줄러 실패로 과거 월에 일기가 있는데 리포트 row가 없다면 조회 API에서 즉시 생성해 복구한다.
+이때도 동일한 unique index와 생성 로직을 사용하므로 scheduler와 조회 요청이 동시에 들어와도 중복 생성되지 않아야 한다.
+
+## 구현 순서
+
+1. Flyway migration을 추가한다.
+   - `monthly_reports`
+   - `monthly_report_emotion_tags`
+   - unique index와 조회 인덱스
+2. report 도메인 모델과 DTO를 만든다.
+   - 월간 리포트 응답
+   - 감정태그 집계 응답
+   - 이 달의 책 응답
+3. repository를 만든다.
+   - 저장된 리포트 조회
+   - 빈 월 판단용 월 일기 수 조회
+   - 월말 기준 전체 일기 수 조회
+   - 감정태그 집계
+   - 이 달의 책 후보 조회
+   - 리포트와 태그 집계 저장
+4. service를 만든다.
+   - 집계 정책
+   - top emotion tag 결정
+   - 이 달의 책 랜덤 선정
+   - 빈 월 응답 생성
+5. usecase를 만든다.
+   - `@Transactional(readOnly = true)` 조회
+   - 누락 리포트 복구 생성은 별도 `@Transactional` 메서드로 분리
+6. controller를 추가한다.
+   - `GET /api/reports/monthly`
+   - `year`, `month` request parameter 검증
+7. scheduler를 추가한다.
+   - 매월 1일 지난달 리포트 생성
+   - advisory lock
+   - page 단위 사용자 처리
+
+## 예외와 경계 조건
+
+현재 월과 미래 월은 조회하지 않는다.
+잘못된 `year`, `month` 값은 기존 `INVALID_INPUT` 응답을 사용한다.
+
+삭제된 일기는 리포트 생성 대상에서 제외한다.
+이미 생성된 리포트는 스냅샷으로 유지한다.
+생성 이후 일기를 삭제했을 때 과거 리포트를 재계산할지는 별도 정책으로 남긴다.
+
+문장 메타데이터가 없는 문장은 감정태그 집계에서 제외한다.
+해당 월에 문장은 있지만 감정태그가 하나도 없으면 `emotionTags`는 빈 배열이고 `monthlyBook`은 `null`이다.
+
+책 장르는 v1에서 `"준비중"`을 반환한다.
+장르 스키마가 추가되면 #102에서 실제 장르 집계로 교체한다.
+
+## 테스트
+
+단위 테스트는 다음 시나리오를 검증한다.
+
+- 해당 월 일기 row 수가 `monthlyQuoteCount`로 집계된다.
+- 같은 날 여러 일기가 있어도 일기 row 수 기준으로 집계된다.
+- `totalQuoteCount`는 해당 월 말 기준 누적 일기 row 수다.
+- 감정태그는 `quote_metadata_tags`와 `tags.type = EMOTION` 기준으로 집계된다.
+- 사용자가 선택한 `daily_recommendation_tags`는 리포트 감정태그 집계에 사용하지 않는다.
+- top 감정태그는 count, sort order, tag id 순서로 결정된다.
+- 이 달의 책은 한 번 저장된 뒤 재조회해도 바뀌지 않는다.
+- 빈 월은 DB row 없이 빈 응답을 반환한다.
+- 스케줄러가 이미 생성된 월 리포트를 중복 생성하지 않는다.
+- 스케줄러 lock 획득 실패 시 작업을 건너뛴다.
+- 과거 월 리포트가 누락된 경우 조회 시 생성해 복구한다.
+
+최종 검증은 다음 명령으로 수행한다.
+
+```bash
+cd app && ./gradlew testClasses
+cd app && ./gradlew test
+cd app && ./gradlew lintKotlin
+cd app && ./gradlew detekt
+```
+
+포맷 수정이 필요한 경우 push 전에 `cd app && ./gradlew formatKotlin`을 실행한다.
+
+## 포트폴리오 어필 포인트
+
+이 기능은 단순 CRUD가 아니라 월 단위 집계 데이터를 안정적으로 확정하는 배치 기능이다.
+다음 내용을 구현 의도와 함께 설명하면 백엔드 포트폴리오에서 강점이 된다.
+
+- 리포트 결과를 실시간 계산하지 않고 월말 스냅샷으로 저장한 이유
+- `daily_recommendations`가 아니라 `diaries.quote_id`를 기준으로 잡은 이유
+- 랜덤으로 뽑는 이 달의 책을 한 번 저장해 결과 일관성을 보장한 점
+- unique index와 conflict 처리로 스케줄러 멱등성을 확보한 점
+- 다중 서버 환경에서 advisory lock을 고려한 점
+- 사용자 단위 트랜잭션으로 중간 실패 후 재실행이 가능하게 한 점
+- 0건 월은 저장하지 않고 조회 시 빈 응답으로 처리해 불필요한 row 증가를 피한 점

--- a/docs/quote-scrap-api.md
+++ b/docs/quote-scrap-api.md
@@ -1,0 +1,138 @@
+# 문장 스크랩 API
+
+## 목표
+
+로그인 사용자가 문장을 스크랩하거나 스크랩을 취소할 수 있게 한다.
+발견탭의 `isScrapped` 값은 이 API가 저장한 `quote_scraps` 데이터를 기준으로 계산한다.
+
+관련 이슈: #100
+
+## API
+
+아래 API 경로는 서버 context-path `/api`를 포함한 공개 경로로 표기한다.
+
+```text
+POST /api/quotes/{quoteId}/scraps
+DELETE /api/quotes/{quoteId}/scraps
+Authorization: Bearer {accessToken}
+```
+
+두 API 모두 본문 없이 호출하고, 성공 시 `204 No Content`를 반환한다.
+
+## 스크랩 생성
+
+```text
+POST /api/quotes/{quoteId}/scraps
+```
+
+정책:
+
+- 로그인 사용자의 `userId`와 path의 `quoteId`로 스크랩을 생성한다.
+- 존재하지 않는 문장은 `QUOTE_NOT_FOUND`로 처리한다.
+- 이미 스크랩한 문장을 다시 요청해도 성공 처리한다.
+- 중복 생성 방지는 `quote_scraps(user_id, quote_id)` unique index와 `ON CONFLICT DO NOTHING`으로 처리한다.
+
+응답:
+
+```text
+204 No Content
+```
+
+## 스크랩 취소
+
+```text
+DELETE /api/quotes/{quoteId}/scraps
+```
+
+정책:
+
+- 로그인 사용자의 `userId`와 path의 `quoteId`에 해당하는 스크랩을 삭제한다.
+- 존재하지 않는 문장은 `QUOTE_NOT_FOUND`로 처리한다.
+- 스크랩하지 않은 문장을 취소해도 성공 처리한다.
+
+응답:
+
+```text
+204 No Content
+```
+
+## DB
+
+스크랩 저장은 `quote_scraps` 테이블을 사용한다.
+이 테이블은 발견탭 조회 API에서 `isScrapped` 계산에도 사용한다.
+
+```sql
+CREATE TABLE IF NOT EXISTS quote_scraps (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    quote_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS quote_scraps_user_quote_uidx
+    ON quote_scraps (user_id, quote_id);
+
+CREATE INDEX IF NOT EXISTS quote_scraps_quote_id_idx
+    ON quote_scraps (quote_id);
+```
+
+프로젝트 DB 규칙에 따라 Foreign Key는 만들지 않는다.
+문장 존재 여부는 usecase에서 `QuoteService.findQuoteById(quoteId)`로 검증한다.
+
+## 레이어 책임
+
+### `QuoteScrapController`
+
+- 인증된 사용자 ID와 path의 `quoteId`를 받는다.
+- 인증 정보가 없으면 `UNAUTHORIZED`를 발생시킨다.
+- 성공 시 `204 No Content`를 반환한다.
+
+### `QuoteScrapUseCase`
+
+- `@Transactional` 경계를 가진다.
+- 문장 존재 여부를 먼저 확인한다.
+- 스크랩 생성 또는 삭제를 service에 위임한다.
+
+### `QuoteScrapService`
+
+- 스크랩 생성/삭제 정책을 표현한다.
+- 중복 생성과 없는 row 삭제를 성공 처리한다.
+
+### `QuoteScrapRepository`
+
+- `insertIgnoreDuplicate(userId, quoteId)`는 `ON CONFLICT DO NOTHING`을 사용한다.
+- `deleteByUserIdAndQuoteId(userId, quoteId)`는 해당 사용자의 스크랩만 삭제한다.
+
+## 발견탭과의 관계
+
+`GET /api/discovery/quotes` 응답의 `isScrapped`는 로그인 사용자 기준으로 계산한다.
+
+```text
+quote_scraps.user_id = 로그인 사용자 ID
+quote_scraps.quote_id = 응답 문장 ID
+```
+
+따라서 스크랩 생성 후 같은 문장이 발견탭 응답에 포함되면 `isScrapped=true`가 된다.
+스크랩 취소 후에는 `isScrapped=false`가 된다.
+
+## 예외와 경계 조건
+
+| 상황 | 처리 |
+|------|------|
+| access token 없음, 만료, 위조 | 인증 에러 응답 |
+| `quoteId` 문장이 없음 | `QUOTE_NOT_FOUND` |
+| 이미 스크랩한 문장 생성 요청 | 성공, `204 No Content` |
+| 스크랩하지 않은 문장 삭제 요청 | 성공, `204 No Content` |
+| 다른 사용자의 스크랩 | 삭제 대상 아님 |
+
+## 테스트
+
+다음 시나리오를 검증한다.
+
+- 문장이 존재하면 스크랩을 생성한다.
+- 이미 스크랩한 문장 생성 요청도 성공 처리한다.
+- 문장이 존재하면 스크랩을 취소한다.
+- 존재하지 않는 스크랩 취소 요청도 성공 처리한다.
+- 존재하지 않는 문장에 대한 생성/삭제 요청은 `QUOTE_NOT_FOUND`로 실패한다.
+- repository 생성 쿼리에 `ON CONFLICT DO NOTHING`이 포함된다.
+- repository 삭제 쿼리는 `user_id`, `quote_id`를 함께 조건으로 사용한다.

--- a/docs/terraform-dev-infra.md
+++ b/docs/terraform-dev-infra.md
@@ -1,0 +1,118 @@
+# Terraform dev 인프라
+
+## 목표
+
+dev 환경의 GCP 인프라를 Terraform으로 관리한다.
+수동으로 생성한 리소스와 코드 상태가 어긋나지 않도록, 변경 전에는 항상 plan을 확인한다.
+
+관련 이슈: #3, #42, #74
+
+## 작업 디렉터리
+
+```bash
+cd infra/terraform/dev
+```
+
+dev state는 GCS backend를 사용한다.
+
+```hcl
+backend "gcs" {
+  bucket = "firstpenguin-tf-state"
+  prefix = "terraform/dev"
+}
+```
+
+`terraform.tfstate`와 `.terraform/` 산출물은 커밋하지 않는다.
+
+## 기본 변수
+
+| 변수 | 기본값 또는 정책 |
+|------|------------------|
+| `project_id` | `project-10e57bb0-e960-4b16-9fa` |
+| `region` | `asia-northeast3` |
+| `zone` | `asia-northeast3-a` |
+| `env` | `dev` |
+| `service_name` | `firstpenguin` |
+| `machine_type` | `e2-medium` |
+
+리소스 이름은 `{env}-{service_name}-{resource}` 형식을 따른다.
+
+## 주요 리소스
+
+| 종류 | 이름 |
+|------|------|
+| VPC | `dev-firstpenguin-vpc` |
+| Public Subnet | `dev-firstpenguin-subnet-public` (`10.0.1.0/24`) |
+| Private Subnet | `dev-firstpenguin-subnet-private` (`10.0.10.0/24`) |
+| Static IP | `dev-firstpenguin-ip-api` |
+| VM | `dev-firstpenguin-vm-api` |
+| API Service Account | `dev-firstpenguin-api-sa` |
+| Image Bucket | `dev-firstpenguin-images` |
+
+VM은 Ubuntu 24.04 LTS, 30GB SSD boot disk를 사용한다.
+VM에는 `api-server`, `db-server` network tag를 부여한다.
+
+## 방화벽
+
+| 규칙 | 대상 태그 | 허용 |
+|------|-----------|------|
+| SSH | `api-server` | TCP 22 |
+| App | `api-server` | TCP 8080 |
+| PostgreSQL | `db-server` | TCP 5432 |
+| ICMP | `api-server` | ICMP |
+| Internal | 전체 내부 대역 | TCP/UDP/ICMP, `10.0.0.0/16` |
+
+PostgreSQL 5432는 현재 dev 운영 편의를 위해 열려 있다.
+운영 환경에서는 접근 source range를 제한하거나 private 접근 구조로 전환한다.
+
+## SSH 키
+
+VM metadata에는 project SSH key를 차단하고, `ssh_public_keys` 변수로 전달한 키만 등록한다.
+
+```hcl
+block-project-ssh-keys = "true"
+```
+
+SSH 키를 바꾸면 `terraform.tfvars`를 수정한 뒤 plan을 확인하고 apply한다.
+
+## 이미지 버킷
+
+이미지 버킷은 public object 조회를 전제로 운영한다.
+
+| 항목 | 정책 |
+|------|------|
+| bucket | `dev-firstpenguin-images` |
+| location | `asia-northeast3` |
+| uniform bucket-level access | enabled |
+| public read | `allUsers roles/storage.objectViewer` |
+| API service account | `roles/storage.objectAdmin` |
+| CORS origin | `https://dev.senti.today`, `http://localhost:3000` |
+| CORS method | `GET`, `PUT` |
+
+presigned URL 발급에는 서비스 계정 서명이 필요하다.
+이를 위해 API 서비스 계정에 자기 자신에 대한 `roles/iam.serviceAccountTokenCreator`를 부여하고, 프로젝트 API로 `iamcredentials.googleapis.com`을 활성화한다.
+
+## 실행 순서
+
+변경 전 항상 plan을 먼저 확인한다.
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+원격 state를 사용하므로 동시에 여러 사람이 apply하지 않는다.
+apply 결과로 VM 외부 IP, VM 이름, VPC 이름을 output으로 확인할 수 있다.
+
+```bash
+terraform output
+```
+
+## 주의사항
+
+- `terraform.tfstate`, `terraform.tfstate.backup`, `.terraform/` 산출물은 커밋하지 않는다.
+- GCS backend bucket은 Terraform이 관리하는 리소스가 아니라 선행 준비 리소스다.
+- public image bucket에는 민감한 이미지를 업로드하지 않는다.
+- apply 전에는 변경 대상 리소스가 dev 환경인지 확인한다.
+- prod 환경은 별도 디렉터리에서 dev와 분리해 관리한다.

--- a/docs/user-profile-api.md
+++ b/docs/user-profile-api.md
@@ -1,0 +1,150 @@
+# 사용자 프로필 API
+
+## 목표
+
+로그인 사용자가 내 정보를 조회하고, 닉네임 또는 프로필 이미지를 수정할 수 있게 한다.
+
+관련 이슈: #76
+
+## API
+
+아래 API 경로는 서버 context-path `/api`를 포함한 공개 경로로 표기한다.
+
+```text
+GET /api/users/me
+PATCH /api/users/me
+Authorization: Bearer {accessToken}
+```
+
+두 API 모두 로그인 사용자만 호출할 수 있다.
+
+## 내 정보 조회
+
+```text
+GET /api/users/me
+```
+
+응답:
+
+```json
+{
+  "id": 1,
+  "email": "user@example.com",
+  "nickname": "책읽는펭귄",
+  "profileImageUrl": "https://cdn.example.com/profile.png"
+}
+```
+
+| 필드 | 설명 |
+|------|------|
+| `id` | 사용자 ID |
+| `email` | OAuth provider에서 제공한 이메일. 제공되지 않으면 `null` |
+| `nickname` | 서비스에서 사용하는 사용자 닉네임 |
+| `profileImageUrl` | `users.profile_image_id`로 연결된 이미지 URL. 연결된 이미지가 없으면 `null` |
+
+`profileImageUrl`은 `images.url`을 조회해서 응답에 포함한다.
+클라이언트는 `profileImageId`가 아니라 조회 가능한 URL만 받는다.
+
+## 내 프로필 수정
+
+```text
+PATCH /api/users/me
+Content-Type: application/json
+```
+
+요청:
+
+```json
+{
+  "nickname": "새닉네임",
+  "profileImageId": 42
+}
+```
+
+| 필드 | 설명 |
+|------|------|
+| `nickname` | 변경할 닉네임. `null`이면 변경하지 않음 |
+| `profileImageId` | 변경할 프로필 이미지 ID. `null`이면 변경하지 않음 |
+
+`nickname`, `profileImageId` 중 하나 이상은 반드시 포함해야 한다.
+두 값이 모두 `null`이면 `INVALID_INPUT`으로 처리한다.
+
+`null` 필드는 변경하지 않는다.
+따라서 현재 API로는 프로필 이미지를 제거할 수 없다.
+
+응답은 수정 후 `UserResponse`를 반환한다.
+
+```json
+{
+  "id": 1,
+  "email": "user@example.com",
+  "nickname": "새닉네임",
+  "profileImageUrl": "https://cdn.example.com/profile.png"
+}
+```
+
+## 프로필 이미지 변경 흐름
+
+프로필 이미지는 이미지 업로드 공통 흐름을 사용한다.
+
+```text
+POST /api/images/presigned-url
+body: { "type": "USER_PROFILE", "contentType": "image/webp" }
+<- { "presignedUrl": "...", "imageId": 42 }
+
+클라이언트가 presignedUrl로 GCS PUT 업로드
+
+PATCH /api/users/me
+body: { "profileImageId": 42 }
+```
+
+`profileImageId`는 서버가 발급한 `imageId`여야 한다.
+존재하지 않는 이미지 ID를 전달하면 `INVALID_INPUT`으로 처리한다.
+
+자세한 이미지 정책은 `docs/image-policy.md`를 따른다.
+
+## 닉네임 정책
+
+닉네임은 공백 문자열을 허용하지 않는다.
+예약 닉네임은 사용할 수 없다.
+현재 예약 닉네임은 다음과 같다.
+
+```text
+개발자
+```
+
+다른 사용자가 이미 사용 중인 닉네임으로 변경하면 `NICKNAME_ALREADY_EXISTS`로 처리한다.
+사전 중복 조회를 통과해도 동시에 같은 닉네임으로 변경될 수 있으므로, 최종 방어는 `users.nickname` unique 제약과 `DuplicateKeyException` 변환으로 처리한다.
+
+## OAuth 닉네임과의 관계
+
+OAuth provider에서 내려준 표시 이름은 서비스 닉네임을 덮어쓰지 않는다.
+신규 가입 시 서비스 닉네임은 랜덤 닉네임 생성 정책으로 만든다.
+provider 표시 이름은 `provider_display_name`에 별도로 저장한다.
+
+기존 사용자가 다시 로그인해도 `users.nickname`은 유지된다.
+닉네임 변경은 `PATCH /api/users/me`에서만 수행한다.
+
+## 예외와 경계 조건
+
+| 상황 | 처리 |
+|------|------|
+| access token 없음, 만료, 위조 | 인증 에러 응답 |
+| `nickname`, `profileImageId` 모두 `null` | `INVALID_INPUT` |
+| `nickname` blank 또는 예약 닉네임 | `INVALID_INPUT` |
+| `nickname` 중복 | `NICKNAME_ALREADY_EXISTS` |
+| `profileImageId`가 존재하지 않음 | `INVALID_INPUT` |
+| 프로필 이미지 제거 요청 | 현재 미지원. `null`은 변경 없음으로 처리 |
+
+## 테스트
+
+다음 시나리오를 검증한다.
+
+- 내 정보 조회 시 `profileImageId`가 있으면 `profileImageUrl`을 응답한다.
+- `PATCH /api/users/me`는 닉네임만 변경할 수 있다.
+- `PATCH /api/users/me`는 프로필 이미지만 변경할 수 있다.
+- 두 필드가 모두 `null`이면 실패한다.
+- 존재하지 않는 `profileImageId`면 실패한다.
+- 공백 또는 예약 닉네임이면 실패한다.
+- 이미 사용 중인 닉네임이면 실패한다.
+- unique 충돌이 발생해도 `NICKNAME_ALREADY_EXISTS`로 변환한다.


### PR DESCRIPTION
## 작업 내용

### 발견탭 장르 필터 추가
- `GET /discovery/quotes`에 선택 파라미터 `genre`를 추가했습니다.
- `genre`가 없거나 `전체`이면 기존처럼 전체 문장을 조회합니다.
- `genre`가 지정되면 `books.category` 값을 기준으로 발견탭 문장 목록을 필터링합니다.
- DB 컬럼은 현재 `category`이지만, 프론트/API 명세에서는 도메인 표현에 맞춰 `genre`로 노출합니다.

### 지원 장르
- 전체
- 한국소설
- 일본소설
- 영미소설
- 판타지
- 고전문학
- 인문
- 철학
- 에세이•시
- 영화•드라마 원작

### 응답 및 Swagger 정리
- 발견탭 문장 응답에 책 장르 값 `genre`를 추가했습니다.
- Swagger에 `genre` 파라미터 설명과 허용 값을 명시했습니다.
- 커서 기반 페이지네이션은 기존 방식대로 유지하며, 장르 변경 시 클라이언트는 첫 페이지부터 다시 조회하는 흐름을 전제로 합니다.

### 문서 정리
- 기존에 진행한 API/인증/이미지/배포/발견탭/월간 리포트/프로필/인프라 관련 문서를 보강했습니다.
- 발견탭 무한스크롤 전환과 장르 필터 구현 과정을 별도 문서로 정리했습니다.

## 구현 상세
- `DiscoveryGenre`에서 요청 문자열을 허용 장르 enum으로 파싱합니다.
- `전체`, 빈 문자열, 미전달 값은 필터 없음으로 처리합니다.
- 허용되지 않은 장르는 `INVALID_INPUT` 예외로 처리합니다.
- `BookTable.CATEGORY`를 추가해 `books.category` 컬럼을 jOOQ 쿼리에서 사용할 수 있게 했습니다.
- `DiscoveryRepository`에서 장르가 있을 때만 `books.category = ?` 조건을 추가합니다.

## 테스트
- 장르가 없을 때 기존 전체 조회 흐름 유지
- `전체` 입력 시 전체 조회 처리
- 유효한 장르 입력 시 서비스/repository까지 필터 전달
- 커서와 장르를 함께 전달하는 조회 흐름
- 유효하지 않은 장르 입력 시 `INVALID_INPUT` 예외
- repository SQL에 `books.category` 조건이 추가되는지 확인

## 검증
- `./gradlew formatKotlin`
- `./gradlew test --tests 'com.firstpenguin.app.domain.discovery.*' lintKotlin detekt`
- push hook: `./gradlew test`
- CodeRabbit: 0 issues

Closes #108
