### PR TITLE
✨ feat: 배치 실패 시 errormessage 기록하도록 추가, quote-metadata limit 500으로 감소

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/openai/dto/OpenAiBatchStatusResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/openai/dto/OpenAiBatchStatusResponse.kt
@@ -7,4 +7,5 @@ data class OpenAiBatchStatusResponse(
     val status: BatchJobStatus,
     val outputFileId: String?,
     val errorFileId: String?,
+    val errorMessage: String?,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/openai/service/OpenAiBatchClient.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/openai/service/OpenAiBatchClient.kt
@@ -103,6 +103,7 @@ class OpenAiBatchClient(
             status = BatchJobStatus.from(response.getValue("status").toString()),
             outputFileId = response["output_file_id"] as? String,
             errorFileId = response["error_file_id"] as? String,
+            errorMessage = response.batchErrorMessage(),
         )
     }
 
@@ -120,3 +121,20 @@ class OpenAiBatchClient(
             setReadTimeout(OPENAI_READ_TIMEOUT)
         }
 }
+
+private fun Map<String, Any?>.batchErrorMessage(): String? =
+    batchErrors()
+        .mapNotNull { error -> error as? Map<*, *> }
+        .mapNotNull { error -> error["message"]?.toString() }
+        .take(MAX_BATCH_ERROR_MESSAGE_COUNT)
+        .joinToString(ERROR_MESSAGE_SEPARATOR)
+        .ifBlank { null }
+
+private fun Map<String, Any?>.batchErrors(): List<*> {
+    val errors = this["errors"] as? Map<*, *> ?: return emptyList<Any>()
+
+    return errors["data"] as? List<*> ?: emptyList<Any>()
+}
+
+private const val MAX_BATCH_ERROR_MESSAGE_COUNT = 3
+private const val ERROR_MESSAGE_SEPARATOR = " | "

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quotecreation/service/QuoteCreationBatchStatusService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quotecreation/service/QuoteCreationBatchStatusService.kt
@@ -67,7 +67,7 @@ class QuoteCreationBatchStatusService(
             itemRepository.updateQuoteBatchItemsStatus(
                 jobId = jobId,
                 status = BatchItemStatus.FAILED,
-                errorMessage = "OpenAI batch status: ${batch.status.name}",
+                errorMessage = batch.failedMessage(),
             )
         }
     }
@@ -84,3 +84,5 @@ class QuoteCreationBatchStatusService(
         val QUOTE_CONTENT_JOB_TYPES = listOf(QuoteBatchType.QUOTE_EXTRACTION, QuoteBatchType.QUOTE_REVIEW)
     }
 }
+
+private fun OpenAiBatchStatusResponse.failedMessage(): String = errorMessage ?: "OpenAI batch status: ${status.name}"

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/dto/QuoteMetadataBatchSubmitRequest.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/dto/QuoteMetadataBatchSubmitRequest.kt
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 
 private const val MIN_LIMIT = 1L
-private const val MAX_LIMIT = 1000L
+private const val MAX_LIMIT = 500L
 
 data class QuoteMetadataBatchSubmitRequest(
     @field:Min(MIN_LIMIT)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/service/QuoteMetadataBatchStatusService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/service/QuoteMetadataBatchStatusService.kt
@@ -57,7 +57,7 @@ class QuoteMetadataBatchStatusService(
             quoteMetadataBatchItemRepository.updateQuoteMetadataBatchItemsStatus(
                 jobId = jobId,
                 status = BatchItemStatus.FAILED,
-                errorMessage = "OpenAI batch status: ${batch.status.name}",
+                errorMessage = batch.failedMessage(),
             )
         }
     }
@@ -79,3 +79,5 @@ class QuoteMetadataBatchStatusService(
         val QUOTE_METADATA_JOB_TYPES = listOf(QuoteBatchType.QUOTE_METADATA)
     }
 }
+
+private fun OpenAiBatchStatusResponse.failedMessage(): String = errorMessage ?: "OpenAI batch status: ${status.name}"


### PR DESCRIPTION
errormessage 가 기록되지 않아 실패 이유를 알지 못했다.
따라서 aiClient 에서 내려주는 errormessage 도 db 에 저장하도록 추가하였다.

quote-metadata 는 프롬프트도 길고, 토큰을 많이 필요로 하기 때문에
기존 1000개 limit 으로 최대 요청을 보내면, 다음 요청에서 사용할 토큰이 남아있지 않아 failed 되었다.
따라서 limit 를 500개로 낮추어 임시방편으로 failed 되는 환경을 줄이도록 하였다.