### PR TITLE
feat: 추천 결과 ranker 및 composer 구현

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorer.kt
@@ -2,10 +2,8 @@ package com.firstpenguin.app.domain.recommendation.service
 
 import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
 import com.firstpenguin.app.domain.recommendation.model.IntentType
-import com.firstpenguin.app.domain.recommendation.model.RankedRecommendationQuote
 import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
 import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
-import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
 import com.firstpenguin.app.domain.recommendation.model.RecommendationScoreBreakdown
 import com.firstpenguin.app.domain.recommendation.policy.IntentFocusWeightPolicy
 import com.firstpenguin.app.domain.recommendation.policy.MoodTagPolicy
@@ -17,41 +15,6 @@ class MetadataScorer(
     private val moodTagPolicy: MoodTagPolicy,
     private val typeScoreCalculator: TypeScoreCalculator,
 ) {
-    fun recommend(
-        input: RecommendationInput,
-        effectiveTags: List<EffectiveTag>,
-        candidates: List<RecommendationCandidate>,
-        moodTagIdByCode: Map<String, Long>,
-    ): RecommendationResult? {
-        val rankedQuotes = rank(input, effectiveTags, candidates, moodTagIdByCode)
-        if (rankedQuotes.isEmpty()) return null
-
-        return RecommendationResult(
-            mainQuote = rankedQuotes.first(),
-            quotes = rankedQuotes,
-        )
-    }
-
-    fun rank(
-        input: RecommendationInput,
-        effectiveTags: List<EffectiveTag>,
-        candidates: List<RecommendationCandidate>,
-        moodTagIdByCode: Map<String, Long>,
-    ): List<RankedRecommendationQuote> =
-        candidates
-            .map { candidate -> candidate to score(input, effectiveTags, candidate, moodTagIdByCode) }
-            .sortedWith(
-                compareByDescending<Pair<RecommendationCandidate, RecommendationScoreBreakdown>> {
-                    it.second.finalScore
-                }.thenBy { it.first.quoteId },
-            ).mapIndexed { index, (candidate, score) ->
-                RankedRecommendationQuote(
-                    rank = index + FIRST_RANK,
-                    candidate = candidate,
-                    score = score,
-                )
-            }
-
     fun score(
         input: RecommendationInput,
         effectiveTags: List<EffectiveTag>,
@@ -82,7 +45,7 @@ class MetadataScorer(
             moodScore = moodScore,
             metadataScore = metadataScore,
             semanticScore = DEFAULT_SEMANTIC_SCORE,
-            finalScore = metadataScore,
+            finalScore = DEFAULT_FINAL_SCORE,
         )
     }
 
@@ -137,8 +100,8 @@ class MetadataScorer(
     private fun RecommendationCandidate.tagIds(tagType: TagType): Set<Long> = tagIdsByType[tagType].orEmpty()
 
     private companion object {
-        const val FIRST_RANK = 1
         const val DEFAULT_SEMANTIC_SCORE = 0.0
+        const val DEFAULT_FINAL_SCORE = 0.0
         const val NO_WEIGHT = 0.0
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationRanker.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationRanker.kt
@@ -1,0 +1,37 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.recommendation.model.RankedRecommendationQuote
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
+import com.firstpenguin.app.domain.recommendation.model.RecommendationScoreBreakdown
+import org.springframework.stereotype.Component
+
+@Component
+class RecommendationRanker {
+    fun rank(
+        candidates: List<RecommendationCandidate>,
+        scoreOf: (RecommendationCandidate) -> RecommendationScoreBreakdown,
+    ): List<RankedRecommendationQuote> =
+        candidates
+            .map { candidate -> candidate to scoreOf(candidate).withFinalScore() }
+            .sortedWith(
+                compareByDescending<Pair<RecommendationCandidate, RecommendationScoreBreakdown>> {
+                    it.second.finalScore
+                }.thenByDescending { it.second.metadataScore }
+                    .thenBy { it.first.quoteId },
+            ).mapIndexed { index, (candidate, score) ->
+                RankedRecommendationQuote(
+                    rank = index + FIRST_RANK,
+                    candidate = candidate,
+                    score = score,
+                )
+            }
+
+    private fun RecommendationScoreBreakdown.withFinalScore(): RecommendationScoreBreakdown =
+        copy(finalScore = METADATA_WEIGHT * metadataScore + SEMANTIC_WEIGHT * semanticScore)
+
+    private companion object {
+        const val FIRST_RANK = 1
+        const val METADATA_WEIGHT = 0.65
+        const val SEMANTIC_WEIGHT = 0.35
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
@@ -1,0 +1,96 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.RankedRecommendationQuote
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
+import org.springframework.stereotype.Component
+
+@Component
+class RecommendationResultComposer(
+    private val metadataScorer: MetadataScorer,
+    private val recommendationRanker: RecommendationRanker,
+    private val fallbackService: RecommendationFallbackService,
+) {
+    fun compose(
+        input: RecommendationInput,
+        effectiveTags: List<EffectiveTag>,
+        candidates: List<RecommendationCandidate>,
+        moodTagIdByCode: Map<String, Long>,
+    ): RecommendationResult? {
+        val initialRankedQuotes = rank(input, effectiveTags, candidates, moodTagIdByCode)
+        val supplementedCandidates =
+            fallbackService.supplementCandidates(
+                effectiveTags = effectiveTags,
+                existingCandidates = candidates,
+                rankedQuotes = initialRankedQuotes,
+            )
+        val rankedQuotes =
+            rank(input, effectiveTags, supplementedCandidates, moodTagIdByCode)
+                .diversifyRoleTags()
+                .take(RECOMMENDATION_RESULT_COUNT)
+                .rerank()
+        if (rankedQuotes.isEmpty()) return null
+
+        return RecommendationResult(
+            mainQuote = rankedQuotes.first(),
+            quotes = rankedQuotes,
+        )
+    }
+
+    private fun rank(
+        input: RecommendationInput,
+        effectiveTags: List<EffectiveTag>,
+        candidates: List<RecommendationCandidate>,
+        moodTagIdByCode: Map<String, Long>,
+    ): List<RankedRecommendationQuote> =
+        recommendationRanker.rank(candidates) { candidate ->
+            metadataScorer.score(
+                input = input,
+                effectiveTags = effectiveTags,
+                candidate = candidate,
+                moodTagIdByCode = moodTagIdByCode,
+            )
+        }
+
+    private fun List<RankedRecommendationQuote>.diversifyRoleTags(): List<RankedRecommendationQuote> {
+        val selectedQuotes = mutableListOf<RankedRecommendationQuote>()
+        val deferredQuotes = mutableListOf<RankedRecommendationQuote>()
+        val roleTagCounts = mutableMapOf<Long, Int>()
+
+        forEach { quote ->
+            if (selectedQuotes.size >= RECOMMENDATION_RESULT_COUNT) return selectedQuotes
+            if (quote.isRoleTagLimitExceeded(roleTagCounts)) {
+                deferredQuotes.add(quote)
+            } else {
+                selectedQuotes.add(quote)
+                quote.candidate.roleTagId?.let { roleTagId -> roleTagCounts.increase(roleTagId) }
+            }
+        }
+
+        return selectedQuotes
+            .plus(deferredQuotes)
+            .distinctBy { quote -> quote.quoteId }
+    }
+
+    private fun RankedRecommendationQuote.isRoleTagLimitExceeded(roleTagCounts: Map<Long, Int>): Boolean {
+        val roleTagId = candidate.roleTagId ?: return false
+
+        return roleTagCounts.getOrDefault(roleTagId, NO_ROLE_TAG_COUNT) >= MAX_SAME_ROLE_TAG_COUNT
+    }
+
+    private fun MutableMap<Long, Int>.increase(roleTagId: Long) {
+        this[roleTagId] = getOrDefault(roleTagId, NO_ROLE_TAG_COUNT) + 1
+    }
+
+    private fun List<RankedRecommendationQuote>.rerank(): List<RankedRecommendationQuote> =
+        mapIndexed { index, quote -> quote.copy(rank = index + FIRST_RANK) }
+
+    private companion object {
+        const val FIRST_RANK = 1
+        const val RECOMMENDATION_RESULT_COUNT = 10
+        const val MAX_SAME_ROLE_TAG_COUNT = 3
+        const val NO_ROLE_TAG_COUNT = 0
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorerTest.kt
@@ -17,7 +17,7 @@ class MetadataScorerTest {
     private val scorer = MetadataScorer(MoodTagPolicy(), TypeScoreCalculator())
 
     @Test
-    fun `metadataScore 기준으로 후보를 정렬한다`() {
+    fun `metadataScore를 계산하고 finalScore는 계산하지 않는다`() {
         val input = recommendationInput(intentType = IntentType.EMOTION_NEED_BASED)
         val effectiveTags =
             listOf(
@@ -46,18 +46,24 @@ class MetadataScorerTest {
                     ),
             )
 
-        val result =
-            scorer.rank(
+        val highMatchScore =
+            scorer.score(
                 input = input,
                 effectiveTags = effectiveTags,
-                candidates = listOf(lowMatchCandidate, highMatchCandidate),
+                candidate = highMatchCandidate,
+                moodTagIdByCode = moodTagIdByCode,
+            )
+        val lowMatchScore =
+            scorer.score(
+                input = input,
+                effectiveTags = effectiveTags,
+                candidate = lowMatchCandidate,
                 moodTagIdByCode = moodTagIdByCode,
             )
 
-        assertEquals(listOf(1L, 2L), result.map { quote -> quote.quoteId })
-        assertEquals(1, result.first().rank)
-        assertEquals(result.first().score.metadataScore, result.first().score.finalScore, DELTA)
-        assertEquals(0.0, result.first().score.semanticScore, DELTA)
+        assertTrue(highMatchScore.metadataScore > lowMatchScore.metadataScore)
+        assertEquals(0.0, highMatchScore.semanticScore, DELTA)
+        assertEquals(0.0, highMatchScore.finalScore, DELTA)
     }
 
     @Test
@@ -78,24 +84,6 @@ class MetadataScorerTest {
             )
 
         assertTrue(result.moodScore > 0.0)
-    }
-
-    @Test
-    fun `추천 결과는 첫 번째 정렬 후보를 mainQuote로 사용한다`() {
-        val result =
-            scorer.recommend(
-                input = recommendationInput(intentType = IntentType.EMOTION_NEED_BASED),
-                effectiveTags = listOf(effectiveTag(NEED_COMFORT_ID, "NEED_COMFORT", TagType.NEED, 1.0)),
-                candidates =
-                    listOf(
-                        candidate(quoteId = 2L, tagIdsByType = emptyMap()),
-                        candidate(quoteId = 1L, tagIdsByType = mapOf(TagType.NEED to setOf(NEED_COMFORT_ID))),
-                    ),
-                moodTagIdByCode = moodTagIdByCode,
-            )
-
-        assertEquals(1L, result?.mainQuote?.quoteId)
-        assertEquals(listOf(1L, 2L), result?.quotes?.map { quote -> quote.quoteId })
     }
 
     private fun recommendationInput(intentType: IntentType): RecommendationInput =

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationRankerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationRankerTest.kt
@@ -1,0 +1,77 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
+import com.firstpenguin.app.domain.recommendation.model.RecommendationScoreBreakdown
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RecommendationRankerTest {
+    private val ranker = RecommendationRanker()
+
+    @Test
+    fun `metadata score와 semantic score를 합산해 finalScore를 계산한다`() {
+        val candidate = candidate(QUOTE_ID)
+
+        val result =
+            ranker.rank(listOf(candidate)) {
+                score(
+                    metadataScore = METADATA_SCORE,
+                    semanticScore = SEMANTIC_SCORE,
+                )
+            }
+
+        assertEquals(EXPECTED_FINAL_SCORE, result.first().score.finalScore, DELTA)
+    }
+
+    @Test
+    fun `finalScore 기준으로 정렬하고 rank를 다시 부여한다`() {
+        val lowScoreCandidate = candidate(quoteId = 1L)
+        val highScoreCandidate = candidate(quoteId = 2L)
+
+        val result =
+            ranker.rank(listOf(lowScoreCandidate, highScoreCandidate)) { candidate ->
+                when (candidate.quoteId) {
+                    highScoreCandidate.quoteId -> score(metadataScore = 0.9, semanticScore = 0.0)
+                    else -> score(metadataScore = 0.1, semanticScore = 1.0)
+                }
+            }
+
+        assertEquals(listOf(2L, 1L), result.map { quote -> quote.quoteId })
+        assertEquals(listOf(1, 2), result.map { quote -> quote.rank })
+    }
+
+    private companion object {
+        const val QUOTE_ID = 1L
+        const val BOOK_ID = 100L
+        const val METADATA_SCORE = 0.8
+        const val SEMANTIC_SCORE = 0.6
+        const val EXPECTED_FINAL_SCORE = 0.73
+        const val DELTA = 0.000001
+
+        fun candidate(quoteId: Long): RecommendationCandidate =
+            RecommendationCandidate(
+                quoteId = quoteId,
+                bookId = BOOK_ID,
+                content = "content-$quoteId",
+                title = "title",
+                author = "author",
+                roleTagId = null,
+                tagIdsByType = emptyMap(),
+            )
+
+        fun score(
+            metadataScore: Double,
+            semanticScore: Double,
+        ): RecommendationScoreBreakdown =
+            RecommendationScoreBreakdown(
+                needScore = 0.0,
+                emotionScore = 0.0,
+                contextScore = 0.0,
+                situationScore = 0.0,
+                moodScore = 0.0,
+                metadataScore = metadataScore,
+                semanticScore = semanticScore,
+                finalScore = 0.0,
+            )
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
@@ -39,7 +39,8 @@ class RecommendationResultComposerTest {
     fun `role tag가 한쪽으로 몰리면 뒤쪽 role 후보를 앞당긴다`() {
         val composer = composer()
         val candidates =
-            (1L..8L).map { quoteId -> candidate(quoteId, roleTagId = ROLE_TAG_ID) }
+            (1L..8L)
+                .map { quoteId -> candidate(quoteId, roleTagId = ROLE_TAG_ID) }
                 .plus((9L..12L).map { quoteId -> candidate(quoteId, roleTagId = OTHER_ROLE_TAG_ID) })
 
         val result =

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
@@ -1,0 +1,186 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.emotion.model.Tag
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.IntentType
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.UserInputAnalysis
+import com.firstpenguin.app.domain.recommendation.policy.MoodTagPolicy
+import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
+import com.firstpenguin.app.global.enums.TagType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class RecommendationResultComposerTest {
+    @Test
+    fun `추천 결과는 top 10 quote와 main quote를 구성한다`() {
+        val composer = composer()
+        val candidates = (1L..12L).map { quoteId -> candidate(quoteId, roleTagId = quoteId) }
+
+        val result =
+            composer.compose(
+                input = recommendationInput(),
+                effectiveTags = effectiveTags,
+                candidates = candidates,
+                moodTagIdByCode = emptyMap(),
+            )
+
+        assertNotNull(result)
+        assertEquals(10, result?.quotes?.size)
+        assertEquals(result?.quotes?.first(), result?.mainQuote)
+        assertEquals((1..10).toList(), result?.quotes?.map { quote -> quote.rank })
+    }
+
+    @Test
+    fun `role tag가 한쪽으로 몰리면 뒤쪽 role 후보를 앞당긴다`() {
+        val composer = composer()
+        val candidates =
+            (1L..8L).map { quoteId -> candidate(quoteId, roleTagId = ROLE_TAG_ID) }
+                .plus((9L..12L).map { quoteId -> candidate(quoteId, roleTagId = OTHER_ROLE_TAG_ID) })
+
+        val result =
+            composer.compose(
+                input = recommendationInput(),
+                effectiveTags = effectiveTags,
+                candidates = candidates,
+                moodTagIdByCode = emptyMap(),
+            )
+        val quoteIds = requireNotNull(result).quotes.map { quote -> quote.quoteId }
+
+        assertTrue(quoteIds.indexOf(9L) < quoteIds.indexOf(4L))
+        assertEquals(1L, quoteIds.first())
+    }
+
+    @Test
+    fun `후보가 부족하면 fallback 후보를 보강해 top 10을 만든다`() {
+        val provider =
+            FakeRecommendationCandidateProvider(
+                randomCandidates = (3L..10L).map { quoteId -> candidate(quoteId, roleTagId = quoteId) },
+            )
+        val composer = composer(provider)
+
+        val result =
+            composer.compose(
+                input = recommendationInput(),
+                effectiveTags = effectiveTags,
+                candidates = listOf(candidate(1L, roleTagId = 1L), candidate(2L, roleTagId = 2L)),
+                moodTagIdByCode = emptyMap(),
+            )
+
+        assertEquals(listOf("NEED", "EMOTION", "RELAXED", "RANDOM"), provider.calls)
+        assertEquals((1L..10L).toList(), result?.quotes?.map { quote -> quote.quoteId })
+    }
+
+    private class FakeRecommendationCandidateProvider(
+        private val randomCandidates: List<RecommendationCandidate> = emptyList(),
+    ) : RecommendationCandidateProvider {
+        val calls = mutableListOf<String>()
+
+        override fun findCandidates(
+            effectiveTags: Collection<EffectiveTag>,
+            limit: Int,
+        ): List<RecommendationCandidate> {
+            calls.add(effectiveTags.firstOrNull()?.type?.name ?: "EMPTY")
+
+            return emptyList()
+        }
+
+        override fun findRelaxedCandidates(limit: Int): List<RecommendationCandidate> {
+            calls.add("RELAXED")
+
+            return emptyList()
+        }
+
+        override fun findRandomCandidates(limit: Int): List<RecommendationCandidate> {
+            calls.add("RANDOM")
+
+            return randomCandidates
+        }
+    }
+
+    private companion object {
+        const val USER_ID = 1L
+        const val BOOK_ID = 10L
+        const val EMOTION_RANGE_ID = 1L
+        const val NEED_TAG_ID = 101L
+        const val EMOTION_TAG_ID = 201L
+        const val ROLE_TAG_ID = 301L
+        const val OTHER_ROLE_TAG_ID = 302L
+
+        val CREATED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 13, 0, 0)
+        val effectiveTags =
+            listOf(
+                EffectiveTag(
+                    tagId = NEED_TAG_ID,
+                    code = "NEED_COMFORT",
+                    type = TagType.NEED,
+                ),
+                EffectiveTag(
+                    tagId = EMOTION_TAG_ID,
+                    code = "EMOTION_ANXIOUS",
+                    type = TagType.EMOTION,
+                ),
+            )
+
+        fun composer(
+            candidateProvider: RecommendationCandidateProvider = FakeRecommendationCandidateProvider(),
+        ): RecommendationResultComposer =
+            RecommendationResultComposer(
+                metadataScorer = MetadataScorer(MoodTagPolicy(), TypeScoreCalculator()),
+                recommendationRanker = RecommendationRanker(),
+                fallbackService = RecommendationFallbackService(candidateProvider),
+            )
+
+        fun recommendationInput(): RecommendationInput =
+            RecommendationInput(
+                userId = USER_ID,
+                emotionRangeId = EMOTION_RANGE_ID,
+                emotionTags = listOf(tag(EMOTION_TAG_ID, TagType.EMOTION, "EMOTION_ANXIOUS")),
+                needTag = tag(NEED_TAG_ID, TagType.NEED, "NEED_COMFORT"),
+                feelingText = null,
+                diaryText = null,
+                analysis =
+                    UserInputAnalysis(
+                        intentType = IntentType.EMOTION_NEED_BASED,
+                        canonicalIntent = null,
+                        tagCandidates = emptyList(),
+                    ),
+            )
+
+        fun candidate(
+            quoteId: Long,
+            roleTagId: Long?,
+        ): RecommendationCandidate =
+            RecommendationCandidate(
+                quoteId = quoteId,
+                bookId = BOOK_ID,
+                content = "content-$quoteId",
+                title = "title",
+                author = "author",
+                roleTagId = roleTagId,
+                tagIdsByType =
+                    mapOf(
+                        TagType.NEED to setOf(NEED_TAG_ID),
+                        TagType.EMOTION to setOf(EMOTION_TAG_ID),
+                    ),
+            )
+
+        fun tag(
+            id: Long,
+            type: TagType,
+            code: String,
+        ): Tag =
+            Tag(
+                id = id,
+                emotionRangeId = if (type == TagType.EMOTION) EMOTION_RANGE_ID else null,
+                code = code,
+                label = code,
+                type = type,
+                createdAt = CREATED_AT,
+            )
+    }
+}


### PR DESCRIPTION
## 📢 요약
- 추천 후보의 최종 점수를 계산하는 `RecommendationRanker`를 추가했습니다.
- `finalScore = 0.65 * metadataScore + 0.35 * semanticScore` 공식을 적용했습니다.
- `RecommendationResultComposer`를 추가해 후보 ranking, fallback 보강, role tag 다양화, top 10 구성을 담당하도록 했습니다.
- `MetadataScorer`는 metadata 점수 계산만 담당하도록 정리하고, 기존 `rank/recommend` 중복 책임을 제거했습니다.

🔗 연관 이슈: Resolves #136

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트 해당 없음

## 📸 스크린샷 / 테스트 결과
```bash
./gradlew testClasses
./gradlew test
./gradlew detekt
```

## 📜 기타
현재 브랜치에는 application.yml 로컬 수정이 남아 있지만, PR 변경 범위에는 포함되지 않습니다.
추천 생성 API에 composer를 연결하는 작업은 후속 이슈에서 진행 예정입니다.