### PR TITLE
feat: 추천 랭킹 다양화 정책 조정 및 응답시간 로그 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/controller/RecommendationController.kt
@@ -53,7 +53,7 @@ class RecommendationController(
         description = "추천 시작 시 저장된 후보 중 최초 문장을 제외한 9개를 반환한다.",
         security = [SecurityRequirement(name = "bearerAuth")],
     )
-    @PostMapping("/{recommendationId}/quotes")
+    @GetMapping("/{recommendationId}/quotes/more")
     fun getNextRecommendationQuotes(
         @Parameter(hidden = true) @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
         @PathVariable recommendationId: Long,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisService.kt
@@ -6,6 +6,7 @@ import com.firstpenguin.app.domain.quotemetadata.dto.TagOption
 import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
 import com.firstpenguin.app.domain.recommendation.model.UserInputAnalysis
 import com.firstpenguin.app.global.enums.TagType
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -15,18 +16,44 @@ class OpenAiUserInputAnalysisService(
     private val outputParser: UserInputParseOutputParser,
     private val openAiResponsesClient: OpenAiResponsesClient,
 ) : UserInputAnalysisService {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     override fun analyze(input: RecommendationInput): UserInputAnalysis? {
         if (!input.hasText()) return null
 
-        return runCatching { analyzeOrThrow(input) }.getOrNull()
+        return runCatching {
+            log.measureRecommendationStep("userInputAnalysis.total", { "userId=${input.userId}" }) {
+                analyzeOrThrow(input)
+            }
+        }.getOrNull()
     }
 
     private fun analyzeOrThrow(input: RecommendationInput): UserInputAnalysis {
-        val tagGroups = tagRepository.getActiveTagsByType().onlyUserInputParseTagGroups()
-        val request = requestBuilder.build(input, tagGroups)
-        val outputText = openAiResponsesClient.createTextResponse(request)
+        val tagGroups = findMeasuredTagGroups(input.userId)
+        val request =
+            log.measureRecommendationStep("userInputAnalysis.buildRequest", { "userId=${input.userId}" }) {
+                requestBuilder.build(input, tagGroups)
+            }
+        val outputText =
+            log.measureRecommendationStep("userInputAnalysis.openAi", { "userId=${input.userId}" }) {
+                openAiResponsesClient.createTextResponse(request)
+            }
 
-        return outputParser.parse(outputText, input, tagGroups)
+        return log.measureRecommendationStep("userInputAnalysis.parse", { "userId=${input.userId}" }) {
+            outputParser.parse(outputText, input, tagGroups)
+        }
+    }
+
+    private fun findMeasuredTagGroups(userId: Long): Map<TagType, List<TagOption>> {
+        var typeCount = 0
+        lateinit var tagGroups: Map<TagType, List<TagOption>>
+
+        log.measureRecommendationStep("userInputAnalysis.tagOptions", { "userId=$userId types=$typeCount" }) {
+            tagGroups = tagRepository.getActiveTagsByType().onlyUserInputParseTagGroups()
+            typeCount = tagGroups.size
+        }
+
+        return tagGroups
     }
 
     private fun RecommendationInput.hasText(): Boolean = feelingText.hasValue() || diaryText.hasValue()

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationEngine.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationEngine.kt
@@ -3,12 +3,15 @@ package com.firstpenguin.app.domain.recommendation.service
 import com.firstpenguin.app.domain.emotion.repository.TagRepository
 import com.firstpenguin.app.domain.emotion.service.EmotionService
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationRequest
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
 import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
 import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
 import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
 import com.firstpenguin.app.domain.recommendation.repository.RecommendationTagRarityRepository
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 private const val RECOMMENDATION_RESULT_QUOTE_COUNT = 10
@@ -23,27 +26,131 @@ class RecommendationEngine(
     private val tagRarityRepository: RecommendationTagRarityRepository,
     private val resultComposer: RecommendationResultComposer,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     fun recommend(
         userId: Long,
         request: RecommendationRequest,
     ): RecommendationResult {
-        val input = buildInput(userId, request).withAnalysis()
-        val effectiveTags = effectiveTagBuilder.build(input)
-        val candidates = candidateProvider.findCandidates(effectiveTags)
-        val result =
-            resultComposer.compose(
-                input = input,
-                effectiveTags = effectiveTags,
-                candidates = candidates,
-                moodTagIdByCode = tagRepository.getActiveMoodTagIdByCode(),
-                tagRarityWeights = tagRarityRepository.findMetadataTagRarityWeights(),
-            ) ?: notEnoughQuotes()
+        var quoteCount = 0
+        lateinit var result: RecommendationResult
 
-        if (result.quotes.size < RECOMMENDATION_RESULT_QUOTE_COUNT) {
-            notEnoughQuotes()
+        log.measureRecommendationStep("engine.total", { "userId=$userId quoteCount=$quoteCount" }) {
+            val input = buildMeasuredInput(userId, request)
+            val effectiveTags = buildMeasuredEffectiveTags(input)
+            val candidates = findMeasuredCandidates(effectiveTags, userId)
+            val moodTagIdByCode = findMeasuredMoodTags(userId)
+            val tagRarityWeights = findMeasuredTagRarityWeights(userId)
+
+            result =
+                composeMeasuredResult(
+                    input = input,
+                    effectiveTags = effectiveTags,
+                    candidates = candidates,
+                    moodTagIdByCode = moodTagIdByCode,
+                    tagRarityWeights = tagRarityWeights,
+                )
+            quoteCount = result.quotes.size
         }
 
         return result
+    }
+
+    private fun buildMeasuredInput(
+        userId: Long,
+        request: RecommendationRequest,
+    ): RecommendationInput {
+        val input =
+            log.measureRecommendationStep("engine.buildInput", { "userId=$userId" }) {
+                buildInput(userId, request)
+            }
+        var hasAnalysis = false
+        lateinit var analyzedInput: RecommendationInput
+
+        log.measureRecommendationStep("engine.userInputAnalysis", { "userId=$userId hasAnalysis=$hasAnalysis" }) {
+            analyzedInput = input.withAnalysis()
+            hasAnalysis = analyzedInput.analysis != null
+        }
+
+        return analyzedInput
+    }
+
+    private fun buildMeasuredEffectiveTags(input: RecommendationInput): List<EffectiveTag> {
+        var effectiveTagCount = 0
+        lateinit var effectiveTags: List<EffectiveTag>
+
+        log.measureRecommendationStep("engine.effectiveTags", { "userId=${input.userId} count=$effectiveTagCount" }) {
+            effectiveTags = effectiveTagBuilder.build(input)
+            effectiveTagCount = effectiveTags.size
+        }
+
+        return effectiveTags
+    }
+
+    private fun findMeasuredCandidates(
+        effectiveTags: List<EffectiveTag>,
+        userId: Long,
+    ): List<RecommendationCandidate> {
+        var candidateCount = 0
+        lateinit var candidates: List<RecommendationCandidate>
+
+        log.measureRecommendationStep("engine.primaryCandidates", { "userId=$userId count=$candidateCount" }) {
+            candidates = candidateProvider.findCandidates(effectiveTags)
+            candidateCount = candidates.size
+        }
+
+        return candidates
+    }
+
+    private fun findMeasuredMoodTags(userId: Long): Map<String, Long> {
+        var moodTagCount = 0
+        lateinit var moodTagIdByCode: Map<String, Long>
+
+        log.measureRecommendationStep("engine.moodTags", { "userId=$userId count=$moodTagCount" }) {
+            moodTagIdByCode = tagRepository.getActiveMoodTagIdByCode()
+            moodTagCount = moodTagIdByCode.size
+        }
+
+        return moodTagIdByCode
+    }
+
+    private fun findMeasuredTagRarityWeights(userId: Long): Map<Long, Double> {
+        var tagRarityWeightCount = 0
+        lateinit var tagRarityWeights: Map<Long, Double>
+
+        log.measureRecommendationStep("engine.tagRarityWeights", { "userId=$userId count=$tagRarityWeightCount" }) {
+            tagRarityWeights = tagRarityRepository.findMetadataTagRarityWeights()
+            tagRarityWeightCount = tagRarityWeights.size
+        }
+
+        return tagRarityWeights
+    }
+
+    private fun composeMeasuredResult(
+        input: RecommendationInput,
+        effectiveTags: List<EffectiveTag>,
+        candidates: List<RecommendationCandidate>,
+        moodTagIdByCode: Map<String, Long>,
+        tagRarityWeights: Map<Long, Double>,
+    ): RecommendationResult {
+        var quoteCount = 0
+        lateinit var result: RecommendationResult
+
+        log.measureRecommendationStep("engine.compose", { "userId=${input.userId} quoteCount=$quoteCount" }) {
+            result =
+                resultComposer.compose(
+                    input = input,
+                    effectiveTags = effectiveTags,
+                    candidates = candidates,
+                    moodTagIdByCode = moodTagIdByCode,
+                    tagRarityWeights = tagRarityWeights,
+                ) ?: notEnoughQuotes()
+            quoteCount = result.quotes.size
+        }
+
+        return result
+            .takeIf { recommendationResult -> recommendationResult.quotes.size >= RECOMMENDATION_RESULT_QUOTE_COUNT }
+            ?: notEnoughQuotes()
     }
 
     private fun buildInput(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
@@ -8,6 +8,7 @@ import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
 import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
 import com.firstpenguin.app.domain.recommendation.model.SourcedRecommendationCandidate
 import com.firstpenguin.app.domain.recommendation.model.UserSemanticEmbedding
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
@@ -17,6 +18,8 @@ class RecommendationResultComposer(
     private val fallbackService: RecommendationFallbackService,
     private val semanticProvider: RecommendationSemanticProvider,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     fun compose(
         input: RecommendationInput,
         effectiveTags: List<EffectiveTag>,
@@ -24,37 +27,96 @@ class RecommendationResultComposer(
         moodTagIdByCode: Map<String, Long>,
         tagRarityWeights: Map<Long, Double> = emptyMap(),
     ): RecommendationResult? {
-        val userEmbedding = semanticProvider.prepare(input)
+        var resultQuoteCount = 0
+        var result: RecommendationResult? = null
+
+        log.measureRecommendationStep("composer.total", { "userId=${input.userId} quoteCount=$resultQuoteCount" }) {
+            result =
+                composeOrNull(
+                    input = input,
+                    effectiveTags = effectiveTags,
+                    candidates = candidates,
+                    moodTagIdByCode = moodTagIdByCode,
+                    tagRarityWeights = tagRarityWeights,
+                ) ?: return@measureRecommendationStep
+            resultQuoteCount = result?.quotes.orEmpty().size
+        }
+
+        return result
+    }
+
+    private fun composeOrNull(
+        input: RecommendationInput,
+        effectiveTags: List<EffectiveTag>,
+        candidates: List<RecommendationCandidate>,
+        moodTagIdByCode: Map<String, Long>,
+        tagRarityWeights: Map<Long, Double>,
+    ): RecommendationResult? {
+        val userEmbedding =
+            log.measureRecommendationStep("composer.semanticPrepare", { "userId=${input.userId}" }) {
+                semanticProvider.prepare(input)
+            }
         val primaryCandidates =
             sourceCandidates(
                 candidates = candidates,
                 source = RecommendationCandidateSource.PRIMARY,
             )
         val initialRankedQuotes =
-            rank(input, effectiveTags, primaryCandidates, moodTagIdByCode, tagRarityWeights, userEmbedding)
+            log.measureRecommendationStep(
+                "composer.initialRank",
+                { "userId=${input.userId} candidateCount=${primaryCandidates.size}" },
+            ) {
+                rank(input, effectiveTags, primaryCandidates, moodTagIdByCode, tagRarityWeights, userEmbedding)
+            }
         val supplementedCandidates =
-            fallbackService.supplementCandidates(
+            findSupplementedCandidates(
                 effectiveTags = effectiveTags,
-                existingCandidates = candidates,
-                rankedQuotes = initialRankedQuotes,
-                semanticCandidates = {
-                    semanticProvider.findSimilarCandidates(
-                        userEmbedding = userEmbedding,
-                        excludedQuoteIds = candidates.map { candidate -> candidate.quoteId },
-                    )
-                },
+                candidates = candidates,
+                initialRankedQuotes = initialRankedQuotes,
+                userEmbedding = userEmbedding,
+                userId = input.userId,
             )
         val rankedQuotes =
-            rank(input, effectiveTags, supplementedCandidates, moodTagIdByCode, tagRarityWeights, userEmbedding)
-                .diversifyRoleTags()
-                .take(RECOMMENDATION_RESULT_COUNT)
-                .rerank()
+            log.measureRecommendationStep(
+                "composer.finalRank",
+                { "userId=${input.userId} candidateCount=${supplementedCandidates.size}" },
+            ) {
+                rank(input, effectiveTags, supplementedCandidates, moodTagIdByCode, tagRarityWeights, userEmbedding)
+                    .diversifyRoleTags()
+                    .take(RECOMMENDATION_RESULT_COUNT)
+                    .rerank()
+            }
         if (rankedQuotes.isEmpty()) return null
 
         return RecommendationResult(
             mainQuote = rankedQuotes.first(),
             quotes = rankedQuotes,
         )
+    }
+
+    private fun findSupplementedCandidates(
+        effectiveTags: List<EffectiveTag>,
+        candidates: List<RecommendationCandidate>,
+        initialRankedQuotes: List<RankedRecommendationQuote>,
+        userEmbedding: UserSemanticEmbedding?,
+        userId: Long,
+    ): List<SourcedRecommendationCandidate> {
+        var candidateCount = 0
+
+        return log.measureRecommendationStep("composer.fallback", { "userId=$userId candidateCount=$candidateCount" }) {
+            fallbackService
+                .supplementCandidates(
+                    effectiveTags = effectiveTags,
+                    existingCandidates = candidates,
+                    rankedQuotes = initialRankedQuotes,
+                    semanticCandidates = {
+                        semanticProvider.findSimilarCandidates(
+                            userEmbedding = userEmbedding,
+                            excludedQuoteIds = candidates.map { candidate -> candidate.quoteId },
+                        )
+                    },
+                ).also { supplementedCandidates -> candidateCount = supplementedCandidates.size }
+        }
     }
 
     private fun rank(
@@ -72,20 +134,26 @@ class RecommendationResultComposer(
                 userEmbedding = userEmbedding,
                 quoteIds = recommendationCandidates.map { candidate -> candidate.quoteId },
             )
+        var rankedQuoteCount = 0
 
-        return recommendationRanker
-            .rank(recommendationCandidates) { candidate ->
-                metadataScorer
-                    .score(
-                        input = input,
-                        effectiveTags = effectiveTags,
-                        candidate = candidate,
-                        moodTagIdByCode = moodTagIdByCode,
-                        tagRarityWeights = tagRarityWeights,
-                    ).copy(semanticScore = semanticScores[candidate.quoteId] ?: DEFAULT_SEMANTIC_SCORE)
-            }.map { quote ->
-                quote.copy(source = sourceByQuoteId.getValue(quote.quoteId))
-            }
+        return log.measureRecommendationStep(
+            "composer.rankScores",
+            { "userId=${input.userId} candidateCount=${recommendationCandidates.size} rankedCount=$rankedQuoteCount" },
+        ) {
+            recommendationRanker
+                .rank(recommendationCandidates) { candidate ->
+                    metadataScorer
+                        .score(
+                            input = input,
+                            effectiveTags = effectiveTags,
+                            candidate = candidate,
+                            moodTagIdByCode = moodTagIdByCode,
+                            tagRarityWeights = tagRarityWeights,
+                        ).copy(semanticScore = semanticScores[candidate.quoteId] ?: DEFAULT_SEMANTIC_SCORE)
+                }.map { quote ->
+                    quote.copy(source = sourceByQuoteId.getValue(quote.quoteId))
+                }.also { rankedQuotes -> rankedQuoteCount = rankedQuotes.size }
+        }
     }
 
     private fun sourceCandidates(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
@@ -95,11 +95,12 @@ class RecommendationResultComposer(
         candidates.map { candidate -> SourcedRecommendationCandidate(candidate = candidate, source = source) }
 
     private fun List<RankedRecommendationQuote>.diversifyRoleTags(): List<RankedRecommendationQuote> {
-        val selectedQuotes = mutableListOf<RankedRecommendationQuote>()
+        val scorePriorityQuotes = take(SCORE_PRIORITY_QUOTE_COUNT)
+        val selectedQuotes = scorePriorityQuotes.toMutableList()
         val deferredQuotes = mutableListOf<RankedRecommendationQuote>()
-        val roleTagCounts = mutableMapOf<Long, Int>()
+        val roleTagCounts = scorePriorityQuotes.roleTagCounts()
 
-        forEach { quote ->
+        drop(SCORE_PRIORITY_QUOTE_COUNT).forEach { quote ->
             if (selectedQuotes.size >= RECOMMENDATION_RESULT_COUNT) return selectedQuotes
             if (quote.isRoleTagLimitExceeded(roleTagCounts)) {
                 deferredQuotes.add(quote)
@@ -113,6 +114,12 @@ class RecommendationResultComposer(
             .plus(deferredQuotes)
             .distinctBy { quote -> quote.quoteId }
     }
+
+    private fun List<RankedRecommendationQuote>.roleTagCounts(): MutableMap<Long, Int> =
+        mapNotNull { quote -> quote.candidate.roleTagId }
+            .groupingBy { roleTagId -> roleTagId }
+            .eachCount()
+            .toMutableMap()
 
     private fun RankedRecommendationQuote.isRoleTagLimitExceeded(roleTagCounts: Map<Long, Int>): Boolean {
         val roleTagId = candidate.roleTagId ?: return false
@@ -130,6 +137,7 @@ class RecommendationResultComposer(
     private companion object {
         const val FIRST_RANK = 1
         const val RECOMMENDATION_RESULT_COUNT = 10
+        const val SCORE_PRIORITY_QUOTE_COUNT = 5
         const val MAX_SAME_ROLE_TAG_COUNT = 3
         const val NO_ROLE_TAG_COUNT = 0
         const val DEFAULT_SEMANTIC_SCORE = 0.0

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationSemanticService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationSemanticService.kt
@@ -6,6 +6,7 @@ import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
 import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
 import com.firstpenguin.app.domain.recommendation.model.UserSemanticEmbedding
 import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 interface RecommendationSemanticProvider {
@@ -29,12 +30,20 @@ class RecommendationSemanticService(
     private val quoteEmbeddingRepository: QuoteEmbeddingRepository,
     private val candidateProvider: RecommendationCandidateProvider,
 ) : RecommendationSemanticProvider {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     override fun prepare(input: RecommendationInput): UserSemanticEmbedding? {
-        val embeddingInput = userEmbeddingInputBuilder.build(input) ?: return null
+        val embeddingInput =
+            log.measureRecommendationStep("semantic.buildEmbeddingInput", { "userId=${input.userId}" }) {
+                userEmbeddingInputBuilder.build(input)
+            } ?: return null
 
         return UserSemanticEmbedding(
             inputText = embeddingInput,
-            embedding = userQueryEmbeddingProcessor.embed(embeddingInput),
+            embedding =
+                log.measureRecommendationStep("semantic.openAiEmbedding", { "userId=${input.userId}" }) {
+                    userQueryEmbeddingProcessor.embed(embeddingInput)
+                },
         )
     }
 
@@ -43,11 +52,19 @@ class RecommendationSemanticService(
         quoteIds: Collection<Long>,
     ): Map<Long, Double> {
         if (userEmbedding == null) return emptyMap()
+        var scoreCount = 0
+        lateinit var scores: Map<Long, Double>
 
-        return quoteEmbeddingRepository.findCosineSimilarities(
-            quoteIds = quoteIds,
-            userEmbedding = userEmbedding.embedding,
-        )
+        log.measureRecommendationStep("semantic.findScores", { "quoteCount=${quoteIds.size} scoreCount=$scoreCount" }) {
+            scores =
+                quoteEmbeddingRepository.findCosineSimilarities(
+                    quoteIds = quoteIds,
+                    userEmbedding = userEmbedding.embedding,
+                )
+            scoreCount = scores.size
+        }
+
+        return scores
     }
 
     override fun findSimilarCandidates(
@@ -55,14 +72,27 @@ class RecommendationSemanticService(
         excludedQuoteIds: Collection<Long>,
     ): List<RecommendationCandidate> {
         if (userEmbedding == null) return emptyList()
-        val quoteIds =
-            quoteEmbeddingRepository.findMostSimilarQuoteIds(
-                userEmbedding = userEmbedding.embedding,
-                excludedQuoteIds = excludedQuoteIds,
-                limit = SEMANTIC_FALLBACK_LIMIT,
-            )
+        var quoteIdCount = 0
+        var candidateCount = 0
+        lateinit var quoteIds: List<Long>
+        lateinit var candidates: List<RecommendationCandidate>
 
-        return candidateProvider.findCandidatesByQuoteIds(quoteIds)
+        log.measureRecommendationStep("semantic.findSimilarQuoteIds", { "quoteCount=$quoteIdCount" }) {
+            quoteIds =
+                quoteEmbeddingRepository.findMostSimilarQuoteIds(
+                    userEmbedding = userEmbedding.embedding,
+                    excludedQuoteIds = excludedQuoteIds,
+                    limit = SEMANTIC_FALLBACK_LIMIT,
+                )
+            quoteIdCount = quoteIds.size
+        }
+
+        log.measureRecommendationStep("semantic.findSimilarCandidates", { "candidateCount=$candidateCount" }) {
+            candidates = candidateProvider.findCandidatesByQuoteIds(quoteIds)
+            candidateCount = candidates.size
+        }
+
+        return candidates
     }
 
     private companion object {

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationTimingLogger.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationTimingLogger.kt
@@ -1,0 +1,36 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import org.slf4j.Logger
+
+private const val RECOMMENDATION_TIMING_LOG_PREFIX = "[recommendation-timing]"
+private const val NANOSECONDS_PER_MILLISECOND = 1_000_000
+
+internal fun <T> Logger.measureRecommendationStep(
+    step: String,
+    detail: () -> String = { "" },
+    block: () -> T,
+): T {
+    val startedAt = System.nanoTime()
+
+    return try {
+        block()
+    } finally {
+        logRecommendationTiming(step, startedAt, detail.safelyBuild())
+    }
+}
+
+private fun (() -> String).safelyBuild(): String = runCatching { this() }.getOrDefault("detail=unavailable")
+
+private fun Logger.logRecommendationTiming(
+    step: String,
+    startedAt: Long,
+    detail: String,
+) {
+    val elapsedMs = (System.nanoTime() - startedAt) / NANOSECONDS_PER_MILLISECOND
+    if (detail.isBlank()) {
+        info("{} step={} elapsedMs={}", RECOMMENDATION_TIMING_LOG_PREFIX, step, elapsedMs)
+        return
+    }
+
+    info("{} step={} elapsedMs={} {}", RECOMMENDATION_TIMING_LOG_PREFIX, step, elapsedMs, detail)
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationCommandUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/useCase/RecommendationCommandUseCase.kt
@@ -7,6 +7,8 @@ import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
 import com.firstpenguin.app.domain.recommendation.service.RecommendationResponseMapper
 import com.firstpenguin.app.domain.recommendation.service.RecommendationService
 import com.firstpenguin.app.domain.recommendation.service.RecommendationValidationService
+import com.firstpenguin.app.domain.recommendation.service.measureRecommendationStep
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,28 +19,64 @@ class RecommendationCommandUseCase(
     private val recommendationValidationService: RecommendationValidationService,
     private val recommendationResponseMapper: RecommendationResponseMapper,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     @Transactional
     fun saveRecommendationResult(
         userId: Long,
         request: RecommendationRequest,
         result: RecommendationResult,
     ): RecommendationResponse {
-        recommendationService.lockRecommendationCreation(userId)
-        recommendationService.findOngoingRecommendation(userId)?.let { recommendation ->
-            return recommendationResponseMapper.toRecommendationResponse(recommendation)
+        lateinit var response: RecommendationResponse
+
+        log.measureRecommendationStep("command.saveRecommendationResult.total", { "userId=$userId" }) {
+            log.measureRecommendationStep("command.lockRecommendationCreation", { "userId=$userId" }) {
+                recommendationService.lockRecommendationCreation(userId)
+            }
+
+            val ongoingRecommendation =
+                log.measureRecommendationStep("command.ongoingLookup", { "userId=$userId" }) {
+                    recommendationService.findOngoingRecommendation(userId)
+                }
+            if (ongoingRecommendation != null) {
+                response = recommendationResponseMapper.toRecommendationResponse(ongoingRecommendation)
+                return@measureRecommendationStep
+            }
+
+            response = saveNewRecommendationResult(userId, request, result)
         }
 
-        recommendationValidationService.validateRecommendationCreatable(userId)
+        return response
+    }
 
-        val recommendationId = createRecommendation(userId, request)
-        recommendationService.createRecommendationTags(
-            recommendationId = recommendationId,
-            tagIds = request.selectedTagIds(),
-        )
-        recommendationService.createRankedRecommendationQuotes(
-            recommendationId = recommendationId,
-            rankedQuotes = result.quotes,
-        )
+    private fun saveNewRecommendationResult(
+        userId: Long,
+        request: RecommendationRequest,
+        result: RecommendationResult,
+    ): RecommendationResponse {
+        log.measureRecommendationStep("command.validateCreatable", { "userId=$userId" }) {
+            recommendationValidationService.validateRecommendationCreatable(userId)
+        }
+        val recommendationId =
+            log.measureRecommendationStep("command.createRecommendation", { "userId=$userId" }) {
+                createRecommendation(userId, request)
+            }
+
+        log.measureRecommendationStep("command.createRecommendationTags", { "recommendationId=$recommendationId" }) {
+            recommendationService.createRecommendationTags(
+                recommendationId = recommendationId,
+                tagIds = request.selectedTagIds(),
+            )
+        }
+        log.measureRecommendationStep(
+            "command.createRecommendationQuotes",
+            { "recommendationId=$recommendationId quoteCount=${result.quotes.size}" },
+        ) {
+            recommendationService.createRankedRecommendationQuotes(
+                recommendationId = recommendationId,
+                rankedQuotes = result.quotes,
+            )
+        }
 
         return recommendationResponseMapper.toRecommendationResponse(
             recommendationId = recommendationId,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
@@ -38,7 +38,7 @@ class RecommendationResultComposerTest {
     }
 
     @Test
-    fun `role tag가 한쪽으로 몰리면 뒤쪽 role 후보를 앞당긴다`() {
+    fun `role tag 다양화는 상위 점수 후보를 유지한 뒤 뒤쪽 후보에 적용한다`() {
         val composer = composer()
         val candidates =
             (1L..8L)
@@ -54,8 +54,8 @@ class RecommendationResultComposerTest {
             )
         val quoteIds = requireNotNull(result).quotes.map { quote -> quote.quoteId }
 
-        assertTrue(quoteIds.indexOf(9L) < quoteIds.indexOf(4L))
-        assertEquals(1L, quoteIds.first())
+        assertEquals((1L..5L).toList(), quoteIds.take(5))
+        assertTrue(quoteIds.indexOf(9L) < quoteIds.indexOf(6L))
     }
 
     @Test


### PR DESCRIPTION
## 📢 요약
- 추천 결과에서 role tag 다양화가 상위 점수 후보를 밀어내지 않도록 조정했습니다.
- 상위 5개 후보는 점수 순서를 유지하고, 이후 후보부터 role tag 다양화 정책을 적용합니다.
- 추천 흐름의 병목을 확인할 수 있도록 `[recommendation-timing]` 로그를 추가했습니다.
  - 사용자 입력 LLM 분석
  - 임베딩 생성
  - 1차 후보 조회
  - semantic score 조회
  - fallback 보강
  - 랭킹/합성
  - 추천 기록 저장
- 추천 결과 composer 테스트를 변경된 다양화 정책에 맞게 수정했습니다.

🔗 연관 이슈: Resolves #146

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [ ] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
추천 응답시간 로그 예시:

```text
[recommendation-timing] step=userInputAnalysis.openAi elapsedMs=8421 userId=1
[recommendation-timing] step=semantic.openAiEmbedding elapsedMs=612 userId=1
[recommendation-timing] step=engine.total elapsedMs=15120 userId=1 quoteCount=10
```

검증 완료:

./gradlew formatKotlin
./gradlew testClasses
./gradlew detekt
./gradlew lintKotlin
./gradlew test --tests '*Recommendation*' --tests '*UserInput*'
./gradlew build


## 📜 기타
- 로그에는 사용자 입력 본문을 남기지 않고 userId, 후보 수, 결과 수, 소요 시간만 남기도록 했습니다.
\