### PR TITLE
[Feature] 추천 엔진 도메인 모델 정리

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/model/Tag.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/model/Tag.kt
@@ -6,6 +6,7 @@ import java.time.LocalDateTime
 data class Tag(
     val id: Long,
     val emotionRangeId: Long?,
+    val code: String,
     val label: String,
     val type: TagType,
     val createdAt: LocalDateTime,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/repository/TagRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/repository/TagRepository.kt
@@ -102,6 +102,7 @@ class TagRepository(
         Tag(
             id = record[TagTable.ID]!!,
             emotionRangeId = record[TagTable.EMOTION_RANGE_ID],
+            code = record[TagTable.CODE]!!,
             label = record[TagTable.LABEL]!!,
             type = TagType.from(record[TagTable.TYPE]!!),
             createdAt = record[TagTable.CREATED_AT]!!,
@@ -120,6 +121,7 @@ class TagRepository(
         listOf(
             TagTable.ID,
             TagTable.EMOTION_RANGE_ID,
+            TagTable.CODE,
             TagTable.LABEL,
             TagTable.TYPE,
             TagTable.CREATED_AT,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quote/service/QuoteService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quote/service/QuoteService.kt
@@ -14,7 +14,7 @@ class QuoteService(
 ) {
     fun findQuoteById(id: Long): Quote =
         quoteRepository.findQuoteById(id)
-            ?: throw CustomException(ErrorCode.NOT_FOUND)
+            ?: throw CustomException(ErrorCode.QUOTE_NOT_FOUND)
 
     fun getRandomQuote(): Quote = getRandomQuoteExcludingIds(emptyList())
 

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quotecreation/service/QuoteCreationBatchService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quotecreation/service/QuoteCreationBatchService.kt
@@ -10,8 +10,6 @@ import com.firstpenguin.app.domain.quotebatch.repository.QuoteBatchItemRepositor
 import com.firstpenguin.app.domain.quotebatch.repository.QuoteBatchJobRepository
 import com.firstpenguin.app.domain.quotecreation.review.repository.QuoteCandidateRepository
 import com.firstpenguin.app.global.enums.BatchItemStatus
-import com.firstpenguin.app.global.exception.CustomException
-import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.stereotype.Service
 
 @Service
@@ -78,15 +76,5 @@ class QuoteCreationBatchService(
             status = BatchItemStatus.FAILED,
             errorMessage = errorMessage,
         )
-    }
-
-    fun validateNoRunningJob() {
-        if (quoteBatchJobRepository.isRunningQuoteBatchJob(RUNNING_BLOCKED_JOB_TYPES)) {
-            throw CustomException(ErrorCode.QUOTE_BATCH_JOB_IS_RUNNING)
-        }
-    }
-
-    private companion object {
-        private val RUNNING_BLOCKED_JOB_TYPES = QuoteBatchType.entries.toList()
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quotecreation/usecase/QuoteCreationBatchCommandUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quotecreation/usecase/QuoteCreationBatchCommandUseCase.kt
@@ -25,7 +25,6 @@ class QuoteCreationBatchCommandUseCase(
 ) {
     @Transactional
     fun prepareExtractionBatch(limit: Int): PreparedQuoteExtractionBatch {
-        batchService.validateNoRunningJob()
         val books = batchService.getBooksNeedingQuotes(limit = limit)
         if (books.isEmpty()) throw CustomException(ErrorCode.QUOTE_EXTRACTION_BATCH_TARGET_NOT_FOUND)
 
@@ -47,7 +46,6 @@ class QuoteCreationBatchCommandUseCase(
 
     @Transactional
     fun prepareCandidateReviewBatch(limit: Int): PreparedCandidateReviewBatch {
-        batchService.validateNoRunningJob()
         val targets = batchService.getPendingTargets(limit = limit)
         if (targets.isEmpty()) throw CustomException(ErrorCode.QUOTE_REVIEW_BATCH_TARGET_NOT_FOUND)
         return createPreparedReviewBatch(targets)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/service/QuoteMetadataBatchService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/service/QuoteMetadataBatchService.kt
@@ -12,8 +12,6 @@ import com.firstpenguin.app.domain.quotemetadata.dto.TagOption
 import com.firstpenguin.app.domain.quotemetadata.repository.QuoteMetadataRepository
 import com.firstpenguin.app.global.enums.BatchItemStatus
 import com.firstpenguin.app.global.enums.TagType
-import com.firstpenguin.app.global.exception.CustomException
-import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.stereotype.Service
 
 @Service
@@ -77,14 +75,7 @@ class QuoteMetadataBatchService(
         )
     }
 
-    fun validateNoRunningJob() {
-        if (quoteBatchJobRepository.isRunningQuoteBatchJob(RUNNING_BLOCKED_JOB_TYPES)) {
-            throw CustomException(ErrorCode.QUOTE_BATCH_JOB_IS_RUNNING)
-        }
-    }
-
     private companion object {
         const val QUOTE_CUSTOM_ID_PREFIX = "quote"
-        private val RUNNING_BLOCKED_JOB_TYPES = QuoteBatchType.entries.toList()
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/usecase/QuoteMetadataBatchCommandUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/usecase/QuoteMetadataBatchCommandUseCase.kt
@@ -22,8 +22,6 @@ class QuoteMetadataBatchCommandUseCase(
 ) {
     @Transactional
     fun prepareBatch(limit: Int): PreparedQuoteMetadataBatch {
-        quoteMetadataBatchService.validateNoRunningJob()
-
         val pendingQuotes = quoteMetadataBatchService.getPendingQuotes(limit = limit)
         if (pendingQuotes.isEmpty()) {
             throw CustomException(ErrorCode.QUOTE_METADATA_BATCH_TARGET_NOT_FOUND)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/AnalyzedUserIntent.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/AnalyzedUserIntent.kt
@@ -1,0 +1,8 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+data class AnalyzedUserIntent(
+    val input: RecommendationInput,
+    val type: IntentType,
+    val queryText: String?,
+    val tagCandidates: List<TagCandidate> = emptyList(),
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/EffectiveTag.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/EffectiveTag.kt
@@ -1,0 +1,9 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+import com.firstpenguin.app.global.enums.TagType
+
+data class EffectiveTag(
+    val tagId: Long,
+    val type: TagType,
+    val weight: Double = 1.0,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/EffectiveTagPolicy.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/EffectiveTagPolicy.kt
@@ -1,0 +1,30 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+@Suppress("MagicNumber")
+object EffectiveTagPolicy {
+    val sourceWeights: Map<TagCandidateSource, Double> =
+        mapOf(
+            TagCandidateSource.USER_SELECTED to 1.0,
+            TagCandidateSource.FEELING_TEXT to 0.85,
+            TagCandidateSource.DIARY_TEXT to 0.55,
+        )
+
+    val priorityWeights: Map<TagCandidatePriority, Double> =
+        mapOf(
+            TagCandidatePriority.PRIMARY to 1.0,
+            TagCandidatePriority.SECONDARY to 0.65,
+            TagCandidatePriority.BACKGROUND to 0.3,
+        )
+
+    fun effectiveImportance(candidate: TagCandidate): Double =
+        sourceWeights.getValue(candidate.source) *
+            priorityWeights.getValue(candidate.priority) *
+            candidate.confidence.coerceIn(0.0, 1.0)
+
+    fun toEffectiveTag(candidate: TagCandidate): EffectiveTag =
+        EffectiveTag(
+            tagId = candidate.tagId,
+            type = candidate.type,
+            weight = effectiveImportance(candidate),
+        )
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/IntentFocusWeightPolicy.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/IntentFocusWeightPolicy.kt
@@ -1,0 +1,49 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+import com.firstpenguin.app.global.enums.TagType
+
+@Suppress("MagicNumber")
+object IntentFocusWeightPolicy {
+    val weights: Map<IntentType, Map<TagType, Double>> =
+        mapOf(
+            IntentType.CONTEXT_BASED to
+                mapOf(
+                    TagType.CONTEXT to 0.40,
+                    TagType.MOOD to 0.25,
+                    TagType.NEED to 0.20,
+                    TagType.EMOTION to 0.05,
+                    TagType.SITUATION to 0.10,
+                ),
+            IntentType.EMOTION_NEED_BASED to
+                mapOf(
+                    TagType.NEED to 0.35,
+                    TagType.EMOTION to 0.30,
+                    TagType.MOOD to 0.15,
+                    TagType.SITUATION to 0.10,
+                    TagType.CONTEXT to 0.10,
+                ),
+            IntentType.SITUATION_BASED to
+                mapOf(
+                    TagType.SITUATION to 0.35,
+                    TagType.NEED to 0.25,
+                    TagType.EMOTION to 0.15,
+                    TagType.MOOD to 0.15,
+                    TagType.CONTEXT to 0.10,
+                ),
+            IntentType.MIXED to
+                mapOf(
+                    TagType.NEED to 0.30,
+                    TagType.EMOTION to 0.25,
+                    TagType.CONTEXT to 0.20,
+                    TagType.MOOD to 0.15,
+                    TagType.SITUATION to 0.10,
+                ),
+        )
+
+    fun weightsOf(intentType: IntentType): Map<TagType, Double> = weights.getValue(intentType)
+
+    fun weightOf(
+        intentType: IntentType,
+        tagType: TagType,
+    ): Double = weightsOf(intentType)[tagType] ?: 0.0
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/IntentType.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/IntentType.kt
@@ -1,0 +1,8 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+enum class IntentType {
+    CONTEXT_BASED,
+    EMOTION_NEED_BASED,
+    SITUATION_BASED,
+    MIXED,
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RankedRecommendationQuote.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RankedRecommendationQuote.kt
@@ -3,7 +3,7 @@ package com.firstpenguin.app.domain.recommendation.model
 data class RankedRecommendationQuote(
     val rank: Int,
     val candidate: RecommendationCandidate,
-    val score: Double,
+    val score: RecommendationScoreBreakdown,
 ) {
     val quoteId: Long
         get() = candidate.quoteId

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RankedRecommendationQuote.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RankedRecommendationQuote.kt
@@ -1,0 +1,10 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+data class RankedRecommendationQuote(
+    val rank: Int,
+    val candidate: RecommendationCandidate,
+    val score: Double,
+) {
+    val quoteId: Long
+        get() = candidate.quoteId
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationCandidate.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationCandidate.kt
@@ -1,8 +1,13 @@
 package com.firstpenguin.app.domain.recommendation.model
 
+import com.firstpenguin.app.global.enums.TagType
+
 data class RecommendationCandidate(
     val quoteId: Long,
-    val score: Double,
-    val effectiveTags: List<EffectiveTag> = emptyList(),
-    val reason: String? = null,
+    val bookId: Long,
+    val content: String,
+    val title: String,
+    val author: String,
+    val roleTagId: Long?,
+    val tagIdsByType: Map<TagType, Set<Long>>,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationCandidate.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationCandidate.kt
@@ -1,0 +1,8 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+data class RecommendationCandidate(
+    val quoteId: Long,
+    val score: Double,
+    val effectiveTags: List<EffectiveTag> = emptyList(),
+    val reason: String? = null,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationInput.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationInput.kt
@@ -1,10 +1,13 @@
 package com.firstpenguin.app.domain.recommendation.model
 
+import com.firstpenguin.app.domain.emotion.model.Tag
+
 data class RecommendationInput(
     val userId: Long,
     val emotionRangeId: Long,
-    val emotionTagIds: List<Long>,
-    val needTagId: Long?,
+    val emotionTags: List<Tag>,
+    val needTag: Tag?,
     val feelingText: String?,
     val diaryText: String?,
+    val analysis: UserInputAnalysis?,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationInput.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationInput.kt
@@ -1,0 +1,10 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+data class RecommendationInput(
+    val userId: Long,
+    val emotionRangeId: Long,
+    val emotionTagIds: List<Long>,
+    val needTagId: Long?,
+    val feelingText: String?,
+    val diaryText: String?,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationResult.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationResult.kt
@@ -1,0 +1,6 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+data class RecommendationResult(
+    val mainQuote: RankedRecommendationQuote,
+    val quotes: List<RankedRecommendationQuote>,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationScoreBreakdown.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationScoreBreakdown.kt
@@ -1,0 +1,12 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+data class RecommendationScoreBreakdown(
+    val needScore: Double,
+    val emotionScore: Double,
+    val contextScore: Double,
+    val situationScore: Double,
+    val moodScore: Double,
+    val metadataScore: Double,
+    val semanticScore: Double,
+    val finalScore: Double,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/TagCandidate.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/TagCandidate.kt
@@ -4,10 +4,10 @@ import com.firstpenguin.app.global.enums.TagType
 
 data class TagCandidate(
     val tagId: Long,
+    val code: String,
+    val label: String,
     val type: TagType,
     val source: TagCandidateSource,
     val priority: TagCandidatePriority,
     val confidence: Double,
-    val label: String? = null,
-    val reason: String? = null,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/TagCandidate.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/TagCandidate.kt
@@ -1,0 +1,13 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+import com.firstpenguin.app.global.enums.TagType
+
+data class TagCandidate(
+    val tagId: Long,
+    val type: TagType,
+    val source: TagCandidateSource,
+    val priority: TagCandidatePriority,
+    val confidence: Double,
+    val label: String? = null,
+    val reason: String? = null,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/TagCandidatePriority.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/TagCandidatePriority.kt
@@ -1,0 +1,7 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+enum class TagCandidatePriority {
+    PRIMARY,
+    SECONDARY,
+    BACKGROUND,
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/TagCandidateSource.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/TagCandidateSource.kt
@@ -1,0 +1,7 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+enum class TagCandidateSource {
+    USER_SELECTED,
+    FEELING_TEXT,
+    DIARY_TEXT,
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/UserInputAnalysis.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/UserInputAnalysis.kt
@@ -1,0 +1,7 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+data class UserInputAnalysis(
+    val intentType: IntentType,
+    val canonicalIntent: String?,
+    val tagCandidates: List<TagCandidate>,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
@@ -62,6 +62,7 @@ enum class ErrorCode(
 
     // Quote
     NOT_ENOUGH_QUOTES(HttpStatus.CONFLICT, "추천 가능한 문장이 부족합니다."),
+    QUOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "문장을 찾을 수 없습니다."),
 
     // OpenAi
     BATCH_ADMIN_SECRET_REQUIRED(HttpStatus.INTERNAL_SERVER_ERROR, "배치 관리자 secret 설정이 누락되었습니다."),

--- a/app/src/main/resources/db/migration/V46__alter_daily_recommendations_rules.sql
+++ b/app/src/main/resources/db/migration/V46__alter_daily_recommendations_rules.sql
@@ -4,6 +4,7 @@ DROP INDEX IF EXISTS daily_recommendation_quotes_quote_id_idx;
 DROP INDEX IF EXISTS daily_recommendation_quotes_recommendation_quote_uidx;
 DROP INDEX IF EXISTS daily_recommendation_quotes_recommendation_display_order_uidx;
 DROP INDEX IF EXISTS daily_recommendation_tags_recommendation_tag_uidx;
+DROP INDEX IF EXISTS quote_batch_jobs_single_running_uidx;
 
 ALTER TABLE daily_recommendations
     RENAME COLUMN selected_emotion_range_id TO emotion_range_id;


### PR DESCRIPTION
## 배경 / 문제
추천 런타임을 metadata score, semantic score, top 10 후보 저장 방식으로 확장하려면 현재 ID 중심 요청 모델만으로는 추천 엔진 내부 입력과 후보 점수 계산을 표현하기 어렵습니다.

## 구현 내용
- `RecommendationInput`을 추천 엔진 입력용 모델로 정리합니다.
- `Tag` 모델에 `code`를 추가해 선택 태그를 코드/ID 모두로 사용할 수 있게 합니다.
- `RecommendationCandidate`를 실제 scoring 가능한 후보 모델로 확장합니다.
  - `quoteId`
  - `bookId`
  - `content`
  - `title`
  - `author`
  - `roleTagId`
  - `tagIdsByType`
- `RecommendationScoreBreakdown`은 avoid 관련 필드 없이 유지합니다.
- top 10 추천 결과를 담는 `RecommendationResult` 모델을 추가합니다.

## 기대 효과
- 후속 `EffectiveTagBuilder`, `MetadataScorer`, `RecommendationRanker`가 공통 모델을 기준으로 구현될 수 있습니다.
- 추천 후보 조회 결과와 점수 계산 결과를 명확하게 분리할 수 있습니다.
- avoid tag/avoid penalty 없이 현재 추천 정책에 맞는 모델 기반을 만들 수 있습니다.

## 영향 범위
- Domain: `recommendation.model`, `emotion.model`
- API: 없음
- DB: 없음
- Client: 없음

## 작업 유형
새로운 기능

## 참고 자료
- quote metadata 기반 추천 런타임 설계
- avoidTag는 이번 추천 정책에서 제외

## 체크리스트
- [x] 중복 이슈가 없는지 확인했습니다.
- [x] 문제와 기대 효과를 명확히 작성했습니다.