### PR TITLE
feat: 추천 metadata scoring 및 메타정보 배치 대상 제한

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/repository/QuoteMetadataRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/repository/QuoteMetadataRepository.kt
@@ -27,7 +27,7 @@ class QuoteMetadataRepository(
         dsl
             .selectCount()
             .from(QuoteTable.QUOTES)
-            .where(QuoteTable.DELETED_AT.isNull)
+            .where(batchTargetQuoteCondition())
             .fetchOne(0, Int::class.java) ?: 0
 
     fun countCreatedMetadata(): Int =
@@ -36,14 +36,14 @@ class QuoteMetadataRepository(
             .from(QuoteMetadataTable.QUOTE_METADATA)
             .join(QuoteTable.QUOTES)
             .on(QuoteTable.ID.eq(QuoteMetadataTable.QUOTE_ID))
-            .where(QuoteTable.DELETED_AT.isNull)
+            .where(batchTargetQuoteCondition())
             .fetchOne(0, Int::class.java) ?: 0
 
     fun countPendingQuotes(): Int =
         dsl
             .selectCount()
             .from(QuoteTable.QUOTES)
-            .where(QuoteTable.DELETED_AT.isNull)
+            .where(batchTargetQuoteCondition())
             .and(metadataNotExists())
             .and(activeBatchItemNotExists())
             .fetchOne(0, Int::class.java) ?: 0
@@ -52,7 +52,7 @@ class QuoteMetadataRepository(
         dsl
             .select(QUOTE_FIELDS)
             .from(QuoteTable.QUOTES)
-            .where(QuoteTable.DELETED_AT.isNull)
+            .where(batchTargetQuoteCondition())
             .and(metadataNotExists())
             .and(activeBatchItemNotExists())
             .orderBy(QuoteTable.ID.asc())
@@ -177,3 +177,8 @@ class QuoteMetadataRepository(
             )
     }
 }
+
+private fun batchTargetQuoteCondition() =
+    QuoteTable.DELETED_AT
+        .isNull
+        .and(QuoteTable.SOURCE_TYPE.eq(QuoteSourceType.BOOK_INSPIRED.name))

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorer.kt
@@ -1,0 +1,144 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.IntentType
+import com.firstpenguin.app.domain.recommendation.model.RankedRecommendationQuote
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
+import com.firstpenguin.app.domain.recommendation.model.RecommendationScoreBreakdown
+import com.firstpenguin.app.domain.recommendation.policy.IntentFocusWeightPolicy
+import com.firstpenguin.app.domain.recommendation.policy.MoodTagPolicy
+import com.firstpenguin.app.global.enums.TagType
+import org.springframework.stereotype.Component
+
+@Component
+class MetadataScorer(
+    private val moodTagPolicy: MoodTagPolicy,
+    private val typeScoreCalculator: TypeScoreCalculator,
+) {
+    fun recommend(
+        input: RecommendationInput,
+        effectiveTags: List<EffectiveTag>,
+        candidates: List<RecommendationCandidate>,
+        moodTagIdByCode: Map<String, Long>,
+    ): RecommendationResult? {
+        val rankedQuotes = rank(input, effectiveTags, candidates, moodTagIdByCode)
+        if (rankedQuotes.isEmpty()) return null
+
+        return RecommendationResult(
+            mainQuote = rankedQuotes.first(),
+            quotes = rankedQuotes,
+        )
+    }
+
+    fun rank(
+        input: RecommendationInput,
+        effectiveTags: List<EffectiveTag>,
+        candidates: List<RecommendationCandidate>,
+        moodTagIdByCode: Map<String, Long>,
+    ): List<RankedRecommendationQuote> =
+        candidates
+            .map { candidate -> candidate to score(input, effectiveTags, candidate, moodTagIdByCode) }
+            .sortedWith(
+                compareByDescending<Pair<RecommendationCandidate, RecommendationScoreBreakdown>> {
+                    it.second.finalScore
+                }.thenBy { it.first.quoteId },
+            ).mapIndexed { index, (candidate, score) ->
+                RankedRecommendationQuote(
+                    rank = index + FIRST_RANK,
+                    candidate = candidate,
+                    score = score,
+                )
+            }
+
+    fun score(
+        input: RecommendationInput,
+        effectiveTags: List<EffectiveTag>,
+        candidate: RecommendationCandidate,
+        moodTagIdByCode: Map<String, Long>,
+    ): RecommendationScoreBreakdown {
+        val intentType = input.analysis?.intentType ?: IntentType.EMOTION_NEED_BASED
+        val needScore = typeScore(TagType.NEED, effectiveTags, candidate)
+        val emotionScore = typeScore(TagType.EMOTION, effectiveTags, candidate)
+        val contextScore = typeScore(TagType.CONTEXT, effectiveTags, candidate)
+        val situationScore = typeScore(TagType.SITUATION, effectiveTags, candidate)
+        val moodScore = moodScore(input, effectiveTags, candidate, moodTagIdByCode)
+        val metadataScore =
+            metadataScore(
+                intentType = intentType,
+                needScore = needScore,
+                emotionScore = emotionScore,
+                contextScore = contextScore,
+                situationScore = situationScore,
+                moodScore = moodScore,
+            )
+
+        return RecommendationScoreBreakdown(
+            needScore = needScore,
+            emotionScore = emotionScore,
+            contextScore = contextScore,
+            situationScore = situationScore,
+            moodScore = moodScore,
+            metadataScore = metadataScore,
+            semanticScore = DEFAULT_SEMANTIC_SCORE,
+            finalScore = metadataScore,
+        )
+    }
+
+    private fun typeScore(
+        tagType: TagType,
+        effectiveTags: List<EffectiveTag>,
+        candidate: RecommendationCandidate,
+    ): Double =
+        typeScoreCalculator.calculate(
+            targetTags = effectiveTags.filter { tag -> tag.type == tagType },
+            candidateTagIds = candidate.tagIds(tagType),
+        )
+
+    private fun moodScore(
+        input: RecommendationInput,
+        effectiveTags: List<EffectiveTag>,
+        candidate: RecommendationCandidate,
+        moodTagIdByCode: Map<String, Long>,
+    ): Double {
+        val targetMoodTagIds =
+            moodTagPolicy
+                .resolveMoodTagCodes(input, effectiveTags)
+                .mapNotNullTo(mutableSetOf()) { code -> moodTagIdByCode[code] }
+
+        return typeScoreCalculator.calculate(
+            targetTagIds = targetMoodTagIds,
+            candidateTagIds = candidate.tagIds(TagType.MOOD),
+        )
+    }
+
+    private fun metadataScore(
+        intentType: IntentType,
+        needScore: Double,
+        emotionScore: Double,
+        contextScore: Double,
+        situationScore: Double,
+        moodScore: Double,
+    ): Double {
+        val scores =
+            mapOf(
+                TagType.NEED to needScore,
+                TagType.EMOTION to emotionScore,
+                TagType.CONTEXT to contextScore,
+                TagType.SITUATION to situationScore,
+                TagType.MOOD to moodScore,
+            )
+        val weights = IntentFocusWeightPolicy.weightsOf(intentType)
+
+        return scores.entries.sumOf { (type, score) -> score * (weights[type] ?: NO_WEIGHT) }
+    }
+
+    private fun RecommendationCandidate.tagIds(tagType: TagType): Set<Long> = tagIdsByType[tagType].orEmpty()
+
+    private companion object {
+        const val FIRST_RANK = 1
+        const val DEFAULT_SEMANTIC_SCORE = 0.0
+        const val NO_WEIGHT = 0.0
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/TypeScoreCalculator.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/TypeScoreCalculator.kt
@@ -1,0 +1,61 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import org.springframework.stereotype.Component
+
+@Suppress("MagicNumber")
+@Component
+class TypeScoreCalculator {
+    fun calculate(
+        targetTags: Collection<EffectiveTag>,
+        candidateTagIds: Set<Long>,
+    ): Double {
+        if (targetTags.isEmpty() || candidateTagIds.isEmpty()) return NO_MATCH_SCORE
+
+        val totalImportance = targetTags.sumOf { tag -> tag.importance }
+        return if (totalImportance <= NO_MATCH_SCORE) {
+            NO_MATCH_SCORE
+        } else {
+            calculateByImportance(targetTags, candidateTagIds, totalImportance)
+        }
+    }
+
+    fun calculate(
+        targetTagIds: Set<Long>,
+        candidateTagIds: Set<Long>,
+    ): Double {
+        if (targetTagIds.isEmpty() || candidateTagIds.isEmpty()) return NO_MATCH_SCORE
+
+        val matchCount = targetTagIds.count { tagId -> tagId in candidateTagIds }
+        val bestMatchScore = if (matchCount > 0) FULL_MATCH_SCORE else NO_MATCH_SCORE
+        val coverageScore = matchCount.toDouble() / targetTagIds.size
+
+        return calculate(bestMatchScore, coverageScore)
+    }
+
+    private fun calculate(
+        bestMatchScore: Double,
+        coverageScore: Double,
+    ): Double =
+        BEST_MATCH_WEIGHT * bestMatchScore.coerceIn(NO_MATCH_SCORE, FULL_MATCH_SCORE) +
+            COVERAGE_WEIGHT * coverageScore.coerceIn(NO_MATCH_SCORE, FULL_MATCH_SCORE)
+
+    private fun calculateByImportance(
+        targetTags: Collection<EffectiveTag>,
+        candidateTagIds: Set<Long>,
+        totalImportance: Double,
+    ): Double {
+        val matchedTags = targetTags.filter { tag -> tag.tagId in candidateTagIds }
+        val bestMatchScore = matchedTags.maxOfOrNull { tag -> tag.importance } ?: NO_MATCH_SCORE
+        val coverageScore = matchedTags.sumOf { tag -> tag.importance } / totalImportance
+
+        return calculate(bestMatchScore, coverageScore)
+    }
+
+    private companion object {
+        const val BEST_MATCH_WEIGHT = 0.75
+        const val COVERAGE_WEIGHT = 0.25
+        const val NO_MATCH_SCORE = 0.0
+        const val FULL_MATCH_SCORE = 1.0
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorerTest.kt
@@ -1,0 +1,172 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.emotion.model.Tag
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.IntentType
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.UserInputAnalysis
+import com.firstpenguin.app.domain.recommendation.policy.MoodTagPolicy
+import com.firstpenguin.app.global.enums.TagType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class MetadataScorerTest {
+    private val scorer = MetadataScorer(MoodTagPolicy(), TypeScoreCalculator())
+
+    @Test
+    fun `metadataScore 기준으로 후보를 정렬한다`() {
+        val input = recommendationInput(intentType = IntentType.EMOTION_NEED_BASED)
+        val effectiveTags =
+            listOf(
+                effectiveTag(NEED_COMFORT_ID, "NEED_COMFORT", TagType.NEED, 1.0),
+                effectiveTag(EMOTION_ANXIOUS_ID, "EMOTION_ANXIOUS", TagType.EMOTION, 1.0),
+                effectiveTag(SITUATION_FAILURE_ID, "SITUATION_FAILURE_MISTAKE", TagType.SITUATION, 0.8),
+                effectiveTag(CONTEXT_RAIN_ID, "CONTEXT_RAIN", TagType.CONTEXT, 0.4),
+            )
+        val highMatchCandidate =
+            candidate(
+                quoteId = 1L,
+                tagIdsByType =
+                    mapOf(
+                        TagType.NEED to setOf(NEED_COMFORT_ID),
+                        TagType.EMOTION to setOf(EMOTION_ANXIOUS_ID),
+                        TagType.MOOD to setOf(MOOD_WARM_ID, MOOD_CALM_TONE_ID),
+                    ),
+            )
+        val lowMatchCandidate =
+            candidate(
+                quoteId = 2L,
+                tagIdsByType =
+                    mapOf(
+                        TagType.SITUATION to setOf(SITUATION_FAILURE_ID),
+                        TagType.CONTEXT to setOf(CONTEXT_RAIN_ID),
+                    ),
+            )
+
+        val result =
+            scorer.rank(
+                input = input,
+                effectiveTags = effectiveTags,
+                candidates = listOf(lowMatchCandidate, highMatchCandidate),
+                moodTagIdByCode = moodTagIdByCode,
+            )
+
+        assertEquals(listOf(1L, 2L), result.map { quote -> quote.quoteId })
+        assertEquals(1, result.first().rank)
+        assertEquals(result.first().score.metadataScore, result.first().score.finalScore, DELTA)
+        assertEquals(0.0, result.first().score.semanticScore, DELTA)
+    }
+
+    @Test
+    fun `moodScore는 mood 정책 결과와 후보 mood tag 매칭으로 계산한다`() {
+        val input = recommendationInput(intentType = IntentType.EMOTION_NEED_BASED)
+        val candidate =
+            candidate(
+                quoteId = 1L,
+                tagIdsByType = mapOf(TagType.MOOD to setOf(MOOD_WARM_ID, MOOD_CALM_TONE_ID)),
+            )
+
+        val result =
+            scorer.score(
+                input = input,
+                effectiveTags = emptyList(),
+                candidate = candidate,
+                moodTagIdByCode = moodTagIdByCode,
+            )
+
+        assertTrue(result.moodScore > 0.0)
+    }
+
+    @Test
+    fun `추천 결과는 첫 번째 정렬 후보를 mainQuote로 사용한다`() {
+        val result =
+            scorer.recommend(
+                input = recommendationInput(intentType = IntentType.EMOTION_NEED_BASED),
+                effectiveTags = listOf(effectiveTag(NEED_COMFORT_ID, "NEED_COMFORT", TagType.NEED, 1.0)),
+                candidates =
+                    listOf(
+                        candidate(quoteId = 2L, tagIdsByType = emptyMap()),
+                        candidate(quoteId = 1L, tagIdsByType = mapOf(TagType.NEED to setOf(NEED_COMFORT_ID))),
+                    ),
+                moodTagIdByCode = moodTagIdByCode,
+            )
+
+        assertEquals(1L, result?.mainQuote?.quoteId)
+        assertEquals(listOf(1L, 2L), result?.quotes?.map { quote -> quote.quoteId })
+    }
+
+    private fun recommendationInput(intentType: IntentType): RecommendationInput =
+        RecommendationInput(
+            userId = USER_ID,
+            emotionRangeId = EMOTION_RANGE_ID,
+            emotionTags = listOf(tag(EMOTION_ANXIOUS_ID, TagType.EMOTION, "EMOTION_ANXIOUS")),
+            needTag = tag(NEED_COMFORT_ID, TagType.NEED, "NEED_COMFORT"),
+            feelingText = null,
+            diaryText = null,
+            analysis = UserInputAnalysis(intentType = intentType, canonicalIntent = null, tagCandidates = emptyList()),
+        )
+
+    private fun effectiveTag(
+        tagId: Long,
+        code: String,
+        type: TagType,
+        importance: Double,
+    ): EffectiveTag =
+        EffectiveTag(
+            tagId = tagId,
+            code = code,
+            type = type,
+            importance = importance,
+        )
+
+    private fun candidate(
+        quoteId: Long,
+        tagIdsByType: Map<TagType, Set<Long>>,
+    ): RecommendationCandidate =
+        RecommendationCandidate(
+            quoteId = quoteId,
+            bookId = BOOK_ID,
+            content = "content-$quoteId",
+            title = "title",
+            author = "author",
+            roleTagId = null,
+            tagIdsByType = tagIdsByType,
+        )
+
+    private fun tag(
+        id: Long,
+        type: TagType,
+        code: String,
+    ): Tag =
+        Tag(
+            id = id,
+            emotionRangeId = if (type == TagType.EMOTION) EMOTION_RANGE_ID else null,
+            code = code,
+            label = code,
+            type = type,
+            createdAt = CREATED_AT,
+        )
+
+    private companion object {
+        const val USER_ID = 1L
+        const val BOOK_ID = 10L
+        const val EMOTION_RANGE_ID = 1L
+        const val NEED_COMFORT_ID = 101L
+        const val EMOTION_ANXIOUS_ID = 201L
+        const val SITUATION_FAILURE_ID = 301L
+        const val CONTEXT_RAIN_ID = 401L
+        const val MOOD_WARM_ID = 501L
+        const val MOOD_CALM_TONE_ID = 502L
+        const val DELTA = 0.000001
+
+        val CREATED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 13, 0, 0)
+        val moodTagIdByCode: Map<String, Long> =
+            mapOf(
+                "MOOD_WARM" to MOOD_WARM_ID,
+                "MOOD_CALM_TONE" to MOOD_CALM_TONE_ID,
+            )
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/TypeScoreCalculatorTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/TypeScoreCalculatorTest.kt
@@ -1,0 +1,53 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.global.enums.TagType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TypeScoreCalculatorTest {
+    private val calculator = TypeScoreCalculator()
+
+    @Test
+    fun `bestMatch와 coverage를 합산해 type score를 계산한다`() {
+        val targetTags =
+            listOf(
+                effectiveTag(tagId = 1L, importance = 0.8),
+                effectiveTag(tagId = 2L, importance = 0.4),
+                effectiveTag(tagId = 3L, importance = 0.2),
+            )
+
+        val result = calculator.calculate(targetTags, setOf(1L, 2L))
+
+        assertEquals(0.814285, result, DELTA)
+    }
+
+    @Test
+    fun `매칭되는 tag가 없으면 0점을 반환한다`() {
+        val result = calculator.calculate(setOf(1L, 2L), setOf(3L))
+
+        assertEquals(0.0, result, DELTA)
+    }
+
+    @Test
+    fun `동일 가중치 tag id도 type score로 계산한다`() {
+        val result = calculator.calculate(setOf(1L, 2L, 3L, 4L), setOf(1L, 2L))
+
+        assertEquals(0.875, result, DELTA)
+    }
+
+    private fun effectiveTag(
+        tagId: Long,
+        importance: Double,
+    ): EffectiveTag =
+        EffectiveTag(
+            tagId = tagId,
+            code = "TAG_$tagId",
+            type = TagType.NEED,
+            importance = importance,
+        )
+
+    private companion object {
+        const val DELTA = 0.000001
+    }
+}


### PR DESCRIPTION
## 📢 요약
- 추천 후보의 metadataScore를 계산하는 TypeScoreCalculator와 MetadataScorer를 추가했습니다.
- 타입별 점수는 bestMatchScore와 coverageScore를 조합해 계산하도록 구현했습니다.
- IntentType별 focus weight를 반영해 NEED, EMOTION, CONTEXT, SITUATION, MOOD 점수를 합산합니다.
- MoodTagPolicy가 계산한 mood tag와 후보 quote의 mood tag를 매칭해 moodScore를 계산합니다.
- quote-metadata batch submit 대상은 BOOK_INSPIRED quote만 포함하도록 제한했습니다.
- 품질이 낮을 수 있는 CANDIDATE_REVIEWED quote는 메타정보 추출 대상에서 제외했습니다.

🔗 연관 이슈: Resolves #123

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
```bash
./gradlew lintKotlin
./gradlew detekt
./gradlew testClasses
./gradlew test

## 📜 기타
metadataScore만으로 후보 정렬이 가능하도록 rank, score, recommend 진입점을 추가했습니다.
avoidPenalty는 이번 범위에 포함하지 않았습니다.
quote-metadata status count도 BOOK_INSPIRED 기준으로 맞춰 submit 대상과 현황 값이 일치하도록 했습니다.
app/src/main/resources/application.yml에 남아 있는 로컬 변경은 PR 포함 여부 확인이 필요합니다.