### PR TITLE
feat: quote metadata 기반 추천 후보 조회 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepository.kt
@@ -1,0 +1,138 @@
+package com.firstpenguin.app.domain.recommendation.repository
+
+import com.firstpenguin.app.domain.book.repository.BookTable
+import com.firstpenguin.app.domain.emotion.repository.table.TagTable
+import com.firstpenguin.app.domain.quote.repository.QuoteTable
+import com.firstpenguin.app.domain.quotemetadata.repository.table.QuoteMetadataTable
+import com.firstpenguin.app.domain.quotemetadata.repository.table.QuoteMetadataTagTable
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
+import com.firstpenguin.app.global.enums.TagType
+import org.jooq.Condition
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.Table
+import org.jooq.impl.DSL
+import org.springframework.stereotype.Repository
+
+@Repository
+class RecommendationCandidateRepository(
+    private val dsl: DSLContext,
+) {
+    fun findCandidates(
+        effectiveTags: Collection<EffectiveTag>,
+        limit: Int = DEFAULT_CANDIDATE_LIMIT,
+    ): List<RecommendationCandidate> {
+        val hardFilterTagIds = effectiveTags.hardFilterTagIds()
+        if (hardFilterTagIds.isEmpty()) return emptyList()
+
+        return dsl
+            .select(CANDIDATE_ROW_FIELDS)
+            .from(candidateQuoteIdsTable(hardFilterTagIds, limit))
+            .join(QuoteTable.QUOTES)
+            .on(QuoteTable.ID.eq(CANDIDATE_QUOTE_ID))
+            .join(BookTable.BOOKS)
+            .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+            .join(QuoteMetadataTable.QUOTE_METADATA)
+            .on(QuoteMetadataTable.QUOTE_ID.eq(QuoteTable.ID))
+            .join(QuoteMetadataTagTable.QUOTE_METADATA_TAGS)
+            .on(QuoteMetadataTagTable.QUOTE_METADATA_ID.eq(QuoteMetadataTable.ID))
+            .join(TagTable.TAGS)
+            .on(TagTable.ID.eq(QuoteMetadataTagTable.TAG_ID))
+            .where(activeTagCondition())
+            .orderBy(QuoteTable.ID.asc())
+            .fetch()
+            .toRecommendationCandidates()
+    }
+
+    private fun candidateQuoteIdsTable(
+        hardFilterTagIds: List<Long>,
+        limit: Int,
+    ): Table<*> =
+        dsl
+            .select(QuoteTable.ID.`as`(CANDIDATE_QUOTE_ID_NAME))
+            .from(QuoteTable.QUOTES)
+            .join(BookTable.BOOKS)
+            .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+            .join(QuoteMetadataTable.QUOTE_METADATA)
+            .on(QuoteMetadataTable.QUOTE_ID.eq(QuoteTable.ID))
+            .where(activeQuoteAndBookCondition())
+            .and(hardFilterMatchExists(hardFilterTagIds))
+            .orderBy(QuoteTable.ID.asc())
+            .limit(limit)
+            .asTable(CANDIDATE_QUOTE_IDS_TABLE)
+
+    private fun hardFilterMatchExists(hardFilterTagIds: List<Long>): Condition =
+        DSL.exists(
+            DSL
+                .selectOne()
+                .from(QuoteMetadataTagTable.QUOTE_METADATA_TAGS)
+                .join(TagTable.TAGS)
+                .on(TagTable.ID.eq(QuoteMetadataTagTable.TAG_ID))
+                .where(QuoteMetadataTagTable.QUOTE_METADATA_ID.eq(QuoteMetadataTable.ID))
+                .and(TagTable.ID.`in`(hardFilterTagIds))
+                .and(TagTable.TYPE.`in`(HARD_FILTER_TAG_TYPE_NAMES))
+                .and(activeTagCondition()),
+        )
+
+    private fun activeQuoteAndBookCondition(): Condition =
+        QuoteTable.DELETED_AT
+            .isNull
+            .and(BookTable.DELETED_AT.isNull)
+
+    private fun activeTagCondition(): Condition = TagTable.IS_ACTIVE.isTrue
+
+    private fun Collection<EffectiveTag>.hardFilterTagIds(): List<Long> =
+        filter { tag -> tag.type in HARD_FILTER_TAG_TYPES }
+            .map { tag -> tag.tagId }
+            .distinct()
+
+    private fun List<Record>.toRecommendationCandidates(): List<RecommendationCandidate> =
+        groupBy { record -> record[QuoteTable.ID]!! }
+            .values
+            .map { records -> records.toRecommendationCandidate() }
+
+    private fun List<Record>.toRecommendationCandidate(): RecommendationCandidate {
+        val firstRecord = first()
+        val tagIdsByType = tagIdsByType()
+
+        return RecommendationCandidate(
+            quoteId = firstRecord[QuoteTable.ID]!!,
+            bookId = firstRecord[QuoteTable.BOOK_ID]!!,
+            content = firstRecord[QuoteTable.CONTENT]!!,
+            title = firstRecord[BookTable.TITLE]!!,
+            author = firstRecord[BookTable.AUTHOR]!!,
+            roleTagId = tagIdsByType[TagType.ROLE]?.firstOrNull(),
+            tagIdsByType = tagIdsByType,
+        )
+    }
+
+    private fun List<Record>.tagIdsByType(): Map<TagType, Set<Long>> =
+        groupBy { record -> TagType.from(record[TagTable.TYPE]!!) }
+            .mapValues { (_, records) ->
+                records
+                    .map { record -> record[TagTable.ID]!! }
+                    .toSet()
+            }
+
+    private companion object {
+        const val DEFAULT_CANDIDATE_LIMIT = 300
+        const val CANDIDATE_QUOTE_IDS_TABLE = "candidate_quote_ids"
+        const val CANDIDATE_QUOTE_ID_NAME = "quote_id"
+        val CANDIDATE_QUOTE_ID: Field<Long> =
+            DSL.field(DSL.name(CANDIDATE_QUOTE_IDS_TABLE, CANDIDATE_QUOTE_ID_NAME), Long::class.java)
+        val HARD_FILTER_TAG_TYPES = setOf(TagType.EMOTION, TagType.NEED)
+        val HARD_FILTER_TAG_TYPE_NAMES = HARD_FILTER_TAG_TYPES.map { type -> type.name }
+        val CANDIDATE_ROW_FIELDS: List<Field<*>> =
+            listOf(
+                QuoteTable.ID,
+                QuoteTable.BOOK_ID,
+                QuoteTable.CONTENT,
+                BookTable.TITLE,
+                BookTable.AUTHOR,
+                TagTable.ID,
+                TagTable.TYPE,
+            )
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepositoryTest.kt
@@ -1,0 +1,182 @@
+package com.firstpenguin.app.domain.recommendation.repository
+
+import com.firstpenguin.app.domain.book.repository.BookTable
+import com.firstpenguin.app.domain.emotion.repository.table.TagTable
+import com.firstpenguin.app.domain.quote.repository.QuoteTable
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.global.enums.TagType
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.Result
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.jooq.tools.jdbc.MockConnection
+import org.jooq.tools.jdbc.MockDataProvider
+import org.jooq.tools.jdbc.MockResult
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RecommendationCandidateRepositoryTest {
+    @Test
+    fun `메타데이터 태그 기반 후보를 조회한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                RecommendationCandidateRepository(dsl).findCandidates(
+                    effectiveTags = listOf(EFFECTIVE_EMOTION_TAG, EFFECTIVE_NEED_TAG),
+                    limit = LIMIT,
+                )
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("as \"candidate_quote_ids\""), normalizedSql)
+        assertTrue(normalizedSql.contains("join \"quote_metadata\""), normalizedSql)
+        assertTrue(normalizedSql.contains("join \"quote_metadata_tags\""), normalizedSql)
+        assertTrue(normalizedSql.contains("join \"tags\""), normalizedSql)
+        assertTrue(normalizedSql.contains("\"quotes\".\"deleted_at\" is null"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"books\".\"deleted_at\" is null"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"tags\".\"id\" in"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"tags\".\"type\" in"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"tags\".\"is_active\" = true"), normalizedSql)
+        assertTrue(normalizedSql.contains("fetch next ? rows only"), normalizedSql)
+    }
+
+    @Test
+    fun `조회 row를 후보 단위로 묶어 태그 타입별 id를 채운다`() {
+        val candidates =
+            findCandidatesWithResult { dsl ->
+                candidateResult(dsl)
+            }
+        val candidate = candidates.first()
+
+        assertEquals(1, candidates.size)
+        assertEquals(QUOTE_ID, candidate.quoteId)
+        assertEquals(BOOK_ID, candidate.bookId)
+        assertEquals(QUOTE_CONTENT, candidate.content)
+        assertEquals(BOOK_TITLE, candidate.title)
+        assertEquals(BOOK_AUTHOR, candidate.author)
+        assertEquals(ROLE_TAG_ID, candidate.roleTagId)
+        assertEquals(setOf(EMOTION_TAG_ID), candidate.tagIdsByType[TagType.EMOTION])
+        assertEquals(setOf(NEED_TAG_ID), candidate.tagIdsByType[TagType.NEED])
+        assertEquals(setOf(MOOD_TAG_ID), candidate.tagIdsByType[TagType.MOOD])
+        assertEquals(setOf(ROLE_TAG_ID), candidate.tagIdsByType[TagType.ROLE])
+    }
+
+    @Test
+    fun `emotion need hard filter tag가 없으면 후보를 조회하지 않는다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                RecommendationCandidateRepository(dsl).findCandidates(
+                    effectiveTags = listOf(EFFECTIVE_CONTEXT_TAG),
+                    limit = LIMIT,
+                )
+            }
+
+        assertEquals("", capturedSql)
+    }
+
+    private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {
+        var capturedSql = ""
+        lateinit var dsl: DSLContext
+        val connection =
+            MockConnection(
+                MockDataProvider { context ->
+                    capturedSql = context.sql()
+                    arrayOf(MockResult(0, dsl.newResult(*CANDIDATE_FIELDS)))
+                },
+            )
+        dsl = DSL.using(connection, SQLDialect.POSTGRES)
+        repositoryCall(dsl)
+        return capturedSql
+    }
+
+    private fun findCandidatesWithResult(result: (DSLContext) -> Result<Record>) =
+        withMockedResult(result) { dsl ->
+            RecommendationCandidateRepository(dsl).findCandidates(
+                effectiveTags = listOf(EFFECTIVE_EMOTION_TAG, EFFECTIVE_NEED_TAG),
+                limit = LIMIT,
+            )
+        }
+
+    private fun <T> withMockedResult(
+        result: (DSLContext) -> Result<Record>,
+        repositoryCall: (DSLContext) -> T,
+    ): T {
+        lateinit var dsl: DSLContext
+        val connection =
+            MockConnection(
+                MockDataProvider {
+                    arrayOf(MockResult(CANDIDATE_ROW_COUNT, result(dsl)))
+                },
+            )
+        dsl = DSL.using(connection, SQLDialect.POSTGRES)
+        return repositoryCall(dsl)
+    }
+
+    private fun candidateResult(dsl: DSLContext): Result<Record> =
+        dsl.newResult(*CANDIDATE_FIELDS).apply {
+            add(candidateRecord(dsl, ROLE_TAG_ID, TagType.ROLE))
+            add(candidateRecord(dsl, EMOTION_TAG_ID, TagType.EMOTION))
+            add(candidateRecord(dsl, NEED_TAG_ID, TagType.NEED))
+            add(candidateRecord(dsl, MOOD_TAG_ID, TagType.MOOD))
+        }
+
+    private fun candidateRecord(
+        dsl: DSLContext,
+        tagId: Long,
+        tagType: TagType,
+    ): Record =
+        dsl.newRecord(*CANDIDATE_FIELDS).apply {
+            set(QuoteTable.ID, QUOTE_ID)
+            set(QuoteTable.BOOK_ID, BOOK_ID)
+            set(QuoteTable.CONTENT, QUOTE_CONTENT)
+            set(BookTable.TITLE, BOOK_TITLE)
+            set(BookTable.AUTHOR, BOOK_AUTHOR)
+            set(TagTable.ID, tagId)
+            set(TagTable.TYPE, tagType.name)
+        }
+
+    private companion object {
+        const val LIMIT = 300
+        const val QUOTE_ID = 10L
+        const val BOOK_ID = 20L
+        const val ROLE_TAG_ID = 30L
+        const val EMOTION_TAG_ID = 31L
+        const val NEED_TAG_ID = 32L
+        const val MOOD_TAG_ID = 33L
+        const val CONTEXT_TAG_ID = 34L
+        const val CANDIDATE_ROW_COUNT = 4
+        const val QUOTE_CONTENT = "좋은 문장"
+        const val BOOK_TITLE = "좋은 책"
+        const val BOOK_AUTHOR = "좋은 작가"
+        val EFFECTIVE_EMOTION_TAG =
+            EffectiveTag(
+                tagId = EMOTION_TAG_ID,
+                code = "EMOTION_STUCK",
+                type = TagType.EMOTION,
+            )
+        val EFFECTIVE_NEED_TAG =
+            EffectiveTag(
+                tagId = NEED_TAG_ID,
+                code = "NEED_COURAGE",
+                type = TagType.NEED,
+            )
+        val EFFECTIVE_CONTEXT_TAG =
+            EffectiveTag(
+                tagId = CONTEXT_TAG_ID,
+                code = "CONTEXT_HOME",
+                type = TagType.CONTEXT,
+            )
+        val CANDIDATE_FIELDS: Array<Field<*>> =
+            arrayOf(
+                QuoteTable.ID,
+                QuoteTable.BOOK_ID,
+                QuoteTable.CONTENT,
+                BookTable.TITLE,
+                BookTable.AUTHOR,
+                TagTable.ID,
+                TagTable.TYPE,
+            )
+    }
+}


### PR DESCRIPTION
## 📢 요약
- quote metadata를 기반으로 추천 엔진의 1차 후보를 조회하는 `RecommendationCandidateRepository`를 추가했습니다.
- `quotes`, `books`, `quote_metadata`, `quote_metadata_tags`, `tags`를 조인해 `RecommendationCandidate`를 구성합니다.
- `EMOTION`/`NEED` effective tag 중 하나 이상 매칭되는 문장만 hard filter로 통과시키고, `CONTEXT`, `SITUATION`, `MOOD`, `ROLE` 등 soft score용 태그는 `tagIdsByType`에 담아 MetadataScorer에서 활용할 수 있도록 했습니다.
- 기본 1차 후보 limit은 300개로 설정했습니다.
- repository SQL 조건과 후보 매핑을 검증하는 테스트를 추가했습니다.

🔗 연관 이슈: Resolves #132 

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [ ] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
```bash
./gradlew lintKotlin
./gradlew testClasses
./gradlew detekt test
git diff --check
```

## 📜 기타
quote/book 삭제 데이터는 후보에서 제외합니다.
quote_metadata가 없는 문장은 후보에서 제외합니다.
avoid 관련 조건은 포함하지 않았습니다.