### PR TITLE
feat: 추천 후보 fallback 보강 구현

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepository.kt
@@ -16,13 +16,28 @@ import org.jooq.Table
 import org.jooq.impl.DSL
 import org.springframework.stereotype.Repository
 
-@Repository
-class RecommendationCandidateRepository(
-    private val dsl: DSLContext,
-) {
+interface RecommendationCandidateProvider {
     fun findCandidates(
         effectiveTags: Collection<EffectiveTag>,
         limit: Int = DEFAULT_CANDIDATE_LIMIT,
+    ): List<RecommendationCandidate>
+
+    fun findRelaxedCandidates(limit: Int = DEFAULT_CANDIDATE_LIMIT): List<RecommendationCandidate>
+
+    fun findRandomCandidates(limit: Int = DEFAULT_CANDIDATE_LIMIT): List<RecommendationCandidate>
+
+    companion object {
+        const val DEFAULT_CANDIDATE_LIMIT = 300
+    }
+}
+
+@Repository
+class RecommendationCandidateRepository(
+    private val dsl: DSLContext,
+) : RecommendationCandidateProvider {
+    override fun findCandidates(
+        effectiveTags: Collection<EffectiveTag>,
+        limit: Int,
     ): List<RecommendationCandidate> {
         val hardFilterTagIds = effectiveTags.hardFilterTagIds()
         if (hardFilterTagIds.isEmpty()) return emptyList()
@@ -45,6 +60,63 @@ class RecommendationCandidateRepository(
             .fetch()
             .toRecommendationCandidates()
     }
+
+    override fun findRelaxedCandidates(limit: Int): List<RecommendationCandidate> =
+        dsl
+            .select(CANDIDATE_ROW_FIELDS)
+            .from(
+                dsl
+                    .select(QuoteTable.ID.`as`(CANDIDATE_QUOTE_ID_NAME))
+                    .from(QuoteTable.QUOTES)
+                    .join(BookTable.BOOKS)
+                    .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+                    .join(QuoteMetadataTable.QUOTE_METADATA)
+                    .on(QuoteMetadataTable.QUOTE_ID.eq(QuoteTable.ID))
+                    .where(activeQuoteAndBookCondition())
+                    .orderBy(QuoteTable.ID.asc())
+                    .limit(limit)
+                    .asTable(CANDIDATE_QUOTE_IDS_TABLE),
+            ).join(QuoteTable.QUOTES)
+            .on(QuoteTable.ID.eq(CANDIDATE_QUOTE_ID))
+            .join(BookTable.BOOKS)
+            .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+            .join(QuoteMetadataTable.QUOTE_METADATA)
+            .on(QuoteMetadataTable.QUOTE_ID.eq(QuoteTable.ID))
+            .join(QuoteMetadataTagTable.QUOTE_METADATA_TAGS)
+            .on(QuoteMetadataTagTable.QUOTE_METADATA_ID.eq(QuoteMetadataTable.ID))
+            .join(TagTable.TAGS)
+            .on(TagTable.ID.eq(QuoteMetadataTagTable.TAG_ID))
+            .where(activeTagCondition())
+            .orderBy(QuoteTable.ID.asc())
+            .fetch()
+            .toRecommendationCandidates()
+
+    override fun findRandomCandidates(limit: Int): List<RecommendationCandidate> =
+        dsl
+            .select(CANDIDATE_ROW_FIELDS)
+            .from(
+                dsl
+                    .select(QuoteTable.ID.`as`(CANDIDATE_QUOTE_ID_NAME))
+                    .from(QuoteTable.QUOTES)
+                    .join(BookTable.BOOKS)
+                    .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+                    .where(activeQuoteAndBookCondition())
+                    .orderBy(DSL.rand())
+                    .limit(limit)
+                    .asTable(CANDIDATE_QUOTE_IDS_TABLE),
+            ).join(QuoteTable.QUOTES)
+            .on(QuoteTable.ID.eq(CANDIDATE_QUOTE_ID))
+            .join(BookTable.BOOKS)
+            .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+            .leftJoin(QuoteMetadataTable.QUOTE_METADATA)
+            .on(QuoteMetadataTable.QUOTE_ID.eq(QuoteTable.ID))
+            .leftJoin(QuoteMetadataTagTable.QUOTE_METADATA_TAGS)
+            .on(QuoteMetadataTagTable.QUOTE_METADATA_ID.eq(QuoteMetadataTable.ID))
+            .leftJoin(TagTable.TAGS)
+            .on(TagTable.ID.eq(QuoteMetadataTagTable.TAG_ID).and(activeTagCondition()))
+            .orderBy(QuoteTable.ID.asc())
+            .fetch()
+            .toRecommendationCandidates()
 
     private fun candidateQuoteIdsTable(
         hardFilterTagIds: List<Long>,
@@ -109,15 +181,19 @@ class RecommendationCandidateRepository(
     }
 
     private fun List<Record>.tagIdsByType(): Map<TagType, Set<Long>> =
-        groupBy { record -> TagType.from(record[TagTable.TYPE]!!) }
+        mapNotNull { record ->
+            val tagId = record[TagTable.ID] ?: return@mapNotNull null
+            val tagType = record[TagTable.TYPE] ?: return@mapNotNull null
+
+            TagType.from(tagType) to tagId
+        }.groupBy { (tagType) -> tagType }
             .mapValues { (_, records) ->
                 records
-                    .map { record -> record[TagTable.ID]!! }
+                    .map { (_, tagId) -> tagId }
                     .toSet()
             }
 
     private companion object {
-        const val DEFAULT_CANDIDATE_LIMIT = 300
         const val CANDIDATE_QUOTE_IDS_TABLE = "candidate_quote_ids"
         const val CANDIDATE_QUOTE_ID_NAME = "quote_id"
         val CANDIDATE_QUOTE_ID: Field<Long> =

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackService.kt
@@ -1,0 +1,92 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.RankedRecommendationQuote
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
+import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
+import com.firstpenguin.app.global.enums.TagType
+import org.springframework.stereotype.Component
+
+@Component
+class RecommendationFallbackService(
+    private val candidateProvider: RecommendationCandidateProvider,
+) {
+    fun supplementCandidates(
+        effectiveTags: List<EffectiveTag>,
+        existingCandidates: List<RecommendationCandidate>,
+        rankedQuotes: List<RankedRecommendationQuote> = emptyList(),
+        minimumCandidateCount: Int = MINIMUM_CANDIDATE_COUNT,
+    ): List<RecommendationCandidate> {
+        val forceFallback = rankedQuotes.hasLowTopScore()
+        if (!forceFallback && existingCandidates.size >= minimumCandidateCount) return existingCandidates
+
+        val accumulator = CandidateAccumulator(existingCandidates)
+        val fallbackSteps =
+            listOf(
+                { candidateProvider.findCandidates(effectiveTags.only(TagType.NEED), FALLBACK_FETCH_LIMIT) },
+                { candidateProvider.findCandidates(effectiveTags.only(TagType.EMOTION), FALLBACK_FETCH_LIMIT) },
+                { candidateProvider.findRelaxedCandidates(FALLBACK_FETCH_LIMIT) },
+                { candidateProvider.findRandomCandidates(FALLBACK_FETCH_LIMIT) },
+            )
+
+        fallbackSteps
+            .takeUntilEnough(accumulator, minimumCandidateCount, forceFallback)
+            .forEach { findCandidates -> accumulator.add(findCandidates()) }
+
+        return accumulator.toList()
+    }
+
+    private fun List<RankedRecommendationQuote>.hasLowTopScore(): Boolean {
+        val topScore = firstOrNull()?.score?.finalScore ?: return false
+
+        return topScore < LOW_TOP_SCORE_THRESHOLD
+    }
+
+    private fun List<EffectiveTag>.only(tagType: TagType): List<EffectiveTag> =
+        filter { tag -> tag.type == tagType }
+
+    private fun List<() -> List<RecommendationCandidate>>.takeUntilEnough(
+        accumulator: CandidateAccumulator,
+        minimumCandidateCount: Int,
+        forceFallback: Boolean,
+    ): Sequence<() -> List<RecommendationCandidate>> =
+        sequence {
+            for (step in this@takeUntilEnough) {
+                if (accumulator.isEnough(minimumCandidateCount, forceFallback)) break
+                yield(step)
+            }
+        }
+
+    private companion object {
+        const val MINIMUM_CANDIDATE_COUNT = 10
+        const val FALLBACK_FETCH_LIMIT = 300
+        const val LOW_TOP_SCORE_THRESHOLD = 0.35
+    }
+}
+
+private class CandidateAccumulator(
+    initialCandidates: List<RecommendationCandidate>,
+) {
+    private val candidatesByQuoteId = linkedMapOf<Long, RecommendationCandidate>()
+
+    init {
+        add(initialCandidates)
+    }
+
+    fun add(candidates: List<RecommendationCandidate>) {
+        candidates.forEach { candidate ->
+            candidatesByQuoteId.putIfAbsent(candidate.quoteId, candidate)
+        }
+    }
+
+    fun isEnough(
+        minimumCandidateCount: Int,
+        forceFallback: Boolean,
+    ): Boolean {
+        if (forceFallback) return false
+
+        return candidatesByQuoteId.size >= minimumCandidateCount
+    }
+
+    fun toList(): List<RecommendationCandidate> = candidatesByQuoteId.values.toList()
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackService.kt
@@ -42,8 +42,7 @@ class RecommendationFallbackService(
         return topScore < LOW_TOP_SCORE_THRESHOLD
     }
 
-    private fun List<EffectiveTag>.only(tagType: TagType): List<EffectiveTag> =
-        filter { tag -> tag.type == tagType }
+    private fun List<EffectiveTag>.only(tagType: TagType): List<EffectiveTag> = filter { tag -> tag.type == tagType }
 
     private fun List<() -> List<RecommendationCandidate>>.takeUntilEnough(
         accumulator: CandidateAccumulator,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepositoryTest.kt
@@ -16,6 +16,8 @@ import org.jooq.tools.jdbc.MockDataProvider
 import org.jooq.tools.jdbc.MockResult
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class RecommendationCandidateRepositoryTest {
@@ -76,6 +78,49 @@ class RecommendationCandidateRepositoryTest {
         assertEquals("", capturedSql)
     }
 
+    @Test
+    fun `완화 후보 조회는 hard filter 없이 metadata 후보를 조회한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                RecommendationCandidateRepository(dsl).findRelaxedCandidates(limit = LIMIT)
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("join \"quote_metadata\""), normalizedSql)
+        assertTrue(normalizedSql.contains("\"quotes\".\"deleted_at\" is null"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"books\".\"deleted_at\" is null"), normalizedSql)
+        assertFalse(normalizedSql.contains("\"tags\".\"id\" in"), normalizedSql)
+    }
+
+    @Test
+    fun `랜덤 후보 조회는 quote 후보를 무작위로 조회한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                RecommendationCandidateRepository(dsl).findRandomCandidates(limit = LIMIT)
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("join \"quote_metadata\""), normalizedSql)
+        assertTrue(
+            normalizedSql.contains("order by rand()") || normalizedSql.contains("order by random()"),
+            normalizedSql,
+        )
+    }
+
+    @Test
+    fun `태그가 없는 랜덤 후보도 조회 결과로 변환한다`() {
+        val candidates =
+            withMockedResult({ dsl -> noTagCandidateResult(dsl) }) { dsl ->
+                RecommendationCandidateRepository(dsl).findRandomCandidates(limit = LIMIT)
+            }
+        val candidate = candidates.first()
+
+        assertEquals(1, candidates.size)
+        assertEquals(QUOTE_ID, candidate.quoteId)
+        assertNull(candidate.roleTagId)
+        assertEquals(emptyMap(), candidate.tagIdsByType)
+    }
+
     private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {
         var capturedSql = ""
         lateinit var dsl: DSLContext
@@ -120,6 +165,19 @@ class RecommendationCandidateRepositoryTest {
             add(candidateRecord(dsl, EMOTION_TAG_ID, TagType.EMOTION))
             add(candidateRecord(dsl, NEED_TAG_ID, TagType.NEED))
             add(candidateRecord(dsl, MOOD_TAG_ID, TagType.MOOD))
+        }
+
+    private fun noTagCandidateResult(dsl: DSLContext): Result<Record> =
+        dsl.newResult(*CANDIDATE_FIELDS).apply {
+            add(
+                dsl.newRecord(*CANDIDATE_FIELDS).apply {
+                    set(QuoteTable.ID, QUOTE_ID)
+                    set(QuoteTable.BOOK_ID, BOOK_ID)
+                    set(QuoteTable.CONTENT, QUOTE_CONTENT)
+                    set(BookTable.TITLE, BOOK_TITLE)
+                    set(BookTable.AUTHOR, BOOK_AUTHOR)
+                },
+            )
         }
 
     private fun candidateRecord(

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackServiceTest.kt
@@ -113,7 +113,9 @@ class RecommendationFallbackServiceTest {
                     emotionCandidates
                 }
 
-                else -> emptyList()
+                else -> {
+                    emptyList()
+                }
             }
         }
 

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackServiceTest.kt
@@ -1,0 +1,189 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.RankedRecommendationQuote
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
+import com.firstpenguin.app.domain.recommendation.model.RecommendationScoreBreakdown
+import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
+import com.firstpenguin.app.global.enums.TagType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RecommendationFallbackServiceTest {
+    @Test
+    fun `후보가 충분하고 top score가 낮지 않으면 fallback 조회하지 않는다`() {
+        val provider = FakeRecommendationCandidateProvider()
+        val service = RecommendationFallbackService(provider)
+        val existingCandidates = (1L..10L).map(::candidate)
+
+        val result =
+            service.supplementCandidates(
+                effectiveTags = effectiveTags,
+                existingCandidates = existingCandidates,
+                rankedQuotes = listOf(rankedQuote(existingCandidates.first(), finalScore = HIGH_SCORE)),
+            )
+
+        assertEquals(existingCandidates, result)
+        assertTrue(provider.calls.isEmpty())
+    }
+
+    @Test
+    fun `후보가 부족하면 need emotion relaxed random 순서로 보강한다`() {
+        val provider =
+            FakeRecommendationCandidateProvider(
+                needCandidates = listOf(candidate(1L), candidate(2L)),
+                emotionCandidates = listOf(candidate(3L)),
+                relaxedCandidates = listOf(candidate(4L)),
+                randomCandidates = (5L..10L).map(::candidate),
+            )
+        val service = RecommendationFallbackService(provider)
+
+        val result =
+            service.supplementCandidates(
+                effectiveTags = effectiveTags,
+                existingCandidates = listOf(candidate(1L)),
+            )
+
+        assertEquals(listOf("NEED", "EMOTION", "RELAXED", "RANDOM"), provider.calls)
+        assertEquals((1L..10L).toList(), result.map { candidate -> candidate.quoteId })
+    }
+
+    @Test
+    fun `need emotion fallback은 해당 타입 effectiveTag만 전달한다`() {
+        val provider = FakeRecommendationCandidateProvider(randomCandidates = (1L..10L).map(::candidate))
+        val service = RecommendationFallbackService(provider)
+
+        service.supplementCandidates(
+            effectiveTags = effectiveTags,
+            existingCandidates = emptyList(),
+        )
+
+        assertEquals(listOf(TagType.NEED), provider.capturedTypes[0])
+        assertEquals(listOf(TagType.EMOTION), provider.capturedTypes[1])
+    }
+
+    @Test
+    fun `top score가 낮으면 후보가 충분해도 모든 fallback 단계를 검토한다`() {
+        val provider =
+            FakeRecommendationCandidateProvider(
+                needCandidates = listOf(candidate(11L)),
+                emotionCandidates = listOf(candidate(12L)),
+                relaxedCandidates = listOf(candidate(13L)),
+                randomCandidates = listOf(candidate(14L)),
+            )
+        val service = RecommendationFallbackService(provider)
+        val existingCandidates = (1L..10L).map(::candidate)
+
+        val result =
+            service.supplementCandidates(
+                effectiveTags = effectiveTags,
+                existingCandidates = existingCandidates,
+                rankedQuotes = listOf(rankedQuote(existingCandidates.first(), finalScore = LOW_SCORE)),
+            )
+
+        assertEquals(listOf("NEED", "EMOTION", "RELAXED", "RANDOM"), provider.calls)
+        assertEquals((1L..14L).toList(), result.map { candidate -> candidate.quoteId })
+    }
+
+    private class FakeRecommendationCandidateProvider(
+        private val needCandidates: List<RecommendationCandidate> = emptyList(),
+        private val emotionCandidates: List<RecommendationCandidate> = emptyList(),
+        private val relaxedCandidates: List<RecommendationCandidate> = emptyList(),
+        private val randomCandidates: List<RecommendationCandidate> = emptyList(),
+    ) : RecommendationCandidateProvider {
+        val calls = mutableListOf<String>()
+        val capturedTypes = mutableListOf<List<TagType>>()
+
+        override fun findCandidates(
+            effectiveTags: Collection<EffectiveTag>,
+            limit: Int,
+        ): List<RecommendationCandidate> {
+            val tagTypes = effectiveTags.map { tag -> tag.type }.distinct()
+            capturedTypes.add(tagTypes)
+
+            return when (tagTypes.singleOrNull()) {
+                TagType.NEED -> {
+                    calls.add("NEED")
+                    needCandidates
+                }
+
+                TagType.EMOTION -> {
+                    calls.add("EMOTION")
+                    emotionCandidates
+                }
+
+                else -> emptyList()
+            }
+        }
+
+        override fun findRelaxedCandidates(limit: Int): List<RecommendationCandidate> {
+            calls.add("RELAXED")
+
+            return relaxedCandidates
+        }
+
+        override fun findRandomCandidates(limit: Int): List<RecommendationCandidate> {
+            calls.add("RANDOM")
+
+            return randomCandidates
+        }
+    }
+
+    private companion object {
+        const val BOOK_ID = 100L
+        const val NEED_TAG_ID = 101L
+        const val EMOTION_TAG_ID = 201L
+        const val CONTEXT_TAG_ID = 301L
+        const val HIGH_SCORE = 0.8
+        const val LOW_SCORE = 0.1
+
+        val effectiveTags =
+            listOf(
+                effectiveTag(NEED_TAG_ID, TagType.NEED),
+                effectiveTag(EMOTION_TAG_ID, TagType.EMOTION),
+                effectiveTag(CONTEXT_TAG_ID, TagType.CONTEXT),
+            )
+
+        fun effectiveTag(
+            tagId: Long,
+            tagType: TagType,
+        ): EffectiveTag =
+            EffectiveTag(
+                tagId = tagId,
+                code = "${tagType.name}_$tagId",
+                type = tagType,
+            )
+
+        fun candidate(quoteId: Long): RecommendationCandidate =
+            RecommendationCandidate(
+                quoteId = quoteId,
+                bookId = BOOK_ID,
+                content = "content-$quoteId",
+                title = "title",
+                author = "author",
+                roleTagId = null,
+                tagIdsByType = emptyMap(),
+            )
+
+        fun rankedQuote(
+            candidate: RecommendationCandidate,
+            finalScore: Double,
+        ): RankedRecommendationQuote =
+            RankedRecommendationQuote(
+                rank = 1,
+                candidate = candidate,
+                score =
+                    RecommendationScoreBreakdown(
+                        needScore = 0.0,
+                        emotionScore = 0.0,
+                        contextScore = 0.0,
+                        situationScore = 0.0,
+                        moodScore = 0.0,
+                        metadataScore = finalScore,
+                        semanticScore = 0.0,
+                        finalScore = finalScore,
+                    ),
+            )
+    }
+}


### PR DESCRIPTION
## 📢 요약
- 추천 후보가 부족하거나 top score가 낮은 경우 후보를 단계적으로 보강하는 `RecommendationFallbackService`를 추가했습니다.
- fallback 순서는 기존 후보 유지 → NEED 중심 재조회 → EMOTION 중심 재조회 → metadata 조건 완화 → random quote fallback으로 구성했습니다.
- `RecommendationCandidateRepository`에 완화 후보 조회와 랜덤 후보 조회를 추가했습니다.
- 마지막 random fallback은 metadata가 없는 quote도 후보가 될 수 있도록 처리했습니다.
- avoid 관련 fallback은 포함하지 않았습니다.

🔗 연관 이슈: Resolves #134 

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [ ] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
```bash
./gradlew testClasses
./gradlew test
./gradlew detekt
```

## 📜 기타
후보는 quoteId 기준으로 중복 제거합니다.
기본 최소 후보 수는 10개입니다.
top score가 0.35 미만이면 후보 수가 충분해도 fallback 단계를 검토합니다.