### PR TITLE
feat: 캘린더 응답 감정 범위 추가

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -43,8 +43,8 @@ reviews:
   # 리뷰 중/완료 상태를 GitHub commit status로 표시합니다.
   commit_status: true
 
-  # CodeRabbit이 리뷰 자체를 수행하지 못하면 commit status를 failure로 표시합니다.
-  fail_commit_status: true
+  # CodeRabbit이 리뷰 자체를 수행하지 못해도 commit status를 failure로 표시하지 않습니다.
+  fail_commit_status: false
 
   # walkthrough를 접힌 영역으로 표시해 PR 화면을 덜 복잡하게 만듭니다.
   collapse_walkthrough: true

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/dto/RecommendationPeriodResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/dto/RecommendationPeriodResponse.kt
@@ -2,6 +2,7 @@ package com.firstpenguin.app.domain.recommendation.dto
 
 import com.firstpenguin.app.domain.quote.dto.QuoteResponse
 import com.firstpenguin.app.domain.recommendation.model.Recommendation
+import com.firstpenguin.app.global.enums.EmotionRangeName
 import java.time.LocalDate
 
 data class RecommendationPeriodResponse(
@@ -26,6 +27,7 @@ data class RecommendationPeriodResponse(
 data class RecommendationPeriodItemResponse(
     val recommendationId: Long,
     val recommendationDate: LocalDate,
+    val emotionRangeName: EmotionRangeName,
     val quote: QuoteResponse,
 ) {
     companion object {
@@ -36,6 +38,7 @@ data class RecommendationPeriodItemResponse(
             RecommendationPeriodItemResponse(
                 recommendationId = recommendation.id,
                 recommendationDate = recommendation.recommendationDate,
+                emotionRangeName = recommendation.emotionRangeName,
                 quote = quote,
             )
     }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/Recommendation.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/Recommendation.kt
@@ -1,5 +1,6 @@
 package com.firstpenguin.app.domain.recommendation.model
 
+import com.firstpenguin.app.global.enums.EmotionRangeName
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -11,5 +12,6 @@ data class Recommendation(
     val feelingText: String?,
     val diaryText: String?,
     val emotionRangeId: Long,
+    val emotionRangeName: EmotionRangeName,
     val createdAt: LocalDateTime,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationRepository.kt
@@ -1,7 +1,9 @@
 package com.firstpenguin.app.domain.recommendation.repository
 
+import com.firstpenguin.app.domain.emotion.repository.table.EmotionRangeTable
 import com.firstpenguin.app.domain.recommendation.model.Recommendation
 import com.firstpenguin.app.domain.recommendation.repository.table.RecommendationTable
+import com.firstpenguin.app.global.enums.EmotionRangeName
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
@@ -19,6 +21,8 @@ class RecommendationRepository(
         dsl
             .select(RECOMMENDATION_FIELDS)
             .from(RecommendationTable.RECOMMENDATIONS)
+            .join(EmotionRangeTable.EMOTION_RANGES)
+            .on(RecommendationTable.EMOTION_RANGE_ID.eq(EmotionRangeTable.ID))
             .where(RecommendationTable.USER_ID.eq(userId))
             .and(RecommendationTable.RECOMMENDATION_DATE.eq(recommendationDate))
             .and(RecommendationTable.QUOTE_ID.isNull)
@@ -35,6 +39,8 @@ class RecommendationRepository(
         dsl
             .select(RECOMMENDATION_FIELDS)
             .from(RecommendationTable.RECOMMENDATIONS)
+            .join(EmotionRangeTable.EMOTION_RANGES)
+            .on(RecommendationTable.EMOTION_RANGE_ID.eq(EmotionRangeTable.ID))
             .where(RecommendationTable.USER_ID.eq(userId))
             .and(RecommendationTable.RECOMMENDATION_DATE.between(start, end))
             .orderBy(RecommendationTable.CREATED_AT.asc())
@@ -48,6 +54,8 @@ class RecommendationRepository(
         dsl
             .select(RECOMMENDATION_FIELDS)
             .from(RecommendationTable.RECOMMENDATIONS)
+            .join(EmotionRangeTable.EMOTION_RANGES)
+            .on(RecommendationTable.EMOTION_RANGE_ID.eq(EmotionRangeTable.ID))
             .where(RecommendationTable.USER_ID.eq(userId))
             .and(RecommendationTable.RECOMMENDATION_DATE.between(start, end))
             .and(RecommendationTable.QUOTE_ID.isNotNull)
@@ -58,6 +66,8 @@ class RecommendationRepository(
         dsl
             .select(RECOMMENDATION_FIELDS)
             .from(RecommendationTable.RECOMMENDATIONS)
+            .join(EmotionRangeTable.EMOTION_RANGES)
+            .on(RecommendationTable.EMOTION_RANGE_ID.eq(EmotionRangeTable.ID))
             .where(RecommendationTable.ID.eq(id))
             .fetchOne()
             ?.let(::toRecommendation)
@@ -66,6 +76,8 @@ class RecommendationRepository(
         dsl
             .select(RECOMMENDATION_FIELDS)
             .from(RecommendationTable.RECOMMENDATIONS)
+            .join(EmotionRangeTable.EMOTION_RANGES)
+            .on(RecommendationTable.EMOTION_RANGE_ID.eq(EmotionRangeTable.ID))
             .where(RecommendationTable.ID.eq(id))
             .forUpdate()
             .fetchOne()
@@ -99,6 +111,7 @@ class RecommendationRepository(
             feelingText = record.get(RecommendationTable.FEELING_TEXT),
             diaryText = record.get(RecommendationTable.DIARY_TEXT),
             emotionRangeId = record.get(RecommendationTable.EMOTION_RANGE_ID),
+            emotionRangeName = EmotionRangeName.from(record.get(EmotionRangeTable.NAME)),
             createdAt = record.get(RecommendationTable.CREATED_AT),
         )
 
@@ -112,6 +125,7 @@ class RecommendationRepository(
                 RecommendationTable.FEELING_TEXT,
                 RecommendationTable.DIARY_TEXT,
                 RecommendationTable.EMOTION_RANGE_ID,
+                EmotionRangeTable.NAME,
                 RecommendationTable.CREATED_AT,
             )
     }


### PR DESCRIPTION
## 작업 내용

- 기간별 추천 기록 응답에 `emotionRangeName`을 추가했습니다.
- `recommendations.emotion_range_id`를 `emotion_ranges`와 조인해 `SAD`, `NORMAL`, `HAPPY` 값을 내려주도록 했습니다.
- CodeRabbit 리뷰 자체가 크레딧 문제 등으로 실패해도 GitHub commit status를 failure로 표시하지 않도록 `fail_commit_status`를 `false`로 변경했습니다.

## 기대 효과

- 프론트는 캘린더 감정 색 모드에서 DB 숫자 ID를 하드코딩하지 않고 `emotionRangeName`으로 색을 매핑할 수 있습니다.
- CodeRabbit 사용 가능 크레딧이 없을 때도 CI와 무관한 X 표시를 줄일 수 있습니다.

## 검증

- `cd app && ./gradlew testClasses`
- `cd app && ./gradlew test`
- `cd app && ./gradlew lintKotlin detekt test`

Closes #148
