### PR TITLE
feat: 태그 라벨 및 감정 태그 그룹 정보 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/dto/TagDto.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/dto/TagDto.kt
@@ -8,6 +8,7 @@ data class TagDto(
     val label: String,
     val type: TagType,
     val emotionRangeId: Long?,
+    val displayGroup: String?,
 ) {
     companion object {
         fun from(tag: Tag): TagDto =
@@ -16,6 +17,7 @@ data class TagDto(
                 label = tag.label,
                 type = tag.type,
                 emotionRangeId = tag.emotionRangeId,
+                displayGroup = tag.displayGroup,
             )
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/model/Tag.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/model/Tag.kt
@@ -10,4 +10,5 @@ data class Tag(
     val label: String,
     val type: TagType,
     val createdAt: LocalDateTime,
+    val displayGroup: String? = null,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/repository/TagRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/repository/TagRepository.kt
@@ -117,6 +117,7 @@ class TagRepository(
             label = record[TagTable.LABEL]!!,
             type = TagType.from(record[TagTable.TYPE]!!),
             createdAt = record[TagTable.CREATED_AT]!!,
+            displayGroup = record[TagTable.DISPLAY_GROUP],
         )
 
     private fun toTagOption(record: Record): TagOption =
@@ -135,6 +136,7 @@ class TagRepository(
             TagTable.CODE,
             TagTable.LABEL,
             TagTable.TYPE,
+            TagTable.DISPLAY_GROUP,
             TagTable.CREATED_AT,
         )
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/repository/table/TagTable.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/repository/table/TagTable.kt
@@ -11,6 +11,7 @@ internal object TagTable {
     val TYPE = DSL.field(DSL.name("tags", "type"), String::class.java)
     val CODE = DSL.field(DSL.name("tags", "code"), String::class.java)
     val DESCRIPTION = DSL.field(DSL.name("tags", "description"), String::class.java)
+    val DISPLAY_GROUP = DSL.field(DSL.name("tags", "display_group"), String::class.java)
     val SORT_ORDER = DSL.field(DSL.name("tags", "sort_order"), Int::class.java)
     val IS_ACTIVE = DSL.field(DSL.name("tags", "is_active"), Boolean::class.java)
     val CREATED_AT = DSL.field(DSL.name("tags", "created_at"), LocalDateTime::class.java)

--- a/app/src/main/resources/db/migration/V51__update_tag_labels_and_emotion_display_groups.sql
+++ b/app/src/main/resources/db/migration/V51__update_tag_labels_and_emotion_display_groups.sql
@@ -1,0 +1,80 @@
+ALTER TABLE IF EXISTS tags
+    ADD COLUMN IF NOT EXISTS display_group VARCHAR(50);
+
+WITH need_tag_labels(id, label, sort_order) AS (
+    VALUES
+        (51, '관점을 전환하는 문장', 1),
+        (106, '마음정리를 돕는 문장', 2),
+        (78, '시작을 응원하는 문장', 3),
+        (50, '영감을 주는 문장', 4),
+        (49, '공감해주는 문장', 5),
+        (48, '위로를 주는 문장', 6),
+        (105, '자존감을 채우는 문장', 7),
+        (121, '마음의 짐을 덜어주는 문장', 8),
+        (111, '용기를 주는 문장', 9)
+)
+UPDATE tags
+SET
+    label = need_tag_labels.label,
+    sort_order = need_tag_labels.sort_order
+FROM need_tag_labels
+WHERE tags.id = need_tag_labels.id
+  AND tags.type = 'NEED';
+
+WITH emotion_tag_groups(id, label, display_group, sort_order) AS (
+    VALUES
+        (4, NULL, '무기력과 우울', 1),
+        (6, NULL, '무기력과 우울', 2),
+        (9, NULL, '무기력과 우울', 3),
+        (10, NULL, '무기력과 우울', 4),
+        (15, NULL, '무기력과 우울', 5),
+        (1, NULL, '불안과 위축', 6),
+        (2, NULL, '불안과 위축', 7),
+        (3, NULL, '불안과 위축', 8),
+        (8, NULL, '불안과 위축', 9),
+        (11, NULL, '불안과 위축', 10),
+        (14, NULL, '불안과 위축', 11),
+        (5, NULL, '분노와 상처', 12),
+        (7, NULL, '분노와 상처', 13),
+        (13, NULL, '분노와 상처', 14),
+        (12, NULL, '분노와 상처', 15),
+        (16, NULL, '분노와 상처', 16),
+        (19, NULL, '평온과 여유', 1),
+        (22, NULL, '평온과 여유', 2),
+        (26, NULL, '평온과 여유', 3),
+        (31, NULL, '평온과 여유', 4),
+        (27, NULL, '평온과 여유', 5),
+        (18, NULL, '사색과 고립', 6),
+        (24, NULL, '사색과 고립', 7),
+        (29, NULL, '사색과 고립', 8),
+        (17, NULL, '사색과 고립', 9),
+        (23, NULL, '사색과 고립', 10),
+        (20, NULL, '무감각과 모호함', 11),
+        (21, NULL, '무감각과 모호함', 12),
+        (28, NULL, '무감각과 모호함', 13),
+        (25, NULL, '무감각과 모호함', 14),
+        (35, NULL, '행복하고 충만한', 1),
+        (34, '기분 좋은', '행복하고 충만한', 2),
+        (32, NULL, '행복하고 충만한', 3),
+        (41, NULL, '행복하고 충만한', 4),
+        (45, NULL, '행복하고 충만한', 5),
+        (43, NULL, '행복하고 충만한', 6),
+        (33, NULL, '열정과 활기', 7),
+        (36, NULL, '열정과 활기', 8),
+        (37, NULL, '열정과 활기', 9),
+        (39, NULL, '열정과 활기', 10),
+        (44, NULL, '열정과 활기', 11),
+        (46, NULL, '열정과 활기', 12),
+        (47, NULL, '열정과 활기', 13),
+        (38, NULL, '안도와 평화', 14),
+        (40, NULL, '안도와 평화', 15),
+        (42, NULL, '안도와 평화', 16)
+)
+UPDATE tags
+SET
+    label = COALESCE(emotion_tag_groups.label, tags.label),
+    display_group = emotion_tag_groups.display_group,
+    sort_order = emotion_tag_groups.sort_order
+FROM emotion_tag_groups
+WHERE tags.id = emotion_tag_groups.id
+  AND tags.type = 'EMOTION';


### PR DESCRIPTION
## 📢 요약
- NEED 태그 라벨을 추천 화면 문맥에 맞게 수정했습니다.
- `tags.display_group` 컬럼을 추가해 감정 태그를 emotion range 내부에서 세부 그룹으로 묶어 내려줄 수 있도록 했습니다.
- 감정 태그 응답 DTO에 `displayGroup`을 추가해 클라이언트에서 그룹별 노출이 가능하도록 변경했습니다.
- 감정 태그의 `sort_order`를 세부 그룹 노출 순서에 맞게 재정렬했습니다.
- `기분 좋게 웃은` 태그 라벨을 `기분 좋은`으로 수정했습니다.

🔗 연관 이슈: Resolves #150

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [ ] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
검증 완료:
- `./gradlew formatKotlin`
- `./gradlew testClasses`
- `./gradlew lintKotlin`
- `./gradlew detekt`
- `./gradlew test`
- `./gradlew build`

응답 변경 예시:

```json
{
  "id": 4,
  "label": "위축되는",
  "type": "EMOTION",
  "emotionRangeId": 1,
  "displayGroup": "무기력과 우울"
}
```

## 📜 기타
- display_group은 현재 감정 태그 화면 그룹핑 목적의 nullable 컬럼으로 추가했습니다.
- 기존 active 태그인 충만한은 요청 목록에는 없었지만, 그룹 없이 남지 않도록 행복하고 충만한 그룹에 포함했습니다.
