### PR TITLE
fix: 내 정보 응답 및 프로필 수정 요청 보완

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
@@ -37,7 +37,7 @@ class DiscoveryController(
             description =
                 "다음 페이지 조회 커서. 첫 페이지에서는 생략한다. " +
                     "직전 응답의 `nextCursor` 값을 그대로 전달하며, 클라이언트에서 디코딩하거나 수정하지 않는다.",
-            example = "MjAyNi0wNi0wNVQxMjozNDo1NnwxMA",
+            example = "MjA5OS0wNi0wNVQxMjozNDo1NnwxMA",
         )
         @RequestParam(required = false) cursor: String?,
         @Parameter(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/controller/UserController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/controller/UserController.kt
@@ -113,6 +113,7 @@ class UserController(
     private companion object {
         const val ME_DESCRIPTION =
             "Authorization 헤더에 `Bearer {accessToken}` 형식으로 access token을 담아 호출합니다. " +
+                "`provider`는 사용자가 가입/로그인한 OAuth provider입니다. " +
                 "`profileImageUrl`은 `users.profile_image_id`로 연결된 이미지가 없으면 null입니다."
 
         const val UPDATE_ME_DESCRIPTION =

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/controller/UserController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/controller/UserController.kt
@@ -83,8 +83,8 @@ class UserController(
             ApiResponse(
                 responseCode = "400",
                 description =
-                    "nickname과 profileImageId가 모두 null이거나, nickname이 빈 문자열 또는 예약 닉네임이거나, " +
-                        "profileImageId가 존재하지 않습니다.",
+                    "nickname과 profileImageId가 모두 생략되었거나 null이거나, " +
+                        "nickname이 빈 문자열 또는 예약 닉네임이거나, profileImageId가 존재하지 않습니다.",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -119,7 +119,7 @@ class UserController(
         const val UPDATE_ME_DESCRIPTION =
             "닉네임 또는 프로필 이미지를 수정합니다. " +
                 "nickname, profileImageId 중 하나 이상은 반드시 포함해야 합니다. " +
-                "null 필드는 변경하지 않습니다. 프로필 이미지 제거(null로 초기화)는 현재 미지원입니다. " +
+                "생략하거나 null인 필드는 변경하지 않습니다. 프로필 이미지 제거(null로 초기화)는 현재 미지원입니다. " +
                 "profileImageId는 `POST /images/presigned-url`로 발급받은 imageId를 사용합니다."
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/dto/UpdateUserRequest.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/dto/UpdateUserRequest.kt
@@ -2,10 +2,10 @@ package com.firstpenguin.app.domain.user.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "프로필 수정 요청. nickname, profileImageId 중 하나 이상 필수. null 필드는 변경하지 않습니다.")
+@Schema(description = "프로필 수정 요청. nickname, profileImageId 중 하나 이상 필수. 생략하거나 null인 필드는 변경하지 않습니다.")
 data class UpdateUserRequest(
-    @field:Schema(description = "변경할 닉네임. null이면 변경하지 않음. 예약 닉네임은 사용할 수 없음", example = "새닉네임")
-    val nickname: String?,
-    @field:Schema(description = "변경할 프로필 이미지 ID. null이면 변경하지 않음. 이미지 제거는 현재 미지원", example = "42")
-    val profileImageId: Long?,
+    @field:Schema(description = "변경할 닉네임. 생략하거나 null이면 변경하지 않음. 예약 닉네임은 사용할 수 없음", example = "새닉네임")
+    val nickname: String? = null,
+    @field:Schema(description = "변경할 프로필 이미지 ID. 생략하거나 null이면 변경하지 않음. 이미지 제거는 현재 미지원", example = "42")
+    val profileImageId: Long? = null,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/dto/UserResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/dto/UserResponse.kt
@@ -8,6 +8,8 @@ import java.time.LocalDate
 data class UserResponse(
     @field:Schema(description = "사용자 ID", example = "1")
     val id: Long,
+    @field:Schema(description = "로그인 OAuth provider", example = "KAKAO", allowableValues = ["KAKAO", "GOOGLE"])
+    val provider: String,
     @field:Schema(description = "OAuth provider에서 제공한 이메일. 제공되지 않으면 null", example = "user@example.com")
     val email: String?,
     @field:Schema(description = "사용자 닉네임", example = "산타는펭귄")
@@ -24,6 +26,7 @@ data class UserResponse(
         ): UserResponse =
             UserResponse(
                 id = user.id,
+                provider = user.provider.name,
                 email = user.email,
                 nickname = user.nickname,
                 profileImageUrl = profileImageUrl,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
@@ -14,6 +14,7 @@ import org.jooq.tools.jdbc.MockDataProvider
 import org.jooq.tools.jdbc.MockResult
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class DiscoveryRepositoryTest {
@@ -32,6 +33,8 @@ class DiscoveryRepositoryTest {
 
         assertTrue(normalizedSql.contains("recommendations"), normalizedSql)
         assertTrue(normalizedSql.contains("recommendation_quotes"), normalizedSql)
+        assertFalse(normalizedSql.contains("daily_recommendation_quotes"), normalizedSql)
+        assertFalse(normalizedSql.contains("daily_recommendation_id"), normalizedSql)
         assertTrue(normalizedSql.contains("recommended_user_id"), normalizedSql)
         assertTrue(normalizedSql.contains("recommended_at"), normalizedSql)
         assertTrue(normalizedSql.contains("quote_scraps"), normalizedSql)

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCaseTest.kt
@@ -24,12 +24,13 @@ class UserUseCaseTest {
     }
 
     @Test
-    fun `내 정보 조회 응답에 가입한 날짜를 포함한다`() {
+    fun `내 정보 조회 응답에 OAuth provider와 가입한 날짜를 포함한다`() {
         val user = user()
         Mockito.`when`(userService.getById(USER_ID)).thenReturn(user)
 
         val response = userUseCase.getMe(USER_ID)
 
+        assertEquals(user.provider.name, response.provider)
         assertEquals(user.createdAt.toLocalDate(), response.createdAt)
         Mockito.verifyNoInteractions(imageService)
     }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.firstpenguin.app.domain.user.usecase
 
 import com.firstpenguin.app.domain.image.service.ImageService
+import com.firstpenguin.app.domain.user.dto.UpdateUserRequest
 import com.firstpenguin.app.domain.user.model.Provider
 import com.firstpenguin.app.domain.user.model.User
 import com.firstpenguin.app.domain.user.model.UserStatus
@@ -35,6 +36,31 @@ class UserUseCaseTest {
         Mockito.verifyNoInteractions(imageService)
     }
 
+    @Test
+    fun `닉네임만 수정할 때 프로필 이미지 ID를 생략할 수 있다`() {
+        val updatedUser = user().copy(nickname = UPDATED_NICKNAME)
+        Mockito.`when`(userService.getById(USER_ID)).thenReturn(updatedUser)
+
+        val response = userUseCase.updateMe(USER_ID, UpdateUserRequest(nickname = UPDATED_NICKNAME))
+
+        assertEquals(UPDATED_NICKNAME, response.nickname)
+        Mockito.verify(userService).updateProfile(USER_ID, UPDATED_NICKNAME, null)
+        Mockito.verifyNoInteractions(imageService)
+    }
+
+    @Test
+    fun `프로필 이미지만 수정할 때 닉네임을 생략할 수 있다`() {
+        val updatedUser = user().copy(profileImageId = PROFILE_IMAGE_ID)
+        Mockito.`when`(userService.getById(USER_ID)).thenReturn(updatedUser)
+        Mockito.`when`(imageService.findUrlById(PROFILE_IMAGE_ID)).thenReturn(PROFILE_IMAGE_URL)
+
+        val response = userUseCase.updateMe(USER_ID, UpdateUserRequest(profileImageId = PROFILE_IMAGE_ID))
+
+        assertEquals(PROFILE_IMAGE_URL, response.profileImageUrl)
+        Mockito.verify(imageService).validateExists(PROFILE_IMAGE_ID)
+        Mockito.verify(userService).updateProfile(USER_ID, null, PROFILE_IMAGE_ID)
+    }
+
     private fun user(): User =
         User(
             id = USER_ID,
@@ -53,6 +79,9 @@ class UserUseCaseTest {
 
     private companion object {
         const val USER_ID = 1L
+        const val PROFILE_IMAGE_ID = 10L
+        const val PROFILE_IMAGE_URL = "https://cdn.example.com/profile.png"
+        const val UPDATED_NICKNAME = "새닉네임"
         val CREATED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 13, 14, 30)
     }
 }

--- a/docs/user-profile-api.md
+++ b/docs/user-profile-api.md
@@ -29,18 +29,22 @@ GET /api/users/me
 ```json
 {
   "id": 1,
+  "provider": "KAKAO",
   "email": "user@example.com",
   "nickname": "책읽는펭귄",
-  "profileImageUrl": "https://cdn.example.com/profile.png"
+  "profileImageUrl": "https://cdn.example.com/profile.png",
+  "createdAt": "2026-06-13"
 }
 ```
 
 | 필드 | 설명 |
 |------|------|
 | `id` | 사용자 ID |
+| `provider` | 가입/로그인에 사용한 OAuth provider. `KAKAO` 또는 `GOOGLE` |
 | `email` | OAuth provider에서 제공한 이메일. 제공되지 않으면 `null` |
 | `nickname` | 서비스에서 사용하는 사용자 닉네임 |
 | `profileImageUrl` | `users.profile_image_id`로 연결된 이미지 URL. 연결된 이미지가 없으면 `null` |
+| `createdAt` | 가입한 날짜 |
 
 `profileImageUrl`은 `images.url`을 조회해서 응답에 포함한다.
 클라이언트는 `profileImageId`가 아니라 조회 가능한 URL만 받는다.
@@ -77,9 +81,11 @@ Content-Type: application/json
 ```json
 {
   "id": 1,
+  "provider": "KAKAO",
   "email": "user@example.com",
   "nickname": "새닉네임",
-  "profileImageUrl": "https://cdn.example.com/profile.png"
+  "profileImageUrl": "https://cdn.example.com/profile.png",
+  "createdAt": "2026-06-13"
 }
 ```
 
@@ -141,6 +147,7 @@ provider 표시 이름은 `provider_display_name`에 별도로 저장한다.
 다음 시나리오를 검증한다.
 
 - 내 정보 조회 시 `profileImageId`가 있으면 `profileImageUrl`을 응답한다.
+- 내 정보 조회 시 OAuth provider를 응답한다.
 - `PATCH /api/users/me`는 닉네임만 변경할 수 있다.
 - `PATCH /api/users/me`는 프로필 이미지만 변경할 수 있다.
 - 두 필드가 모두 `null`이면 실패한다.

--- a/docs/user-profile-api.md
+++ b/docs/user-profile-api.md
@@ -71,10 +71,18 @@ Content-Type: application/json
 | `profileImageId` | 변경할 프로필 이미지 ID. `null`이면 변경하지 않음 |
 
 `nickname`, `profileImageId` 중 하나 이상은 반드시 포함해야 한다.
-두 값이 모두 `null`이면 `INVALID_INPUT`으로 처리한다.
+필드는 생략할 수 있으며, 두 값이 모두 생략되거나 `null`이면 `INVALID_INPUT`으로 처리한다.
 
-`null` 필드는 변경하지 않는다.
+생략하거나 `null`인 필드는 변경하지 않는다.
 따라서 현재 API로는 프로필 이미지를 제거할 수 없다.
+
+닉네임만 변경할 때는 `profileImageId`를 보내지 않아도 된다.
+
+```json
+{
+  "nickname": "새닉네임"
+}
+```
 
 응답은 수정 후 `UserResponse`를 반환한다.
 


### PR DESCRIPTION
## 📢 요약
- `GET /users/me` 응답에 OAuth provider를 추가해 카카오/Google 로그인 여부를 프론트에서 구분할 수 있게 했습니다.
- 프로필 수정 요청 DTO의 nullable 필드에 기본값을 추가해 `nickname`만 또는 `profileImageId`만 보내는 부분 수정 요청이 동작하도록 했습니다.
- 발견탭 jOOQ 쿼리가 변경된 `recommendation_quotes` 테이블과 `recommendation_id` 컬럼을 유지하도록 회귀 테스트를 보강했습니다.
- 발견탭 Swagger의 `cursor` 예시를 `2099-06-05T12:34:56|10` 기반 값으로 변경했습니다.
- 사용자 프로필 API 문서와 Swagger 설명을 현재 요청/응답 동작에 맞게 갱신했습니다.

🔗 연관 이슈: Resolves #128

## 원인
- `UserResponse`가 `users.provider` 값을 응답하지 않아 클라이언트가 로그인 provider를 알 수 없었습니다.
- `UpdateUserRequest`의 nullable 필드에 기본값이 없어 JSON에서 필드를 생략하면 부분 수정 요청으로 처리되지 않을 수 있었습니다.
- daily recommendation quote 테이블명이 `recommendation_quotes`로 변경된 뒤 발견탭 SQL이 이전 테이블명으로 되돌아가지 않도록 테스트 보호가 필요했습니다.
- Swagger cursor 예시가 실제 다음 페이지 커서처럼 동작해 테스트 호출 시 빈 결과로 오해할 수 있었습니다.

## 변경 사항
- `UserResponse`에 `provider` 필드를 추가하고 Swagger schema에 `KAKAO`, `GOOGLE` 값을 명시했습니다.
- `UpdateUserRequest.nickname`, `UpdateUserRequest.profileImageId` 기본값을 `null`로 지정했습니다.
- `PATCH /users/me`에서 빈 JSON은 기존처럼 `INVALID_INPUT`으로 처리하고, 단일 필드 요청은 허용합니다.
- `UserUseCaseTest`에 닉네임 단독 수정과 프로필 이미지 단독 수정 케이스를 추가했습니다.
- `DiscoveryRepositoryTest`에 `daily_recommendation_quotes`, `daily_recommendation_id`가 SQL에 남지 않는 검증을 추가했습니다.
- `DiscoveryController`의 Swagger cursor 예시를 `MjA5OS0wNi0wNVQxMjozNDo1NnwxMA`로 변경했습니다.
- `docs/user-profile-api.md`에 `provider`, `createdAt`, 필드 생략 가능 여부, 닉네임 단독 수정 예시를 반영했습니다.

## 프론트 영향
- `GET /users/me` 응답에 `provider`가 추가됩니다.
- 이미지 업로드용 `POST /images/presigned-url` 응답은 기존처럼 `imageId`를 포함합니다.
- 닉네임만 수정할 때는 `{ "nickname": "새닉네임" }`만 보내면 됩니다.
- 이미지만 수정할 때는 `POST /images/presigned-url`에서 받은 `imageId`를 `{ "profileImageId": 42 }`로 보내면 됩니다.
- 발견탭 첫 페이지는 `cursor` 없이 호출하고, 다음 페이지부터 응답의 `nextCursor`를 그대로 전달해야 합니다.

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
```bash
cd app && ./gradlew formatKotlin lintKotlin detekt test
cd app && ./gradlew testClasses
```

결과: `BUILD SUCCESSFUL`

## 📜 기타
- PR은 draft로 생성했습니다.
- 커밋은 변경 성격에 따라 3개로 분리했습니다.
