### PR TITLE
feat: 사용자 입력 기반 추천 엔진 연결

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/repository/TagRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/repository/TagRepository.kt
@@ -98,6 +98,17 @@ class TagRepository(
             .fetch(::toTagOption)
             .groupBy { tag -> tag.type }
 
+    fun getActiveMoodTagIdByCode(): Map<String, Long> =
+        dsl
+            .select(TagTable.CODE, TagTable.ID)
+            .from(TagTable.TAGS)
+            .where(
+                TagTable.TYPE
+                    .eq(TagType.MOOD.name)
+                    .and(TagTable.IS_ACTIVE.isTrue),
+            ).fetch()
+            .associate { record -> record[TagTable.CODE]!! to record[TagTable.ID]!! }
+
     private fun toTag(record: Record): Tag =
         Tag(
             id = record[TagTable.ID]!!,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/openai/dto/OpenAiResponsesRequest.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/openai/dto/OpenAiResponsesRequest.kt
@@ -1,0 +1,13 @@
+package com.firstpenguin.app.domain.openai.dto
+
+data class OpenAiResponsesRequest(
+    val model: String,
+    val reasoning: Map<String, String>,
+    val input: String,
+    val text: OpenAiResponsesTextRequest,
+)
+
+data class OpenAiResponsesTextRequest(
+    val format: Map<String, Any>,
+    val verbosity: String,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/openai/service/OpenAiResponsesClient.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/openai/service/OpenAiResponsesClient.kt
@@ -1,0 +1,105 @@
+package com.firstpenguin.app.domain.openai.service
+
+import com.firstpenguin.app.domain.openai.dto.OpenAiResponsesRequest
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientException
+import org.springframework.web.client.body
+import java.time.Duration
+
+private const val OPENAI_BASE_URL = "https://api.openai.com/v1"
+private const val OPENAI_RESPONSES_PATH = "/responses"
+private const val OPENAI_CONNECT_TIMEOUT_SECONDS = 5L
+private const val OPENAI_READ_TIMEOUT_SECONDS = 30L
+private const val OUTPUT_TEXT_TYPE = "output_text"
+private val OPENAI_CONNECT_TIMEOUT: Duration = Duration.ofSeconds(OPENAI_CONNECT_TIMEOUT_SECONDS)
+private val OPENAI_READ_TIMEOUT: Duration = Duration.ofSeconds(OPENAI_READ_TIMEOUT_SECONDS)
+
+@Component
+class OpenAiResponsesClient(
+    @Value("\${openai.api-key:}") private val apiKey: String,
+) {
+    init {
+        if (apiKey.isBlank()) {
+            throw CustomException(ErrorCode.OPENAI_API_KEY_REQUIRED)
+        }
+    }
+
+    private val restClient =
+        RestClient
+            .builder()
+            .baseUrl(OPENAI_BASE_URL)
+            .requestFactory(openAiRequestFactory())
+            .defaultHeader("Authorization", "Bearer $apiKey")
+            .build()
+
+    fun createTextResponse(request: OpenAiResponsesRequest): String =
+        runCatching {
+            requestResponses(request).outputText()
+        }.getOrElse { exception ->
+            throw exception.toResponsesException()
+        }
+
+    private fun requestResponses(request: OpenAiResponsesRequest): Map<String, Any?> =
+        restClient
+            .post()
+            .uri(OPENAI_RESPONSES_PATH)
+            .body(request)
+            .retrieve()
+            .body<Map<String, Any?>>()
+            ?: throw CustomException(ErrorCode.OPENAI_RESPONSES_OUTPUT_TEXT_NOT_FOUND)
+
+    private fun openAiRequestFactory(): SimpleClientHttpRequestFactory =
+        SimpleClientHttpRequestFactory().apply {
+            setConnectTimeout(OPENAI_CONNECT_TIMEOUT)
+            setReadTimeout(OPENAI_READ_TIMEOUT)
+        }
+}
+
+private fun Map<String, Any?>.outputText(): String =
+    directOutputText()
+        ?: nestedOutputText()
+        ?: throw CustomException(ErrorCode.OPENAI_RESPONSES_OUTPUT_TEXT_NOT_FOUND)
+
+private fun Map<String, Any?>.directOutputText(): String? =
+    this["output_text"]
+        ?.toString()
+        ?.takeIf { text -> text.isNotBlank() }
+
+private fun Map<String, Any?>.nestedOutputText(): String? =
+    outputItems()
+        .flatMap { outputItem -> outputItem.contentItems() }
+        .firstOrNull { content -> content["type"] == OUTPUT_TEXT_TYPE }
+        ?.get("text")
+        ?.toString()
+        ?.takeIf { text -> text.isNotBlank() }
+
+private fun Map<String, Any?>.outputItems(): List<Map<*, *>> =
+    (this["output"] as? List<*>)
+        .orEmpty()
+        .mapNotNull { item -> item as? Map<*, *> }
+
+private fun Map<*, *>.contentItems(): List<Map<*, *>> =
+    (this["content"] as? List<*>)
+        .orEmpty()
+        .mapNotNull { item -> item as? Map<*, *> }
+
+private fun Throwable.toResponsesException(): Throwable =
+    when (this) {
+        is CustomException -> {
+            this
+        }
+
+        is RestClientException -> {
+            CustomException(ErrorCode.OPENAI_RESPONSES_REQUEST_FAILED)
+                .also { exception -> exception.initCause(this) }
+        }
+
+        else -> {
+            this
+        }
+    }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
@@ -50,7 +50,7 @@ class RecommendationController(
 
     @Operation(
         summary = "추천 문장 더보기 API",
-        description = "추천 기록에 추가 후보 문장 9개를 저장하고 반환한다.",
+        description = "추천 시작 시 저장된 후보 중 최초 문장을 제외한 9개를 반환한다.",
         security = [SecurityRequirement(name = "bearerAuth")],
     )
     @PostMapping("/{recommendationId}/quotes")

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationAiModelVersion.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationAiModelVersion.kt
@@ -1,0 +1,11 @@
+package com.firstpenguin.app.domain.recommendation.model
+
+enum class RecommendationAiModelVersion(
+    val model: String,
+    val version: Int,
+) {
+    USER_INPUT_ANALYSIS_V1(
+        model = "gpt-5-mini",
+        version = 1,
+    ),
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationTagRarityRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationTagRarityRepository.kt
@@ -1,0 +1,75 @@
+package com.firstpenguin.app.domain.recommendation.repository
+
+import com.firstpenguin.app.domain.book.repository.BookTable
+import com.firstpenguin.app.domain.emotion.repository.table.TagTable
+import com.firstpenguin.app.domain.quote.repository.QuoteTable
+import com.firstpenguin.app.domain.quotemetadata.repository.table.QuoteMetadataTable
+import com.firstpenguin.app.domain.quotemetadata.repository.table.QuoteMetadataTagTable
+import com.firstpenguin.app.global.enums.TagType
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.impl.DSL
+import org.springframework.stereotype.Repository
+
+@Repository
+class RecommendationTagRarityRepository(
+    private val dsl: DSLContext,
+) {
+    fun findMetadataTagRarityWeights(): Map<Long, Double> {
+        val tagCounts =
+            dsl
+                .select(TagTable.ID, TagTable.TYPE, TAG_ASSIGNMENT_COUNT)
+                .from(QuoteMetadataTagTable.QUOTE_METADATA_TAGS)
+                .join(QuoteMetadataTable.QUOTE_METADATA)
+                .on(QuoteMetadataTable.ID.eq(QuoteMetadataTagTable.QUOTE_METADATA_ID))
+                .join(QuoteTable.QUOTES)
+                .on(QuoteTable.ID.eq(QuoteMetadataTable.QUOTE_ID))
+                .join(BookTable.BOOKS)
+                .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+                .join(TagTable.TAGS)
+                .on(TagTable.ID.eq(QuoteMetadataTagTable.TAG_ID))
+                .where(TagTable.TYPE.`in`(RARITY_WEIGHTED_TAG_TYPE_NAMES))
+                .and(TagTable.IS_ACTIVE.isTrue)
+                .and(QuoteTable.DELETED_AT.isNull)
+                .and(BookTable.DELETED_AT.isNull)
+                .groupBy(TagTable.ID, TagTable.TYPE)
+                .fetch(::toMetadataTagCount)
+
+        return tagCounts.toRarityWeights()
+    }
+
+    private fun toMetadataTagCount(record: Record): MetadataTagCount =
+        MetadataTagCount(
+            tagId = record[TagTable.ID]!!,
+            type = TagType.from(record[TagTable.TYPE]!!),
+            count = record[TAG_ASSIGNMENT_COUNT]!!,
+        )
+
+    private fun List<MetadataTagCount>.toRarityWeights(): Map<Long, Double> {
+        val totalCountByType = groupBy { count -> count.type }.mapValues { (_, counts) -> counts.sumOf { it.count } }
+
+        return associate { count ->
+            val totalCount = totalCountByType.getValue(count.type)
+            count.tagId to rarityWeight(count.count.toDouble() / totalCount)
+        }
+    }
+
+    private fun rarityWeight(typeRatio: Double): Double = 1.0 - typeRatio.coerceIn(MIN_TYPE_RATIO, MAX_DISCOUNT_RATIO)
+
+    private companion object {
+        const val TAG_ASSIGNMENT_COUNT_NAME = "tag_assignment_count"
+        const val MIN_TYPE_RATIO = 0.0
+        const val MAX_DISCOUNT_RATIO = 0.5
+
+        val TAG_ASSIGNMENT_COUNT: Field<Int> = DSL.count().`as`(TAG_ASSIGNMENT_COUNT_NAME)
+        val RARITY_WEIGHTED_TAG_TYPES = setOf(TagType.EMOTION, TagType.NEED, TagType.MOOD)
+        val RARITY_WEIGHTED_TAG_TYPE_NAMES = RARITY_WEIGHTED_TAG_TYPES.map { type -> type.name }
+    }
+}
+
+private data class MetadataTagCount(
+    val tagId: Long,
+    val type: TagType,
+    val count: Int,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorer.kt
@@ -20,13 +20,14 @@ class MetadataScorer(
         effectiveTags: List<EffectiveTag>,
         candidate: RecommendationCandidate,
         moodTagIdByCode: Map<String, Long>,
+        tagRarityWeights: Map<Long, Double> = emptyMap(),
     ): RecommendationScoreBreakdown {
         val intentType = input.analysis?.intentType ?: IntentType.EMOTION_NEED_BASED
-        val needScore = typeScore(TagType.NEED, effectiveTags, candidate)
-        val emotionScore = typeScore(TagType.EMOTION, effectiveTags, candidate)
+        val needScore = typeScore(TagType.NEED, effectiveTags, candidate, tagRarityWeights)
+        val emotionScore = typeScore(TagType.EMOTION, effectiveTags, candidate, tagRarityWeights)
         val contextScore = typeScore(TagType.CONTEXT, effectiveTags, candidate)
         val situationScore = typeScore(TagType.SITUATION, effectiveTags, candidate)
-        val moodScore = moodScore(input, effectiveTags, candidate, moodTagIdByCode)
+        val moodScore = moodScore(input, effectiveTags, candidate, moodTagIdByCode, tagRarityWeights)
         val metadataScore =
             metadataScore(
                 intentType = intentType,
@@ -53,10 +54,12 @@ class MetadataScorer(
         tagType: TagType,
         effectiveTags: List<EffectiveTag>,
         candidate: RecommendationCandidate,
+        tagRarityWeights: Map<Long, Double> = emptyMap(),
     ): Double =
         typeScoreCalculator.calculate(
             targetTags = effectiveTags.filter { tag -> tag.type == tagType },
             candidateTagIds = candidate.tagIds(tagType),
+            tagRarityWeights = tagRarityWeights,
         )
 
     private fun moodScore(
@@ -64,6 +67,7 @@ class MetadataScorer(
         effectiveTags: List<EffectiveTag>,
         candidate: RecommendationCandidate,
         moodTagIdByCode: Map<String, Long>,
+        tagRarityWeights: Map<Long, Double>,
     ): Double {
         val targetMoodTagIds =
             moodTagPolicy
@@ -73,6 +77,7 @@ class MetadataScorer(
         return typeScoreCalculator.calculate(
             targetTagIds = targetMoodTagIds,
             candidateTagIds = candidate.tagIds(TagType.MOOD),
+            tagRarityWeights = tagRarityWeights,
         )
     }
 

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisService.kt
@@ -1,0 +1,40 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.emotion.repository.TagRepository
+import com.firstpenguin.app.domain.openai.service.OpenAiResponsesClient
+import com.firstpenguin.app.domain.quotemetadata.dto.TagOption
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.UserInputAnalysis
+import com.firstpenguin.app.global.enums.TagType
+import org.springframework.stereotype.Service
+
+@Service
+class OpenAiUserInputAnalysisService(
+    private val tagRepository: TagRepository,
+    private val requestBuilder: UserInputParseRequestBuilder,
+    private val outputParser: UserInputParseOutputParser,
+    private val openAiResponsesClient: OpenAiResponsesClient,
+) : UserInputAnalysisService {
+    override fun analyze(input: RecommendationInput): UserInputAnalysis? {
+        if (!input.hasText()) return null
+
+        return runCatching { analyzeOrThrow(input) }.getOrNull()
+    }
+
+    private fun analyzeOrThrow(input: RecommendationInput): UserInputAnalysis {
+        val tagGroups = tagRepository.getActiveTagsByType().onlyUserInputParseTagGroups()
+        val request = requestBuilder.build(input, tagGroups)
+        val outputText = openAiResponsesClient.createTextResponse(request)
+
+        return outputParser.parse(outputText, input, tagGroups)
+    }
+
+    private fun RecommendationInput.hasText(): Boolean = feelingText.hasValue() || diaryText.hasValue()
+
+    private fun String?.normalizedText(): String? = this?.trim()?.takeIf { text -> text.isNotEmpty() }
+
+    private fun String?.hasValue(): Boolean = normalizedText() != null
+
+    private fun Map<TagType, List<TagOption>>.onlyUserInputParseTagGroups(): Map<TagType, List<TagOption>> =
+        filterKeys { type -> type in USER_INPUT_PARSE_TAG_TYPES }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationEngine.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationEngine.kt
@@ -6,6 +6,7 @@ import com.firstpenguin.app.domain.recommendation.dto.RecommendationRequest
 import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
 import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
 import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
+import com.firstpenguin.app.domain.recommendation.repository.RecommendationTagRarityRepository
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.stereotype.Service
@@ -19,6 +20,7 @@ class RecommendationEngine(
     private val userInputAnalysisService: UserInputAnalysisService,
     private val effectiveTagBuilder: EffectiveTagBuilder,
     private val candidateProvider: RecommendationCandidateProvider,
+    private val tagRarityRepository: RecommendationTagRarityRepository,
     private val resultComposer: RecommendationResultComposer,
 ) {
     fun recommend(
@@ -34,6 +36,7 @@ class RecommendationEngine(
                 effectiveTags = effectiveTags,
                 candidates = candidates,
                 moodTagIdByCode = tagRepository.getActiveMoodTagIdByCode(),
+                tagRarityWeights = tagRarityRepository.findMetadataTagRarityWeights(),
             ) ?: notEnoughQuotes()
 
         if (result.quotes.size < RECOMMENDATION_RESULT_QUOTE_COUNT) {

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationEngine.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationEngine.kt
@@ -1,0 +1,72 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.emotion.repository.TagRepository
+import com.firstpenguin.app.domain.emotion.service.EmotionService
+import com.firstpenguin.app.domain.recommendation.dto.RecommendationRequest
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
+import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+import org.springframework.stereotype.Service
+
+private const val RECOMMENDATION_RESULT_QUOTE_COUNT = 10
+
+@Service
+class RecommendationEngine(
+    private val emotionService: EmotionService,
+    private val tagRepository: TagRepository,
+    private val userInputAnalysisService: UserInputAnalysisService,
+    private val effectiveTagBuilder: EffectiveTagBuilder,
+    private val candidateProvider: RecommendationCandidateProvider,
+    private val resultComposer: RecommendationResultComposer,
+) {
+    fun recommend(
+        userId: Long,
+        request: RecommendationRequest,
+    ): RecommendationResult {
+        val input = buildInput(userId, request).withAnalysis()
+        val effectiveTags = effectiveTagBuilder.build(input)
+        val candidates = candidateProvider.findCandidates(effectiveTags)
+        val result =
+            resultComposer.compose(
+                input = input,
+                effectiveTags = effectiveTags,
+                candidates = candidates,
+                moodTagIdByCode = tagRepository.getActiveMoodTagIdByCode(),
+            ) ?: notEnoughQuotes()
+
+        if (result.quotes.size < RECOMMENDATION_RESULT_QUOTE_COUNT) {
+            notEnoughQuotes()
+        }
+
+        return result
+    }
+
+    private fun buildInput(
+        userId: Long,
+        request: RecommendationRequest,
+    ): RecommendationInput {
+        val selectedTagIds = request.emotionTagIds + listOfNotNull(request.needTagId)
+        val (emotionTags, needTag) = emotionService.getEmotionTagsAndNeedTagByIds(selectedTagIds)
+
+        return RecommendationInput(
+            userId = userId,
+            emotionRangeId = request.emotionRangeId,
+            emotionTags = emotionTags,
+            needTag = needTag,
+            feelingText = request.feelingText.normalizedText(),
+            diaryText = request.diaryText.normalizedText(),
+            analysis = null,
+        )
+    }
+
+    private fun RecommendationInput.withAnalysis(): RecommendationInput =
+        copy(
+            analysis = userInputAnalysisService.analyze(this),
+        )
+}
+
+private fun String?.normalizedText(): String? = this?.trim()?.takeIf { text -> text.isNotEmpty() }
+
+private fun notEnoughQuotes(): Nothing = throw CustomException(ErrorCode.NOT_ENOUGH_QUOTES)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
@@ -20,9 +20,11 @@ class RecommendationResultComposer(
         effectiveTags: List<EffectiveTag>,
         candidates: List<RecommendationCandidate>,
         moodTagIdByCode: Map<String, Long>,
+        tagRarityWeights: Map<Long, Double> = emptyMap(),
     ): RecommendationResult? {
         val userEmbedding = semanticProvider.prepare(input)
-        val initialRankedQuotes = rank(input, effectiveTags, candidates, moodTagIdByCode, userEmbedding)
+        val initialRankedQuotes =
+            rank(input, effectiveTags, candidates, moodTagIdByCode, tagRarityWeights, userEmbedding)
         val supplementedCandidates =
             fallbackService.supplementCandidates(
                 effectiveTags = effectiveTags,
@@ -36,7 +38,7 @@ class RecommendationResultComposer(
                 },
             )
         val rankedQuotes =
-            rank(input, effectiveTags, supplementedCandidates, moodTagIdByCode, userEmbedding)
+            rank(input, effectiveTags, supplementedCandidates, moodTagIdByCode, tagRarityWeights, userEmbedding)
                 .diversifyRoleTags()
                 .take(RECOMMENDATION_RESULT_COUNT)
                 .rerank()
@@ -53,6 +55,7 @@ class RecommendationResultComposer(
         effectiveTags: List<EffectiveTag>,
         candidates: List<RecommendationCandidate>,
         moodTagIdByCode: Map<String, Long>,
+        tagRarityWeights: Map<Long, Double>,
         userEmbedding: UserSemanticEmbedding?,
     ): List<RankedRecommendationQuote> {
         val semanticScores =
@@ -68,6 +71,7 @@ class RecommendationResultComposer(
                     effectiveTags = effectiveTags,
                     candidate = candidate,
                     moodTagIdByCode = moodTagIdByCode,
+                    tagRarityWeights = tagRarityWeights,
                 ).copy(semanticScore = semanticScores[candidate.quoteId] ?: DEFAULT_SEMANTIC_SCORE)
         }
     }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/TypeScoreCalculator.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/TypeScoreCalculator.kt
@@ -9,6 +9,7 @@ class TypeScoreCalculator {
     fun calculate(
         targetTags: Collection<EffectiveTag>,
         candidateTagIds: Set<Long>,
+        tagRarityWeights: Map<Long, Double> = emptyMap(),
     ): Double {
         if (targetTags.isEmpty() || candidateTagIds.isEmpty()) return NO_MATCH_SCORE
 
@@ -16,19 +17,23 @@ class TypeScoreCalculator {
         return if (totalImportance <= NO_MATCH_SCORE) {
             NO_MATCH_SCORE
         } else {
-            calculateByImportance(targetTags, candidateTagIds, totalImportance)
+            calculateByImportance(targetTags, candidateTagIds, totalImportance, tagRarityWeights)
         }
     }
 
     fun calculate(
         targetTagIds: Set<Long>,
         candidateTagIds: Set<Long>,
+        tagRarityWeights: Map<Long, Double> = emptyMap(),
     ): Double {
         if (targetTagIds.isEmpty() || candidateTagIds.isEmpty()) return NO_MATCH_SCORE
 
-        val matchCount = targetTagIds.count { tagId -> tagId in candidateTagIds }
-        val bestMatchScore = if (matchCount > 0) FULL_MATCH_SCORE else NO_MATCH_SCORE
-        val coverageScore = matchCount.toDouble() / targetTagIds.size
+        val matchedWeights =
+            targetTagIds
+                .filter { tagId -> tagId in candidateTagIds }
+                .map { tagId -> tagRarityWeights.rarityWeight(tagId) }
+        val bestMatchScore = matchedWeights.maxOrNull() ?: NO_MATCH_SCORE
+        val coverageScore = matchedWeights.sum() / targetTagIds.size
 
         return calculate(bestMatchScore, coverageScore)
     }
@@ -44,13 +49,20 @@ class TypeScoreCalculator {
         targetTags: Collection<EffectiveTag>,
         candidateTagIds: Set<Long>,
         totalImportance: Double,
+        tagRarityWeights: Map<Long, Double>,
     ): Double {
-        val matchedTags = targetTags.filter { tag -> tag.tagId in candidateTagIds }
-        val bestMatchScore = matchedTags.maxOfOrNull { tag -> tag.importance } ?: NO_MATCH_SCORE
-        val coverageScore = matchedTags.sumOf { tag -> tag.importance } / totalImportance
+        val matchedWeights =
+            targetTags
+                .filter { tag -> tag.tagId in candidateTagIds }
+                .map { tag -> tag.importance * tagRarityWeights.rarityWeight(tag.tagId) }
+        val bestMatchScore = matchedWeights.maxOrNull() ?: NO_MATCH_SCORE
+        val coverageScore = matchedWeights.sum() / totalImportance
 
         return calculate(bestMatchScore, coverageScore)
     }
+
+    private fun Map<Long, Double>.rarityWeight(tagId: Long): Double =
+        getOrDefault(tagId, FULL_MATCH_SCORE).coerceIn(NO_MATCH_SCORE, FULL_MATCH_SCORE)
 
     private companion object {
         const val BEST_MATCH_WEIGHT = 0.75

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputAnalysisService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputAnalysisService.kt
@@ -1,0 +1,8 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.UserInputAnalysis
+
+interface UserInputAnalysisService {
+    fun analyze(input: RecommendationInput): UserInputAnalysis?
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseOutputParser.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseOutputParser.kt
@@ -1,0 +1,58 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.quotemetadata.dto.TagOption
+import com.firstpenguin.app.domain.recommendation.model.IntentType
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.UserInputAnalysis
+import com.firstpenguin.app.global.enums.TagType
+import org.springframework.stereotype.Component
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+
+@Component
+class UserInputParseOutputParser(
+    private val objectMapper: ObjectMapper,
+    private val tagCandidateMapper: UserInputTagCandidateMapper,
+) {
+    fun parse(
+        outputText: String,
+        input: RecommendationInput,
+        tagGroups: Map<TagType, List<TagOption>>,
+    ): UserInputAnalysis =
+        objectMapper
+            .readTree(outputText)
+            .toUserInputAnalysis(input, tagGroups, tagCandidateMapper)
+}
+
+private fun JsonNode.toUserInputAnalysis(
+    input: RecommendationInput,
+    tagGroups: Map<TagType, List<TagOption>>,
+    tagCandidateMapper: UserInputTagCandidateMapper,
+): UserInputAnalysis =
+    UserInputAnalysis(
+        intentType = IntentType.valueOf(requiredText("intentType")),
+        canonicalIntent = requiredText("canonicalIntent"),
+        tagCandidates = tagCandidateMapper.map(tagCandidateNodes(), input, tagGroups),
+    )
+
+private fun JsonNode.tagCandidateNodes(): List<Pair<TagType, JsonNode>> =
+    listOf(
+        TagType.EMOTION to "emotionTagCandidates",
+        TagType.NEED to "needTagCandidates",
+        TagType.SITUATION to "situationTagCandidates",
+        TagType.CONTEXT to "contextTagCandidates",
+        TagType.ROLE to "roleTagCandidates",
+    ).flatMap { (type, fieldName) ->
+        path(fieldName).toList().map { node -> type to node }
+    }
+
+private fun JsonNode.requiredText(fieldName: String): String =
+    stringOrEmpty(fieldName)
+        .takeIf { value -> value.isNotBlank() }
+        ?: error("Missing required text field: $fieldName")
+
+private fun JsonNode.stringOrEmpty(fieldName: String): String =
+    path(fieldName)
+        .takeUnless { node -> node.isMissingNode || node.isNull }
+        ?.asString()
+        .orEmpty()

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseRequestBuilder.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseRequestBuilder.kt
@@ -1,0 +1,112 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.openai.dto.OpenAiResponsesRequest
+import com.firstpenguin.app.domain.openai.dto.OpenAiResponsesTextRequest
+import com.firstpenguin.app.domain.quotemetadata.dto.TagOption
+import com.firstpenguin.app.domain.recommendation.model.RecommendationAiModelVersion
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.global.enums.TagType
+import org.springframework.stereotype.Component
+import tools.jackson.databind.json.JsonMapper
+
+private const val OPENAI_REASONING_EFFORT = "low"
+private const val OPENAI_TEXT_VERBOSITY = "low"
+
+private val USER_INPUT_PARSE_PROMPT_GUIDE =
+    """
+너는 감정 기반 문장 추천 서비스의 사용자 입력 분석기다.
+
+너의 역할은 사용자의 free text와 diary text를 분석하여 추천 엔진이 사용할 intentType, canonicalIntent,
+타입별 tag candidate를 반환하는 것이다.
+
+중요 규칙:
+1. 반드시 제공된 tagCode 중에서만 선택하라.
+2. feelingText는 사용자가 원하는 추천 의도를 나타내는 가장 중요한 텍스트다.
+3. diaryText는 배경 정보로만 사용하라.
+4. feelingText와 diaryText가 충돌하면 feelingText를 우선하라.
+5. context/situation tag를 중심으로 추출하라.
+6. emotion/need tag는 명확한 근거가 있을 때만 추출하라.
+7. 개수를 채우기 위해 약한 태그를 선택하지 마라.
+8. hasSelectedNeedTag가 false이고 feelingText가 있으면 allowed NEED tag 중
+    feelingText와 가장 일치하는 NEED tag를 반드시 1개 반환하라.
+9. hasSelectedNeedTag가 true이면 need tag도 emotion tag와 동일하게 12번 규칙을 따른다.
+10. context tag는 실제 장소, 날씨, 시간, 활동, 장면이 직접 드러날 때만 선택하라.
+11. situation tag는 실제 삶의 문제, 사건, 관계, 주제가 직접 드러날 때만 선택하라.
+12. 은유적 표현만으로 context나 situation을 선택하지 마라.
+13. 출력은 반드시 JSON schema를 따르고 JSON 외의 설명 문장은 출력하지 마라.
+
+[intentType 기준]
+- EMOTION_NEED_BASED: 감정과 필요한 반응이 중심이다.
+- CONTEXT_BASED: 날씨, 시간, 장소, 활동 같은 맥락이 추천 의도에 직접적이다.
+- SITUATION_BASED: 실패, 관계, 일, 이별, 변화 같은 삶의 사건이 중심이다.
+- MIXED: 감정, 필요, 상황, 성찰이 섞여 있거나 관점 전환/마음정리가 중심이다.
+
+[canonicalIntent 작성 기준]
+- 한국어 한 문장으로 작성하라.
+- 사용자의 현재 마음과 원하는 도움을 요약하라.
+- quote, 문장, 추천 결과를 설명하지 마라.
+- tagCode나 label을 단순 나열하지 마라.
+- 35~90자 사이를 권장한다.
+- 좋은 형태: 실패한 뒤 불안하고 위축된 마음을 다독이며 다시 관점을 정리하고 싶다
+- 나쁜 형태: 이 사용자에게 위로와 관점 전환 태그가 적합하다
+    """.trimIndent()
+
+@Component
+class UserInputParseRequestBuilder(
+    private val jsonMapper: JsonMapper,
+) {
+    fun build(
+        input: RecommendationInput,
+        tagGroups: Map<TagType, List<TagOption>>,
+    ): OpenAiResponsesRequest =
+        OpenAiResponsesRequest(
+            model = RecommendationAiModelVersion.USER_INPUT_ANALYSIS_V1.model,
+            reasoning = mapOf("effort" to OPENAI_REASONING_EFFORT),
+            input = buildPrompt(input, tagGroups),
+            text =
+                OpenAiResponsesTextRequest(
+                    format = userInputParseSchema(tagGroups),
+                    verbosity = OPENAI_TEXT_VERBOSITY,
+                ),
+        )
+
+    private fun buildPrompt(
+        input: RecommendationInput,
+        tagGroups: Map<TagType, List<TagOption>>,
+    ): String =
+        listOf(
+            USER_INPUT_PARSE_PROMPT_GUIDE,
+            requestPayload(input, tagGroups),
+        ).joinToString("\n\n")
+
+    private fun requestPayload(
+        input: RecommendationInput,
+        tagGroups: Map<TagType, List<TagOption>>,
+    ): String =
+        """
+        [분석 대상 사용자 입력]
+        ${jsonMapper.writeValueAsString(input.toPayload(tagGroups))}
+        """.trimIndent()
+
+    private fun RecommendationInput.toPayload(tagGroups: Map<TagType, List<TagOption>>): Map<String, Any?> =
+        mapOf(
+            "hasSelectedNeedTag" to (needTag != null),
+            "feelingText" to feelingText.normalizedText(),
+            "diaryText" to diaryText.normalizedText(),
+            "allowedTags" to tagGroups.toAllowedTagsPayload(),
+        )
+
+    private fun String?.normalizedText(): String? = this?.trim()?.takeIf { text -> text.isNotEmpty() }
+
+    private fun Map<TagType, List<TagOption>>.toAllowedTagsPayload(): Map<String, List<Map<String, String>>> =
+        USER_INPUT_PARSE_TAG_TYPES.associate { type ->
+            type.name to get(type).orEmpty().map { option -> option.toPayload() }
+        }
+
+    private fun TagOption.toPayload(): Map<String, String> =
+        mapOf(
+            "label" to label,
+            "tagCode" to code,
+            "description" to description.orEmpty(),
+        )
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchema.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchema.kt
@@ -1,0 +1,143 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.quotemetadata.dto.TagOption
+import com.firstpenguin.app.domain.recommendation.model.IntentType
+import com.firstpenguin.app.domain.recommendation.model.TagCandidatePriority
+import com.firstpenguin.app.domain.recommendation.model.TagCandidateSource
+import com.firstpenguin.app.global.enums.TagType
+
+private const val CANONICAL_INTENT_MIN_LENGTH = 10
+private const val CANONICAL_INTENT_MAX_LENGTH = 120
+private const val EMOTION_TAG_MAX_ITEMS = 2
+private const val NEED_TAG_MAX_ITEMS = 1
+private const val SUPPORTING_TAG_MAX_ITEMS = 3
+private const val ROLE_TAG_MAX_ITEMS = 1
+
+internal fun userInputParseSchema(tagGroups: Map<TagType, List<TagOption>>): Map<String, Any> =
+    mapOf(
+        "type" to "json_schema",
+        "name" to "user_input_parse",
+        "strict" to true,
+        "schema" to userInputParseObjectSchema(tagGroups),
+    )
+
+private fun userInputParseObjectSchema(tagGroups: Map<TagType, List<TagOption>>): Map<String, Any> =
+    mapOf(
+        "type" to "object",
+        "additionalProperties" to false,
+        "required" to requiredUserInputParseFields(),
+        "properties" to userInputParseProperties(tagGroups),
+    )
+
+private fun requiredUserInputParseFields(): List<String> =
+    listOf(
+        "intentType",
+        "canonicalIntent",
+        "emotionTagCandidates",
+        "needTagCandidates",
+        "situationTagCandidates",
+        "contextTagCandidates",
+        "roleTagCandidates",
+    )
+
+private fun userInputParseProperties(tagGroups: Map<TagType, List<TagOption>>): Map<String, Any> =
+    mapOf(
+        "intentType" to
+            enumSchema(
+                values = IntentType.entries.map { type -> type.name },
+                description = "사용자 입력의 추천 의도 유형",
+            ),
+        "canonicalIntent" to
+            mapOf(
+                "type" to "string",
+                "description" to "사용자의 현재 마음과 원하는 도움을 요약한 한국어 한 문장",
+                "minLength" to CANONICAL_INTENT_MIN_LENGTH,
+                "maxLength" to CANONICAL_INTENT_MAX_LENGTH,
+            ),
+        "emotionTagCandidates" to
+            tagCandidatesSchema(
+                options = tagGroups.getValue(TagType.EMOTION),
+                description = "텍스트에 명확히 드러난 사용자 감정 후보.",
+                maxItems = EMOTION_TAG_MAX_ITEMS,
+            ),
+        "needTagCandidates" to
+            tagCandidatesSchema(
+                options = tagGroups.getValue(TagType.NEED),
+                description = "텍스트에 명확히 드러난 필요/기대 후보. hasSelectedNeedTag=false이면 feelingText와 가장 일치하는 후보 1개를 반환한다.",
+                maxItems = NEED_TAG_MAX_ITEMS,
+            ),
+        "situationTagCandidates" to
+            tagCandidatesSchema(
+                options = tagGroups.getValue(TagType.SITUATION),
+                description = "실제 삶의 문제, 사건, 관계, 주제가 직접 드러난 경우의 상황 후보",
+                maxItems = SUPPORTING_TAG_MAX_ITEMS,
+            ),
+        "contextTagCandidates" to
+            tagCandidatesSchema(
+                options = tagGroups.getValue(TagType.CONTEXT),
+                description = "실제 장소, 날씨, 시간, 활동, 장면이 직접 드러난 경우의 맥락 후보",
+                maxItems = SUPPORTING_TAG_MAX_ITEMS,
+            ),
+        "roleTagCandidates" to
+            tagCandidatesSchema(
+                options = tagGroups.getValue(TagType.ROLE),
+                description = "사용자가 원하는 문장의 역할 후보. 명확한 경우에만 반환한다.",
+                maxItems = ROLE_TAG_MAX_ITEMS,
+            ),
+    )
+
+private fun tagCandidatesSchema(
+    options: List<TagOption>,
+    description: String,
+    maxItems: Int,
+): Map<String, Any> =
+    mapOf(
+        "type" to "array",
+        "description" to description,
+        "maxItems" to maxItems,
+        "items" to tagCandidateSchema(options),
+    )
+
+private fun tagCandidateSchema(options: List<TagOption>): Map<String, Any> =
+    mapOf(
+        "type" to "object",
+        "additionalProperties" to false,
+        "required" to listOf("tagCode", "source", "priority", "confidence"),
+        "properties" to tagCandidateProperties(options),
+    )
+
+private fun tagCandidateProperties(options: List<TagOption>): Map<String, Any> =
+    mapOf(
+        "tagCode" to
+            enumSchema(
+                values = options.map { option -> option.code },
+                description = "반드시 이 카테고리에 허용된 tagCode 중 하나만 선택한다.",
+            ),
+        "source" to
+            enumSchema(
+                values = listOf(TagCandidateSource.FEELING_TEXT.name, TagCandidateSource.DIARY_TEXT.name),
+                description = "태그 선택의 근거가 된 입력 텍스트",
+            ),
+        "priority" to
+            enumSchema(
+                values = TagCandidatePriority.entries.map { priority -> priority.name },
+                description = "같은 카테고리 안에서 추천 엔진에 전달할 우선순위",
+            ),
+        "confidence" to
+            mapOf(
+                "type" to "number",
+                "description" to "텍스트 근거가 얼마나 명확한지 0.0부터 1.0 사이로 표현한다.",
+                "minimum" to 0.0,
+                "maximum" to 1.0,
+            ),
+    )
+
+private fun enumSchema(
+    values: List<String>,
+    description: String,
+): Map<String, Any> =
+    mapOf(
+        "type" to "string",
+        "description" to description,
+        "enum" to values.distinct(),
+    )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseTagTypes.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseTagTypes.kt
@@ -1,0 +1,12 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.global.enums.TagType
+
+internal val USER_INPUT_PARSE_TAG_TYPES =
+    listOf(
+        TagType.EMOTION,
+        TagType.NEED,
+        TagType.SITUATION,
+        TagType.CONTEXT,
+        TagType.ROLE,
+    )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputTagCandidateMapper.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputTagCandidateMapper.kt
@@ -1,0 +1,131 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.quotemetadata.dto.TagOption
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.TagCandidate
+import com.firstpenguin.app.domain.recommendation.model.TagCandidatePriority
+import com.firstpenguin.app.domain.recommendation.model.TagCandidateSource
+import com.firstpenguin.app.global.enums.TagType
+import org.springframework.stereotype.Component
+import tools.jackson.databind.JsonNode
+
+@Component
+class UserInputTagCandidateMapper {
+    fun map(
+        nodes: List<Pair<TagType, JsonNode>>,
+        input: RecommendationInput,
+        tagGroups: Map<TagType, List<TagOption>>,
+    ): List<TagCandidate> {
+        val selectedCodes = input.selectedTagCodes()
+        val tagOptionByCode = tagGroups.toTagOptionByCode()
+
+        val candidates =
+            nodes
+                .mapNotNull { (tagType, node) ->
+                    node.toTagCandidate(tagType, input, selectedCodes, tagOptionByCode)
+                }
+
+        return candidates.distinctBy { candidate -> candidate.type to candidate.tagId }
+    }
+
+    private fun JsonNode.toTagCandidate(
+        tagType: TagType,
+        input: RecommendationInput,
+        selectedCodes: Set<String>,
+        tagOptionByCode: Map<String, TagOption>,
+    ): TagCandidate? =
+        runCatching {
+            val tagCode = requiredText("tagCode")
+            val source = TagCandidateSource.valueOf(requiredText("source"))
+            val priority = TagCandidatePriority.valueOf(requiredText("priority"))
+            val confidence = path("confidence").asDouble().coerceIn(0.0, 1.0)
+            val tagOption = tagOptionByCode[tagCode] ?: return@runCatching null
+
+            if (!isResolvable(tagCode, tagType, source, confidence, selectedCodes, tagOption)) {
+                return@runCatching null
+            }
+
+            tagOption.toTagCandidate(input, source, priority, confidence)
+        }.getOrNull()
+
+    private fun isResolvable(
+        tagCode: String,
+        tagType: TagType,
+        source: TagCandidateSource,
+        confidence: Double,
+        selectedCodes: Set<String>,
+        tagOption: TagOption,
+    ): Boolean =
+        confidence >= MIN_CONFIDENCE &&
+            tagType in USER_INPUT_PARSE_TAG_TYPES &&
+            source != TagCandidateSource.USER_SELECTED &&
+            tagCode !in selectedCodes &&
+            tagOption.type == tagType
+
+    private fun TagOption.toTagCandidate(
+        input: RecommendationInput,
+        source: TagCandidateSource,
+        priority: TagCandidatePriority,
+        confidence: Double,
+    ): TagCandidate =
+        TagCandidate(
+            tagId = id,
+            code = code,
+            label = label,
+            type = type,
+            source = source,
+            priority = priority.normalized(input, type, source),
+            confidence = confidence,
+        )
+
+    private fun TagCandidatePriority.normalized(
+        input: RecommendationInput,
+        tagType: TagType,
+        source: TagCandidateSource,
+    ): TagCandidatePriority {
+        val maxPriority =
+            when {
+                source == TagCandidateSource.DIARY_TEXT -> TagCandidatePriority.SECONDARY
+                tagType == TagType.EMOTION -> TagCandidatePriority.SECONDARY
+                tagType == TagType.NEED && input.needTag != null -> TagCandidatePriority.SECONDARY
+                else -> TagCandidatePriority.PRIMARY
+            }
+
+        return atMost(maxPriority)
+    }
+
+    private fun TagCandidatePriority.atMost(maxPriority: TagCandidatePriority): TagCandidatePriority =
+        if (rank() > maxPriority.rank()) maxPriority else this
+
+    private fun TagCandidatePriority.rank(): Int =
+        when (this) {
+            TagCandidatePriority.BACKGROUND -> BACKGROUND_RANK
+            TagCandidatePriority.SECONDARY -> SECONDARY_RANK
+            TagCandidatePriority.PRIMARY -> PRIMARY_RANK
+        }
+
+    private fun RecommendationInput.selectedTagCodes(): Set<String> =
+        emotionTags
+            .map { tag -> tag.code }
+            .plus(listOfNotNull(needTag?.code))
+            .toSet()
+
+    private fun Map<TagType, List<TagOption>>.toTagOptionByCode(): Map<String, TagOption> =
+        USER_INPUT_PARSE_TAG_TYPES
+            .flatMap { type -> get(type).orEmpty() }
+            .associateBy { option -> option.code }
+
+    private fun JsonNode.requiredText(fieldName: String): String =
+        path(fieldName)
+            .takeUnless { node -> node.isMissingNode || node.isNull }
+            ?.asString()
+            ?.takeIf { value -> value.isNotBlank() }
+            ?: error("Missing required text field: $fieldName")
+
+    private companion object {
+        const val MIN_CONFIDENCE = 0.3
+        const val BACKGROUND_RANK = 1
+        const val SECONDARY_RANK = 2
+        const val PRIMARY_RANK = 3
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationCommandUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationCommandUseCase.kt
@@ -1,0 +1,63 @@
+package com.firstpenguin.app.domain.recommendation.useCase
+
+import com.firstpenguin.app.domain.quote.service.QuoteService
+import com.firstpenguin.app.domain.recommendation.dto.RecommendationRequest
+import com.firstpenguin.app.domain.recommendation.dto.RecommendationResponse
+import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
+import com.firstpenguin.app.domain.recommendation.service.RecommendationResponseMapper
+import com.firstpenguin.app.domain.recommendation.service.RecommendationService
+import com.firstpenguin.app.domain.recommendation.service.RecommendationValidationService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class RecommendationCommandUseCase(
+    private val quoteService: QuoteService,
+    private val recommendationService: RecommendationService,
+    private val recommendationValidationService: RecommendationValidationService,
+    private val recommendationResponseMapper: RecommendationResponseMapper,
+) {
+    @Transactional
+    fun saveRecommendationResult(
+        userId: Long,
+        request: RecommendationRequest,
+        result: RecommendationResult,
+    ): RecommendationResponse {
+        recommendationService.lockRecommendationCreation(userId)
+        recommendationService.findOngoingRecommendation(userId)?.let { recommendation ->
+            return recommendationResponseMapper.toRecommendationResponse(recommendation)
+        }
+
+        recommendationValidationService.validateRecommendationCreatable(userId)
+
+        val recommendationId = createRecommendation(userId, request)
+        recommendationService.createRecommendationTags(
+            recommendationId = recommendationId,
+            tagIds = request.selectedTagIds(),
+        )
+        recommendationService.createRecommendationQuotes(
+            recommendationId = recommendationId,
+            quoteIds = result.quotes.map { quote -> quote.quoteId },
+        )
+
+        return recommendationResponseMapper.toRecommendationResponse(
+            recommendationId = recommendationId,
+            quote = quoteService.findQuoteById(result.mainQuote.quoteId),
+        )
+    }
+
+    private fun createRecommendation(
+        userId: Long,
+        request: RecommendationRequest,
+    ): Long =
+        recommendationService.createRecommendation(
+            userId = userId,
+            feelingText = request.feelingText.normalizedText(),
+            diaryText = request.diaryText,
+            emotionRangeId = request.emotionRangeId,
+        )
+
+    private fun RecommendationRequest.selectedTagIds(): List<Long> = emotionTagIds + listOfNotNull(needTagId)
+}
+
+private fun String?.normalizedText(): String? = this?.trim()?.takeIf { text -> text.isNotEmpty() }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationUseCase.kt
@@ -8,6 +8,7 @@ import com.firstpenguin.app.domain.recommendation.dto.RecommendationPeriodRespon
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationRequest
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationResponse
 import com.firstpenguin.app.domain.recommendation.service.RecommendationCommandService
+import com.firstpenguin.app.domain.recommendation.service.RecommendationEngine
 import com.firstpenguin.app.domain.recommendation.service.RecommendationRequestValidator
 import com.firstpenguin.app.domain.recommendation.service.RecommendationResponseMapper
 import com.firstpenguin.app.domain.recommendation.service.RecommendationService
@@ -19,57 +20,37 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
 private const val NEXT_RECOMMENDATION_QUOTE_COUNT = 9
+private const val FIRST_RECOMMENDATION_QUOTE_COUNT = 1
 
 @Service
 class RecommendationUseCase(
     private val quoteService: QuoteService,
+    private val recommendationEngine: RecommendationEngine,
+    private val recommendationCommandUseCase: RecommendationCommandUseCase,
     private val recommendationService: RecommendationService,
     private val recommendationCommandService: RecommendationCommandService,
     private val recommendationValidationService: RecommendationValidationService,
     private val recommendationRequestValidator: RecommendationRequestValidator,
     private val recommendationResponseMapper: RecommendationResponseMapper,
 ) {
-    @Transactional
     fun recommendQuote(
         userId: Long,
         request: RecommendationRequest,
     ): RecommendationResponse {
         recommendationRequestValidator.validate(request)
-
-        val selectedTagIds = request.emotionTagIds + listOfNotNull(request.needTagId)
-
-        recommendationService.lockRecommendationCreation(userId)
         recommendationService.findOngoingRecommendation(userId)?.let { recommendation ->
             return recommendationResponseMapper.toRecommendationResponse(recommendation)
         }
-
         recommendationValidationService.validateRecommendationCreatable(userId)
 
-        val recommendationId =
-            recommendationService.createRecommendation(
-                userId = userId,
-                feelingText = request.feelingText.normalizedText(),
-                diaryText = request.diaryText,
-                emotionRangeId = request.emotionRangeId,
-            )
-        val randomQuote = quoteService.getRandomQuote()
-
-        recommendationService.createRecommendationTags(
-            recommendationId = recommendationId,
-            tagIds = selectedTagIds,
-        )
-        recommendationService.createRecommendationQuotes(
-            recommendationId = recommendationId,
-            quoteIds = listOf(randomQuote.id),
-        )
-
-        return recommendationResponseMapper.toRecommendationResponse(
-            recommendationId = recommendationId,
-            quote = randomQuote,
+        return recommendationCommandUseCase.saveRecommendationResult(
+            userId = userId,
+            request = request,
+            result = recommendationEngine.recommend(userId, request),
         )
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     fun getNextRecommendationQuotes(
         userId: Long,
         recommendationId: Long,
@@ -77,25 +58,12 @@ class RecommendationUseCase(
         val recommendation = recommendationValidationService.validateRecommendation(userId, recommendationId)
         recommendationValidationService.validateRecommendationOngoing(recommendation)
 
-        val recommendationHistory = recommendationService.getRecommendationHistory(recommendationId)
-        recommendationValidationService.validateRecommendationCount(
-            currentCount = recommendationHistory.size,
-            nextCount = NEXT_RECOMMENDATION_QUOTE_COUNT,
-        )
-
-        val quoteIdHistory = recommendationHistory.map { recommendationQuote -> recommendationQuote.quoteId }
-        val nextQuotes =
-            quoteService.getRandomQuotesExcludingIds(
-                excludedQuoteIds = quoteIdHistory,
-                count = NEXT_RECOMMENDATION_QUOTE_COUNT,
-            )
-
-        recommendationService.createRecommendationQuotes(
-            recommendationId = recommendationId,
-            quoteIds = nextQuotes.map { quote -> quote.id },
-        )
-
-        return nextQuotes.map(recommendationResponseMapper::toQuoteResponse)
+        return recommendationService
+            .getRecommendationHistory(recommendationId)
+            .drop(FIRST_RECOMMENDATION_QUOTE_COUNT)
+            .take(NEXT_RECOMMENDATION_QUOTE_COUNT)
+            .map { recommendationQuote -> quoteService.findQuoteById(recommendationQuote.quoteId) }
+            .map(recommendationResponseMapper::toQuoteResponse)
     }
 
     @Transactional
@@ -189,5 +157,3 @@ class RecommendationUseCase(
         )
     }
 }
-
-private fun String?.normalizedText(): String? = this?.trim()?.takeIf { text -> text.isNotEmpty() }

--- a/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
@@ -70,7 +70,8 @@ enum class ErrorCode(
     OPENAI_FILE_UPLOAD_FAILED(HttpStatus.BAD_GATEWAY, "OpenAI 파일 업로드에 실패했습니다."),
     OPENAI_BATCH_CREATE_FAILED(HttpStatus.BAD_GATEWAY, "OpenAI 배치 생성에 실패했습니다."),
     OPENAI_BATCH_STATUS_FETCH_FAILED(HttpStatus.BAD_GATEWAY, "OpenAI 배치 상태 조회에 실패했습니다."),
-    QUOTE_BATCH_JOB_IS_RUNNING(HttpStatus.CONFLICT, "현재 배치 작업이 진행 중입니다."),
+    OPENAI_RESPONSES_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "OpenAI 실시간 응답 요청에 실패했습니다."),
+    OPENAI_RESPONSES_OUTPUT_TEXT_NOT_FOUND(HttpStatus.BAD_GATEWAY, "OpenAI 실시간 응답 결과를 찾을 수 없습니다."),
     INVALID_QUOTE_BATCH_JOB_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "문구 배치 상태가 올바르지 않습니다."),
     INVALID_QUOTE_BATCH_ITEMS_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "문구 배치 대상 상태가 올바르지 않습니다."),
 

--- a/app/src/main/resources/db/migration/V50__alter_recommendations_column.sql
+++ b/app/src/main/resources/db/migration/V50__alter_recommendations_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS recommendations
+    RENAME COLUMN selected_emotion_range_id TO emotion_range_id;

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorerTest.kt
@@ -86,6 +86,31 @@ class MetadataScorerTest {
         assertTrue(result.moodScore > 0.0)
     }
 
+    @Test
+    fun `rarity weight가 있으면 흔한 metadata tag 점수를 낮춘다`() {
+        val input = recommendationInput(intentType = IntentType.EMOTION_NEED_BASED)
+        val effectiveTags = listOf(effectiveTag(NEED_COMFORT_ID, "NEED_COMFORT", TagType.NEED, 1.0))
+        val candidate = candidate(quoteId = 1L, tagIdsByType = mapOf(TagType.NEED to setOf(NEED_COMFORT_ID)))
+
+        val normalScore =
+            scorer.score(
+                input = input,
+                effectiveTags = effectiveTags,
+                candidate = candidate,
+                moodTagIdByCode = moodTagIdByCode,
+            )
+        val rarityWeightedScore =
+            scorer.score(
+                input = input,
+                effectiveTags = effectiveTags,
+                candidate = candidate,
+                moodTagIdByCode = moodTagIdByCode,
+                tagRarityWeights = mapOf(NEED_COMFORT_ID to 0.55),
+            )
+
+        assertTrue(rarityWeightedScore.needScore < normalScore.needScore)
+    }
+
     private fun recommendationInput(intentType: IntentType): RecommendationInput =
         RecommendationInput(
             userId = USER_ID,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisServiceTest.kt
@@ -1,0 +1,254 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.emotion.model.Tag
+import com.firstpenguin.app.domain.emotion.repository.TagRepository
+import com.firstpenguin.app.domain.emotion.repository.table.TagTable
+import com.firstpenguin.app.domain.openai.dto.OpenAiResponsesRequest
+import com.firstpenguin.app.domain.openai.service.OpenAiResponsesClient
+import com.firstpenguin.app.domain.recommendation.model.IntentType
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.global.enums.TagType
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.Result
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.jooq.tools.jdbc.MockConnection
+import org.jooq.tools.jdbc.MockDataProvider
+import org.jooq.tools.jdbc.MockResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import tools.jackson.databind.json.JsonMapper
+import java.time.LocalDateTime
+
+class OpenAiUserInputAnalysisServiceTest {
+    @Test
+    fun `feelingText와 diaryText가 모두 없으면 LLM을 호출하지 않는다`() {
+        val openAi = openAiResponsesClient()
+        val service = service(client = openAi.client)
+
+        val result = service.analyze(recommendationInput(feelingText = null, diaryText = null))
+
+        assertNull(result)
+        Mockito.verifyNoInteractions(openAi.client)
+    }
+
+    @Test
+    fun `free text가 있으면 LLM 응답을 UserInputAnalysis로 변환한다`() {
+        val openAi = openAiResponsesClient(outputText = outputText)
+        val service = service(client = openAi.client)
+
+        val result = service.analyze(recommendationInput(feelingText = "비 오는 출근길에 마음이 불안해"))
+
+        requireNotNull(result)
+        assertEquals(IntentType.CONTEXT_BASED, result.intentType)
+        assertEquals("비 오는 출근길에 불안한 마음을 차분히 다독이고 싶다", result.canonicalIntent)
+        assertEquals(listOf(NEED_TAG_ID, CONTEXT_TAG_ID), result.tagCandidates.map { candidate -> candidate.tagId })
+        assertTrue(openAi.lastRequest.input.contains("비 오는 출근길"))
+        assertTrue(openAi.lastRequest.input.contains("\"hasSelectedNeedTag\":false"))
+        assertTrue(
+            openAi.lastRequest.text.format
+                .toString()
+                .contains("CONTEXT_RAIN"),
+        )
+    }
+
+    @Test
+    fun `사용자가 선택한 태그는 LLM prompt payload에 포함하지 않는다`() {
+        val openAi = openAiResponsesClient(outputText = outputText)
+        val service = service(client = openAi.client)
+
+        service.analyze(
+            recommendationInput(
+                feelingText = "비 오는 출근길에 마음이 불안해",
+                emotionTags = listOf(tag(100L, TagType.EMOTION, "EMOTION_SELECTED")),
+                needTag = tag(101L, TagType.NEED, "NEED_SELECTED"),
+            ),
+        )
+
+        assertFalsePromptContainsSelectedTags(openAi.lastRequest.input)
+        assertTrue(openAi.lastRequest.input.contains("\"hasSelectedNeedTag\":true"))
+    }
+
+    @Test
+    fun `LLM 호출이나 파싱이 실패하면 분석 결과를 버린다`() {
+        val openAi = openAiResponsesClient(exception = IllegalStateException("failed"))
+        val service = service(client = openAi.client)
+
+        val result = service.analyze(recommendationInput(feelingText = "마음이 복잡해"))
+
+        assertNull(result)
+    }
+
+    private companion object {
+        const val EMOTION_RANGE_ID = 1L
+        const val NEED_TAG_ID = 10L
+        const val CONTEXT_TAG_ID = 20L
+        val CREATED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 14, 0, 0)
+        val outputText: String =
+            """
+            {
+              "intentType": "CONTEXT_BASED",
+              "canonicalIntent": "비 오는 출근길에 불안한 마음을 차분히 다독이고 싶다",
+              "emotionTagCandidates": [],
+              "needTagCandidates": [
+                {
+                  "tagCode": "NEED_COMFORT",
+                  "source": "FEELING_TEXT",
+                  "priority": "PRIMARY",
+                  "confidence": 0.88
+                }
+              ],
+              "situationTagCandidates": [],
+              "contextTagCandidates": [
+                {
+                  "tagCode": "CONTEXT_RAIN",
+                  "source": "FEELING_TEXT",
+                  "priority": "PRIMARY",
+                  "confidence": 0.92
+                }
+              ],
+              "roleTagCandidates": []
+            }
+            """.trimIndent()
+
+        fun service(client: OpenAiResponsesClient): OpenAiUserInputAnalysisService =
+            OpenAiUserInputAnalysisService(
+                tagRepository = TagRepository(dslWithTags()),
+                requestBuilder = UserInputParseRequestBuilder(JsonMapper.builder().build()),
+                outputParser =
+                    UserInputParseOutputParser(
+                        objectMapper = JsonMapper.builder().build(),
+                        tagCandidateMapper = UserInputTagCandidateMapper(),
+                    ),
+                openAiResponsesClient = client,
+            )
+
+        fun openAiResponsesClient(
+            outputText: String = "",
+            exception: RuntimeException? = null,
+        ): OpenAiResponsesClientStub {
+            val stub = OpenAiResponsesClientStub()
+            val client =
+                Mockito.mock(OpenAiResponsesClient::class.java) { invocation ->
+                    if (invocation.method.name != "createTextResponse") {
+                        return@mock Mockito.RETURNS_DEFAULTS.answer(invocation)
+                    }
+
+                    stub.lastRequest = invocation.getArgument(0)
+
+                    exception?.let { throw it }
+                    outputText
+                }
+            stub.client = client
+
+            return stub
+        }
+
+        class OpenAiResponsesClientStub(
+            var lastRequest: OpenAiResponsesRequest = emptyOpenAiResponsesRequest(),
+        ) {
+            lateinit var client: OpenAiResponsesClient
+        }
+
+        fun emptyOpenAiResponsesRequest(): OpenAiResponsesRequest =
+            OpenAiResponsesRequest(
+                model = "",
+                reasoning = emptyMap(),
+                input = "",
+                text =
+                    com.firstpenguin.app.domain.openai.dto.OpenAiResponsesTextRequest(
+                        format = emptyMap(),
+                        verbosity = "",
+                    ),
+            )
+
+        fun dslWithTags(): DSLContext {
+            lateinit var dsl: DSLContext
+            val connection =
+                MockConnection(
+                    MockDataProvider {
+                        arrayOf(MockResult(TAG_ROW_COUNT, tagResult(dsl)))
+                    },
+                )
+            dsl = DSL.using(connection, SQLDialect.POSTGRES)
+
+            return dsl
+        }
+
+        fun tagResult(dsl: DSLContext): Result<Record> =
+            dsl.newResult(*TAG_FIELDS).apply {
+                add(tagRecord(dsl, 1L, TagType.EMOTION, "EMOTION_ANXIOUS"))
+                add(tagRecord(dsl, NEED_TAG_ID, TagType.NEED, "NEED_COMFORT"))
+                add(tagRecord(dsl, 11L, TagType.SITUATION, "SITUATION_FAILURE_MISTAKE"))
+                add(tagRecord(dsl, CONTEXT_TAG_ID, TagType.CONTEXT, "CONTEXT_RAIN"))
+                add(tagRecord(dsl, 30L, TagType.ROLE, "ROLE_EMPATHY"))
+            }
+
+        fun tagRecord(
+            dsl: DSLContext,
+            id: Long,
+            type: TagType,
+            code: String,
+        ): Record =
+            dsl.newRecord(*TAG_FIELDS).apply {
+                set(TagTable.ID, id)
+                set(TagTable.TYPE, type.name)
+                set(TagTable.CODE, code)
+                set(TagTable.LABEL, code)
+                set(TagTable.DESCRIPTION, code)
+            }
+
+        fun recommendationInput(
+            feelingText: String?,
+            diaryText: String? = null,
+            emotionTags: List<Tag> = emptyList(),
+            needTag: Tag? = null,
+        ): RecommendationInput =
+            RecommendationInput(
+                userId = 1L,
+                emotionRangeId = EMOTION_RANGE_ID,
+                emotionTags = emotionTags,
+                needTag = needTag,
+                feelingText = feelingText,
+                diaryText = diaryText,
+                analysis = null,
+            )
+
+        fun assertFalsePromptContainsSelectedTags(input: String) {
+            assertFalse(input.contains("selectedEmotionTagCodes"))
+            assertFalse(input.contains("selectedNeedTagCode"))
+            assertFalse(input.contains("EMOTION_SELECTED"))
+            assertFalse(input.contains("NEED_SELECTED"))
+        }
+
+        fun tag(
+            id: Long,
+            type: TagType,
+            code: String,
+        ): Tag =
+            Tag(
+                id = id,
+                emotionRangeId = if (type == TagType.EMOTION) EMOTION_RANGE_ID else null,
+                code = code,
+                label = code,
+                type = type,
+                createdAt = CREATED_AT,
+            )
+
+        const val TAG_ROW_COUNT = 5
+        val TAG_FIELDS: Array<Field<*>> =
+            arrayOf(
+                TagTable.ID,
+                TagTable.TYPE,
+                TagTable.CODE,
+                TagTable.LABEL,
+                TagTable.DESCRIPTION,
+            )
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/TypeScoreCalculatorTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/TypeScoreCalculatorTest.kt
@@ -36,6 +36,20 @@ class TypeScoreCalculatorTest {
         assertEquals(0.875, result, DELTA)
     }
 
+    @Test
+    fun `흔한 tag는 rarity weight만큼 매칭 점수를 낮춘다`() {
+        val targetTags = listOf(effectiveTag(tagId = 1L, importance = 1.0))
+
+        val result =
+            calculator.calculate(
+                targetTags = targetTags,
+                candidateTagIds = setOf(1L),
+                tagRarityWeights = mapOf(1L to 0.55),
+            )
+
+        assertEquals(0.55, result, DELTA)
+    }
+
     private fun effectiveTag(
         tagId: Long,
         importance: Double,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseOutputParserTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseOutputParserTest.kt
@@ -1,0 +1,199 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.emotion.model.Tag
+import com.firstpenguin.app.domain.quotemetadata.dto.TagOption
+import com.firstpenguin.app.domain.recommendation.model.IntentType
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.TagCandidatePriority
+import com.firstpenguin.app.domain.recommendation.model.TagCandidateSource
+import com.firstpenguin.app.global.enums.TagType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.json.JsonMapper
+import java.time.LocalDateTime
+
+class UserInputParseOutputParserTest {
+    private val outputParser =
+        UserInputParseOutputParser(
+            objectMapper = JsonMapper.builder().build(),
+            tagCandidateMapper = UserInputTagCandidateMapper(),
+        )
+
+    @Test
+    fun `LLM output JSON을 기존 TagCandidate 모델로 변환한다`() {
+        val result =
+            outputParser.parse(
+                outputText(candidate("SITUATION_FAILURE_MISTAKE", TagType.SITUATION)),
+                input,
+                tagGroups,
+            )
+        val candidate = result.tagCandidates.first()
+
+        assertEquals(IntentType.EMOTION_NEED_BASED, result.intentType)
+        assertEquals("불안한 마음을 다독이며 다시 움직일 힘이 필요하다", result.canonicalIntent)
+        assertEquals(SITUATION_TAG_ID, candidate.tagId)
+        assertEquals("SITUATION_FAILURE_MISTAKE", candidate.code)
+        assertEquals(TagType.SITUATION, candidate.type)
+        assertEquals(TagCandidateSource.FEELING_TEXT, candidate.source)
+        assertEquals(TagCandidatePriority.PRIMARY, candidate.priority)
+    }
+
+    @Test
+    fun `selected tag와 중복된 LLM 후보는 제외한다`() {
+        val result =
+            outputParser.parse(
+                outputText(candidate("NEED_COMFORT", TagType.NEED)),
+                input.copy(needTag = tag(NEED_TAG_ID, TagType.NEED, "NEED_COMFORT")),
+                tagGroups,
+            )
+
+        assertEquals(emptyList<Any>(), result.tagCandidates)
+    }
+
+    @Test
+    fun `selected needTag가 있으면 LLM need 후보는 secondary 이하로 낮춘다`() {
+        val result =
+            outputParser.parse(
+                outputText(candidate("NEED_PERSPECTIVE_SHIFT", TagType.NEED)),
+                input.copy(needTag = tag(NEED_TAG_ID, TagType.NEED, "NEED_COMFORT")),
+                tagGroups,
+            )
+
+        assertEquals(TagCandidatePriority.SECONDARY, result.tagCandidates.first().priority)
+    }
+
+    @Test
+    fun `needTag가 없고 feelingText 기반 NEED 후보면 primary를 유지한다`() {
+        val result =
+            outputParser.parse(
+                outputText(candidate("NEED_COMFORT", TagType.NEED)),
+                input.copy(needTag = null),
+                tagGroups,
+            )
+
+        assertEquals(TagCandidatePriority.PRIMARY, result.tagCandidates.first().priority)
+    }
+
+    @Test
+    fun `LLM emotion 후보는 약한 보조 신호로 낮춘다`() {
+        val result =
+            outputParser.parse(
+                outputText(candidate("EMOTION_ANXIOUS", TagType.EMOTION)),
+                input,
+                tagGroups,
+            )
+
+        assertEquals(TagCandidatePriority.SECONDARY, result.tagCandidates.first().priority)
+    }
+
+    @Test
+    fun `지원하지 않는 tagType이나 낮은 confidence 후보는 제외한다`() {
+        val result =
+            outputParser.parse(
+                outputText(
+                    candidate("MOOD_CALM", TagType.MOOD),
+                    candidate("CONTEXT_RAIN", TagType.CONTEXT, confidence = 0.1),
+                ),
+                input,
+                tagGroups,
+            )
+
+        assertFalse(result.tagCandidates.any())
+    }
+
+    private companion object {
+        const val EMOTION_RANGE_ID = 1L
+        const val NEED_TAG_ID = 10L
+        const val NEED_PERSPECTIVE_TAG_ID = 11L
+        const val EMOTION_TAG_ID = 20L
+        const val SITUATION_TAG_ID = 30L
+        const val CONTEXT_TAG_ID = 40L
+        const val MOOD_TAG_ID = 50L
+        val CREATED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 14, 0, 0)
+        val input =
+            RecommendationInput(
+                userId = 1L,
+                emotionRangeId = EMOTION_RANGE_ID,
+                emotionTags = emptyList(),
+                needTag = null,
+                feelingText = "불안해서 위로받고 싶어",
+                diaryText = null,
+                analysis = null,
+            )
+        val tagGroups: Map<TagType, List<TagOption>> =
+            mapOf(
+                TagType.NEED to
+                    listOf(
+                        tagOption(NEED_TAG_ID, TagType.NEED, "NEED_COMFORT"),
+                        tagOption(NEED_PERSPECTIVE_TAG_ID, TagType.NEED, "NEED_PERSPECTIVE_SHIFT"),
+                    ),
+                TagType.EMOTION to listOf(tagOption(EMOTION_TAG_ID, TagType.EMOTION, "EMOTION_ANXIOUS")),
+                TagType.SITUATION to
+                    listOf(
+                        tagOption(SITUATION_TAG_ID, TagType.SITUATION, "SITUATION_FAILURE_MISTAKE"),
+                    ),
+                TagType.CONTEXT to listOf(tagOption(CONTEXT_TAG_ID, TagType.CONTEXT, "CONTEXT_RAIN")),
+                TagType.MOOD to listOf(tagOption(MOOD_TAG_ID, TagType.MOOD, "MOOD_CALM")),
+            )
+
+        fun outputText(vararg candidates: Pair<TagType, String>): String =
+            """
+            {
+              "intentType": "EMOTION_NEED_BASED",
+              "canonicalIntent": "불안한 마음을 다독이며 다시 움직일 힘이 필요하다",
+              "emotionTagCandidates": [${candidates.jsonArray(TagType.EMOTION)}],
+              "needTagCandidates": [${candidates.jsonArray(TagType.NEED)}],
+              "situationTagCandidates": [${candidates.jsonArray(TagType.SITUATION)}],
+              "contextTagCandidates": [${candidates.jsonArray(TagType.CONTEXT)}],
+              "roleTagCandidates": [${candidates.jsonArray(TagType.ROLE)}]
+            }
+            """.trimIndent()
+
+        fun candidate(
+            code: String,
+            type: TagType,
+            confidence: Double = 0.9,
+        ): Pair<TagType, String> =
+            type to
+                """
+                {
+                  "tagCode": "$code",
+                  "source": "FEELING_TEXT",
+                  "priority": "PRIMARY",
+                  "confidence": $confidence
+                }
+                """.trimIndent()
+
+        fun Array<out Pair<TagType, String>>.jsonArray(type: TagType): String =
+            filter { candidate -> candidate.first == type }
+                .joinToString(",\n") { candidate -> candidate.second }
+
+        fun tag(
+            id: Long,
+            type: TagType,
+            code: String,
+        ): Tag =
+            Tag(
+                id = id,
+                emotionRangeId = if (type == TagType.EMOTION) EMOTION_RANGE_ID else null,
+                code = code,
+                label = code,
+                type = type,
+                createdAt = CREATED_AT,
+            )
+
+        fun tagOption(
+            id: Long,
+            type: TagType,
+            code: String,
+        ): TagOption =
+            TagOption(
+                id = id,
+                type = type,
+                code = code,
+                label = code,
+                description = null,
+            )
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchemaTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchemaTest.kt
@@ -1,0 +1,70 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.quotemetadata.dto.TagOption
+import com.firstpenguin.app.global.enums.TagType
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class UserInputParseSchemaTest {
+    @Test
+    fun `schema는 mood와 avoid를 반환 대상에 포함하지 않는다`() {
+        val schema = userInputParseSchema(tagGroups).toString()
+
+        assertFalse(schema.contains("MOOD"))
+        assertFalse(schema.contains("AVOID"))
+        assertTrue(schema.contains("EMOTION"))
+        assertTrue(schema.contains("NEED"))
+        assertTrue(schema.contains("SITUATION"))
+        assertTrue(schema.contains("CONTEXT"))
+        assertTrue(schema.contains("ROLE"))
+        assertFalse(schema.contains("evidence"))
+    }
+
+    @Test
+    fun `schema는 tag type별 후보 배열을 최상위 필수로 둔다`() {
+        val schemaBody = userInputParseSchema(tagGroups)["schema"] as Map<*, *>
+        val required = schemaBody["required"] as List<*>
+
+        assertTrue(
+            required.containsAll(
+                listOf(
+                    "intentType",
+                    "canonicalIntent",
+                    "emotionTagCandidates",
+                    "needTagCandidates",
+                    "situationTagCandidates",
+                    "contextTagCandidates",
+                    "roleTagCandidates",
+                ),
+            ),
+        )
+        assertFalse(required.contains("tagCandidates"))
+        assertFalse(required.contains("quoteId"))
+    }
+
+    @Test
+    fun `schema는 허용 tagCode를 tag type별 후보 배열 안에 나눠서 둔다`() {
+        val schema = userInputParseSchema(tagGroups).toString()
+
+        assertTrue(schema.contains("emotionTagCandidates"))
+        assertTrue(schema.contains("EMOTION_CODE"))
+        assertTrue(schema.contains("needTagCandidates"))
+        assertTrue(schema.contains("NEED_CODE"))
+    }
+
+    private companion object {
+        val tagGroups: Map<TagType, List<TagOption>> =
+            TagType.entries.associateWith { type ->
+                listOf(
+                    TagOption(
+                        id = type.ordinal.toLong() + 1,
+                        type = type,
+                        code = "${type.name}_CODE",
+                        label = type.name,
+                        description = null,
+                    ),
+                )
+            }
+    }
+}


### PR DESCRIPTION
## 📢 요약
- 사용자 입력 기반 추천을 위해 실시간 LLM Parser를 추가했습니다.
- 기존 랜덤 추천 흐름을 제거하고, 추천 엔진 실행 결과를 기반으로 top 10 후보 문장을 저장하도록 변경했습니다.
- 추천 시작 시 `recommendations.quote_id`는 null로 유지하고, 최종 선택 API에서만 선택 문장을 저장하도록 흐름을 정리했습니다.
- 메타데이터 태그가 특정 태그에 과하게 쏠리는 문제를 완화하기 위해 태그 분포 기반 rarity weight를 추천 점수에 반영했습니다.
- `recommendations` 컬럼명을 현재 추천 도메인 용어에 맞게 정리하는 마이그레이션을 추가했습니다.

🔗 연관 이슈: Resolves #140

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
```bash
./gradlew testClasses
./gradlew lintKotlin
./gradlew detekt
./gradlew test
```

## 📜 기타
- LLM Parser는 사용자가 직접 선택한 emotion/need 태그를 판단하지 않고, free text/diary text에서 canonicalIntent와 보조 tagCandidates만 추출합니다.
- 추천 저장은 RecommendationUseCase -> RecommendationEngine.recommend() -> RecommendationCommandUseCase.saveRecommendationResult() 흐름으로 분리했습니다.
- OpenAI 호출은 트랜잭션 밖에서 수행하고, 추천 기록/태그/후보 저장만 트랜잭션으로 처리합니다.
- EMOTION, NEED, MOOD 메타 태그는 전체 타입 내 점유율에 따라 매칭 점수를 감쇠합니다.
예: NEED_PERSPECTIVE_SHIFT처럼 많이 붙은 태그는 구분력이 낮다고 보고 점수를 낮게 반영합니다.