### PR TITLE
Feat/#153/recommendation response time optimization

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/policy/IntentFocusWeightPolicy.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/policy/IntentFocusWeightPolicy.kt
@@ -10,15 +10,15 @@ object IntentFocusWeightPolicy {
             IntentType.CONTEXT_BASED to
                 mapOf(
                     TagType.CONTEXT to 0.40,
-                    TagType.MOOD to 0.25,
-                    TagType.NEED to 0.20,
-                    TagType.EMOTION to 0.05,
+                    TagType.EMOTION to 0.20,
+                    TagType.MOOD to 0.20,
                     TagType.SITUATION to 0.10,
+                    TagType.NEED to 0.10,
                 ),
             IntentType.EMOTION_NEED_BASED to
                 mapOf(
-                    TagType.NEED to 0.35,
-                    TagType.EMOTION to 0.30,
+                    TagType.EMOTION to 0.45,
+                    TagType.NEED to 0.20,
                     TagType.MOOD to 0.15,
                     TagType.SITUATION to 0.10,
                     TagType.CONTEXT to 0.10,
@@ -26,16 +26,16 @@ object IntentFocusWeightPolicy {
             IntentType.SITUATION_BASED to
                 mapOf(
                     TagType.SITUATION to 0.35,
-                    TagType.NEED to 0.25,
-                    TagType.EMOTION to 0.15,
+                    TagType.EMOTION to 0.25,
+                    TagType.NEED to 0.15,
                     TagType.MOOD to 0.15,
                     TagType.CONTEXT to 0.10,
                 ),
             IntentType.MIXED to
                 mapOf(
-                    TagType.NEED to 0.30,
-                    TagType.EMOTION to 0.25,
-                    TagType.CONTEXT to 0.20,
+                    TagType.EMOTION to 0.40,
+                    TagType.NEED to 0.20,
+                    TagType.CONTEXT to 0.15,
                     TagType.MOOD to 0.15,
                     TagType.SITUATION to 0.10,
                 ),

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/policy/IntentTypePolicy.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/policy/IntentTypePolicy.kt
@@ -1,0 +1,37 @@
+package com.firstpenguin.app.domain.recommendation.policy
+
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.IntentType
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.global.enums.TagType
+
+object IntentTypePolicy {
+    fun resolve(
+        input: RecommendationInput,
+        effectiveTags: Collection<EffectiveTag>,
+    ): IntentType {
+        val hasContext = effectiveTags.hasType(TagType.CONTEXT)
+        val hasSituation = effectiveTags.hasType(TagType.SITUATION)
+        val hasEmotionNeed = input.hasSelectedEmotionNeed() || effectiveTags.hasEmotionNeed()
+
+        return when {
+            hasContext && hasSituation -> IntentType.MIXED
+            hasContext -> IntentType.CONTEXT_BASED
+            hasSituation -> IntentType.SITUATION_BASED
+            hasEmotionNeed -> IntentType.EMOTION_NEED_BASED
+            else -> IntentType.MIXED
+        }
+    }
+
+    private fun RecommendationInput.hasSelectedEmotionNeed(): Boolean {
+        if (emotionTags.isNotEmpty()) return true
+
+        return needTag != null
+    }
+
+    private fun Collection<EffectiveTag>.hasEmotionNeed(): Boolean = any { tag -> tag.type in EMOTION_NEED_TAG_TYPES }
+
+    private fun Collection<EffectiveTag>.hasType(tagType: TagType): Boolean = any { tag -> tag.type == tagType }
+
+    private val EMOTION_NEED_TAG_TYPES = setOf(TagType.EMOTION, TagType.NEED)
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/policy/MoodTagPolicy.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/policy/MoodTagPolicy.kt
@@ -13,8 +13,8 @@ class MoodTagPolicy {
     fun resolveMoodTagCodes(
         input: RecommendationInput,
         effectiveTags: List<EffectiveTag>,
+        intentType: IntentType = IntentTypePolicy.resolve(input, effectiveTags),
     ): Set<String> {
-        val intentType = input.analysis?.intentType ?: IntentType.EMOTION_NEED_BASED
         if (IntentFocusWeightPolicy.weightOf(intentType, TagType.MOOD) <= 0.0) return emptySet()
 
         return moodScores(input, effectiveTags)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/MetadataScorer.kt
@@ -6,6 +6,7 @@ import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
 import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
 import com.firstpenguin.app.domain.recommendation.model.RecommendationScoreBreakdown
 import com.firstpenguin.app.domain.recommendation.policy.IntentFocusWeightPolicy
+import com.firstpenguin.app.domain.recommendation.policy.IntentTypePolicy
 import com.firstpenguin.app.domain.recommendation.policy.MoodTagPolicy
 import com.firstpenguin.app.global.enums.TagType
 import org.springframework.stereotype.Component
@@ -22,12 +23,12 @@ class MetadataScorer(
         moodTagIdByCode: Map<String, Long>,
         tagRarityWeights: Map<Long, Double> = emptyMap(),
     ): RecommendationScoreBreakdown {
-        val intentType = input.analysis?.intentType ?: IntentType.EMOTION_NEED_BASED
+        val intentType = IntentTypePolicy.resolve(input, effectiveTags)
         val needScore = typeScore(TagType.NEED, effectiveTags, candidate, tagRarityWeights)
         val emotionScore = typeScore(TagType.EMOTION, effectiveTags, candidate, tagRarityWeights)
         val contextScore = typeScore(TagType.CONTEXT, effectiveTags, candidate)
         val situationScore = typeScore(TagType.SITUATION, effectiveTags, candidate)
-        val moodScore = moodScore(input, effectiveTags, candidate, moodTagIdByCode, tagRarityWeights)
+        val moodScore = moodScore(input, effectiveTags, candidate, moodTagIdByCode, tagRarityWeights, intentType)
         val metadataScore =
             metadataScore(
                 intentType = intentType,
@@ -68,10 +69,11 @@ class MetadataScorer(
         candidate: RecommendationCandidate,
         moodTagIdByCode: Map<String, Long>,
         tagRarityWeights: Map<Long, Double>,
+        intentType: IntentType,
     ): Double {
         val targetMoodTagIds =
             moodTagPolicy
-                .resolveMoodTagCodes(input, effectiveTags)
+                .resolveMoodTagCodes(input, effectiveTags, intentType)
                 .mapNotNullTo(mutableSetOf()) { code -> moodTagIdByCode[code] }
 
         return typeScoreCalculator.calculate(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
@@ -2,6 +2,7 @@ package com.firstpenguin.app.domain.recommendation.service
 
 import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
 import com.firstpenguin.app.domain.recommendation.model.RankedRecommendationQuote
+import com.firstpenguin.app.domain.recommendation.model.RecommendationAiModelVersion
 import com.firstpenguin.app.domain.recommendation.model.RecommendationAnalysisLog
 import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
 import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidateSource
@@ -73,22 +74,6 @@ class RecommendationResultComposer(
             mainQuote = rankedQuotes.first(),
             quotes = rankedQuotes,
             analysisLog = input.analysisLog(userEmbedding),
-        )
-    }
-
-    private fun RecommendationInput.analysisLog(userEmbedding: UserSemanticEmbedding?): RecommendationAnalysisLog? {
-        val analysis = analysis ?: return null
-
-        return RecommendationAnalysisLog(
-            llmModel = analysis.llmModel,
-            llmModelVersion = analysis.llmModelVersion,
-            canonicalIntent = analysis.canonicalIntent,
-            embeddingInputText = userEmbedding?.inputText,
-            inputTokens = analysis.inputTokens,
-            cachedTokens = analysis.cachedTokens,
-            outputTokens = analysis.outputTokens,
-            llmElapsedMs = analysis.llmElapsedMs,
-            embeddingElapsedMs = userEmbedding?.embeddingElapsedMs,
         )
     }
 
@@ -187,3 +172,40 @@ class RecommendationResultComposer(
     private fun List<RankedRecommendationQuote>.rerank(): List<RankedRecommendationQuote> =
         mapIndexed { index, quote -> quote.copy(rank = index + FIRST_RANK) }
 }
+
+private fun RecommendationInput.analysisLog(userEmbedding: UserSemanticEmbedding?): RecommendationAnalysisLog? {
+    val analysis = analysis ?: return fallbackAnalysisLog()
+
+    return RecommendationAnalysisLog(
+        llmModel = analysis.llmModel,
+        llmModelVersion = analysis.llmModelVersion,
+        canonicalIntent = analysis.canonicalIntent,
+        embeddingInputText = userEmbedding?.inputText,
+        inputTokens = analysis.inputTokens,
+        cachedTokens = analysis.cachedTokens,
+        outputTokens = analysis.outputTokens,
+        llmElapsedMs = analysis.llmElapsedMs,
+        embeddingElapsedMs = userEmbedding?.embeddingElapsedMs,
+    )
+}
+
+private fun RecommendationInput.fallbackAnalysisLog(): RecommendationAnalysisLog? {
+    if (!hasAnalysisText()) return null
+    val modelVersion = RecommendationAiModelVersion.USER_INPUT_ANALYSIS_V1
+
+    return RecommendationAnalysisLog(
+        llmModel = modelVersion.model,
+        llmModelVersion = modelVersion.version,
+        canonicalIntent = null,
+        embeddingInputText = null,
+        inputTokens = null,
+        cachedTokens = null,
+        outputTokens = null,
+        llmElapsedMs = null,
+        embeddingElapsedMs = null,
+    )
+}
+
+private fun RecommendationInput.hasAnalysisText(): Boolean = feelingText.hasValue() || diaryText.hasValue()
+
+private fun String?.hasValue(): Boolean = !isNullOrBlank()

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseOutputParser.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseOutputParser.kt
@@ -30,10 +30,16 @@ private fun JsonNode.toUserInputAnalysis(
     tagCandidateMapper: UserInputTagCandidateMapper,
 ): UserInputAnalysis =
     UserInputAnalysis(
-        intentType = IntentType.valueOf(requiredText("intentType")),
+        intentType = optionalIntentType(),
         canonicalIntent = requiredText("canonicalIntent"),
         tagCandidates = tagCandidateMapper.map(tagCandidateNodes(), input, tagGroups),
     )
+
+private fun JsonNode.optionalIntentType(): IntentType =
+    stringOrEmpty("intentType")
+        .takeIf { value -> value.isNotBlank() }
+        ?.let(IntentType::valueOf)
+        ?: IntentType.EMOTION_NEED_BASED
 
 private fun JsonNode.tagCandidateNodes(): List<Pair<TagType, JsonNode>> =
     listOf(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseRequestBuilder.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseRequestBuilder.kt
@@ -28,9 +28,8 @@ private val USER_INPUT_PARSE_PROMPT_GUIDE =
 5. context/situation tag를 중심으로 추출하라.
 6. emotion/need tag는 명확한 근거가 있을 때만 추출하라.
 7. 개수를 채우기 위해 약한 태그를 선택하지 마라.
-8. hasSelectedNeedTag가 false이고 feelingText가 있으면 allowed NEED tag 중
-    feelingText와 가장 일치하는 NEED tag를 반드시 1개 반환하라.
-9. hasSelectedNeedTag가 true이면 need tag도 emotion tag와 동일하게 12번 규칙을 따른다.
+8. emotion tag는 사용자가 고른 감정 태그를 보조하는 후보이므로 PRIMARY priority를 사용하지 마라.
+9. need tag는 원하는 도움이나 기대가 명확히 드러날 때만 1개까지 추출하라.
 10. context tag는 실제 장소, 날씨, 시간, 활동, 장면이 직접 드러날 때만 선택하라.
 11. situation tag는 실제 삶의 문제, 사건, 관계, 주제가 직접 드러날 때만 선택하라.
 12. 은유적 표현만으로 context나 situation을 선택하지 마라.
@@ -90,7 +89,6 @@ class UserInputParseRequestBuilder(
 
     private fun RecommendationInput.toPayload(): Map<String, Any?> =
         mapOf(
-            "hasSelectedNeedTag" to (needTag != null),
             "feelingText" to feelingText.normalizedText(),
             "diaryText" to diaryText.normalizedText(),
         )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseRequestBuilder.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseRequestBuilder.kt
@@ -11,7 +11,6 @@ import tools.jackson.databind.json.JsonMapper
 
 private const val OPENAI_REASONING_EFFORT = "low"
 private const val OPENAI_TEXT_VERBOSITY = "low"
-private const val USER_INPUT_ANALYSIS_MAX_OUTPUT_TOKENS = 800
 private const val USER_INPUT_ANALYSIS_PROMPT_CACHE_KEY_PREFIX = "user-input-analysis-v1"
 
 private val USER_INPUT_PARSE_PROMPT_GUIDE =
@@ -71,7 +70,6 @@ class UserInputParseRequestBuilder(
                     verbosity = OPENAI_TEXT_VERBOSITY,
                 ),
             promptCacheKey = USER_INPUT_ANALYSIS_MODEL.promptCacheKey,
-            maxOutputTokens = USER_INPUT_ANALYSIS_MAX_OUTPUT_TOKENS,
         )
 
     private fun buildPrompt(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseRequestBuilder.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseRequestBuilder.kt
@@ -17,7 +17,7 @@ private val USER_INPUT_PARSE_PROMPT_GUIDE =
     """
 너는 감정 기반 문장 추천 서비스의 사용자 입력 분석기다.
 
-너의 역할은 사용자의 free text와 diary text를 분석하여 추천 엔진이 사용할 intentType, canonicalIntent,
+너의 역할은 사용자의 free text와 diary text를 분석하여 추천 엔진이 사용할 canonicalIntent,
 타입별 tag candidate를 반환하는 것이다.
 
 중요 규칙:
@@ -35,12 +35,6 @@ private val USER_INPUT_PARSE_PROMPT_GUIDE =
 11. situation tag는 실제 삶의 문제, 사건, 관계, 주제가 직접 드러날 때만 선택하라.
 12. 은유적 표현만으로 context나 situation을 선택하지 마라.
 13. 출력은 반드시 JSON schema를 따르고 JSON 외의 설명 문장은 출력하지 마라.
-
-[intentType 기준]
-- EMOTION_NEED_BASED: 감정과 필요한 반응이 중심이다.
-- CONTEXT_BASED: 날씨, 시간, 장소, 활동 같은 맥락이 추천 의도에 직접적이다.
-- SITUATION_BASED: 실패, 관계, 일, 이별, 변화 같은 삶의 사건이 중심이다.
-- MIXED: 감정, 필요, 상황, 성찰이 섞여 있거나 관점 전환/마음정리가 중심이다.
 
 [canonicalIntent 작성 기준]
 - 한국어 한 문장으로 작성하라.

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchema.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchema.kt
@@ -50,13 +50,14 @@ private fun userInputParseProperties(tagGroups: Map<TagType, List<TagOption>>): 
         "emotionTagCandidates" to
             tagCandidatesSchema(
                 options = tagGroups.getValue(TagType.EMOTION),
-                description = "텍스트에 명확히 드러난 사용자 감정 후보.",
+                description = "텍스트에 명확히 드러난 사용자 감정 보조 후보. PRIMARY priority를 사용하지 않는다.",
                 maxItems = EMOTION_TAG_MAX_ITEMS,
+                priorities = listOf(TagCandidatePriority.SECONDARY, TagCandidatePriority.BACKGROUND),
             ),
         "needTagCandidates" to
             tagCandidatesSchema(
                 options = tagGroups.getValue(TagType.NEED),
-                description = "텍스트에 명확히 드러난 필요/기대 후보. hasSelectedNeedTag=false이면 feelingText와 가장 일치하는 후보 1개를 반환한다.",
+                description = "텍스트에 명확히 드러난 필요/기대 후보",
                 maxItems = NEED_TAG_MAX_ITEMS,
             ),
         "situationTagCandidates" to
@@ -83,23 +84,30 @@ private fun tagCandidatesSchema(
     options: List<TagOption>,
     description: String,
     maxItems: Int,
+    priorities: List<TagCandidatePriority> = TagCandidatePriority.entries,
 ): Map<String, Any> =
     mapOf(
         "type" to "array",
         "description" to description,
         "maxItems" to maxItems,
-        "items" to tagCandidateSchema(options),
+        "items" to tagCandidateSchema(options, priorities),
     )
 
-private fun tagCandidateSchema(options: List<TagOption>): Map<String, Any> =
+private fun tagCandidateSchema(
+    options: List<TagOption>,
+    priorities: List<TagCandidatePriority>,
+): Map<String, Any> =
     mapOf(
         "type" to "object",
         "additionalProperties" to false,
         "required" to listOf("tagCode", "source", "priority", "confidence"),
-        "properties" to tagCandidateProperties(options),
+        "properties" to tagCandidateProperties(options, priorities),
     )
 
-private fun tagCandidateProperties(options: List<TagOption>): Map<String, Any> =
+private fun tagCandidateProperties(
+    options: List<TagOption>,
+    priorities: List<TagCandidatePriority>,
+): Map<String, Any> =
     mapOf(
         "tagCode" to
             enumSchema(
@@ -113,7 +121,7 @@ private fun tagCandidateProperties(options: List<TagOption>): Map<String, Any> =
             ),
         "priority" to
             enumSchema(
-                values = TagCandidatePriority.entries.map { priority -> priority.name },
+                values = priorities.map { priority -> priority.name },
                 description = "같은 카테고리 안에서 추천 엔진에 전달할 우선순위",
             ),
         "confidence" to

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchema.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchema.kt
@@ -1,7 +1,6 @@
 package com.firstpenguin.app.domain.recommendation.service
 
 import com.firstpenguin.app.domain.quotemetadata.dto.TagOption
-import com.firstpenguin.app.domain.recommendation.model.IntentType
 import com.firstpenguin.app.domain.recommendation.model.TagCandidatePriority
 import com.firstpenguin.app.domain.recommendation.model.TagCandidateSource
 import com.firstpenguin.app.global.enums.TagType
@@ -31,7 +30,6 @@ private fun userInputParseObjectSchema(tagGroups: Map<TagType, List<TagOption>>)
 
 private fun requiredUserInputParseFields(): List<String> =
     listOf(
-        "intentType",
         "canonicalIntent",
         "emotionTagCandidates",
         "needTagCandidates",
@@ -42,11 +40,6 @@ private fun requiredUserInputParseFields(): List<String> =
 
 private fun userInputParseProperties(tagGroups: Map<TagType, List<TagOption>>): Map<String, Any> =
     mapOf(
-        "intentType" to
-            enumSchema(
-                values = IntentType.entries.map { type -> type.name },
-                description = "사용자 입력의 추천 의도 유형",
-            ),
         "canonicalIntent" to
             mapOf(
                 "type" to "string",

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/policy/IntentFocusWeightPolicyTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/policy/IntentFocusWeightPolicyTest.kt
@@ -1,0 +1,32 @@
+package com.firstpenguin.app.domain.recommendation.policy
+
+import com.firstpenguin.app.domain.recommendation.model.IntentType
+import com.firstpenguin.app.global.enums.TagType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class IntentFocusWeightPolicyTest {
+    @Test
+    fun `모든 intent type에서 emotion weight는 need weight보다 크다`() {
+        IntentType.entries.forEach { intentType ->
+            val weights = IntentFocusWeightPolicy.weightsOf(intentType)
+
+            assertTrue(weights.getValue(TagType.EMOTION) > weights.getValue(TagType.NEED))
+        }
+    }
+
+    @Test
+    fun `모든 intent type의 focus weight 합은 1이다`() {
+        IntentType.entries.forEach { intentType ->
+            val weights = IntentFocusWeightPolicy.weightsOf(intentType)
+
+            assertEquals(FULL_WEIGHT, weights.values.sum(), DELTA)
+        }
+    }
+
+    private companion object {
+        const val FULL_WEIGHT = 1.0
+        const val DELTA = 0.000001
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/policy/IntentTypePolicyTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/policy/IntentTypePolicyTest.kt
@@ -1,0 +1,94 @@
+package com.firstpenguin.app.domain.recommendation.policy
+
+import com.firstpenguin.app.domain.emotion.model.Tag
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.IntentType
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.global.enums.TagType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class IntentTypePolicyTest {
+    @Test
+    fun `context와 situation이 함께 있으면 mixed로 계산한다`() {
+        val result =
+            IntentTypePolicy.resolve(
+                input = recommendationInput(),
+                effectiveTags =
+                    listOf(
+                        effectiveTag(TagType.CONTEXT),
+                        effectiveTag(TagType.SITUATION),
+                    ),
+            )
+
+        assertEquals(IntentType.MIXED, result)
+    }
+
+    @Test
+    fun `context tag가 있으면 context based로 계산한다`() {
+        val result =
+            IntentTypePolicy.resolve(
+                input = recommendationInput(),
+                effectiveTags = listOf(effectiveTag(TagType.CONTEXT)),
+            )
+
+        assertEquals(IntentType.CONTEXT_BASED, result)
+    }
+
+    @Test
+    fun `situation tag가 있으면 situation based로 계산한다`() {
+        val result =
+            IntentTypePolicy.resolve(
+                input = recommendationInput(),
+                effectiveTags = listOf(effectiveTag(TagType.SITUATION)),
+            )
+
+        assertEquals(IntentType.SITUATION_BASED, result)
+    }
+
+    @Test
+    fun `선택한 emotion need 중심이면 emotion need based로 계산한다`() {
+        val result =
+            IntentTypePolicy.resolve(
+                input = recommendationInput(),
+                effectiveTags = emptyList(),
+            )
+
+        assertEquals(IntentType.EMOTION_NEED_BASED, result)
+    }
+
+    private fun recommendationInput(): RecommendationInput =
+        RecommendationInput(
+            userId = USER_ID,
+            emotionRangeId = EMOTION_RANGE_ID,
+            emotionTags = listOf(tag(TagType.EMOTION)),
+            needTag = tag(TagType.NEED),
+            feelingText = null,
+            diaryText = null,
+            analysis = null,
+        )
+
+    private fun tag(type: TagType): Tag =
+        Tag(
+            id = type.ordinal.toLong(),
+            emotionRangeId = if (type == TagType.EMOTION) EMOTION_RANGE_ID else null,
+            code = "${type.name}_CODE",
+            label = type.name,
+            type = type,
+            createdAt = CREATED_AT,
+        )
+
+    private fun effectiveTag(type: TagType): EffectiveTag =
+        EffectiveTag(
+            tagId = type.ordinal.toLong(),
+            code = "${type.name}_CODE",
+            type = type,
+        )
+
+    private companion object {
+        const val USER_ID = 1L
+        const val EMOTION_RANGE_ID = 1L
+        val CREATED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 16, 0, 0)
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisServiceTest.kt
@@ -56,7 +56,7 @@ class OpenAiUserInputAnalysisServiceTest {
         assertEquals(OPEN_AI_CACHED_TOKENS, result.cachedTokens)
         assertEquals(OPEN_AI_OUTPUT_TOKENS, result.outputTokens)
         assertTrue(openAi.lastRequest.input.contains("비 오는 출근길"))
-        assertTrue(openAi.lastRequest.input.contains("\"hasSelectedNeedTag\":false"))
+        assertFalse(openAi.lastRequest.input.contains("hasSelectedNeedTag"))
         assertEquals(USER_INPUT_ANALYSIS_MODEL, openAi.lastRequest.model)
         assertEquals("user-input-analysis-v1-gpt-5-mini", openAi.lastRequest.promptCacheKey)
         assertTrue(
@@ -81,7 +81,7 @@ class OpenAiUserInputAnalysisServiceTest {
         )
 
         assertFalsePromptContainsSelectedTags(openAi.lastRequest.input)
-        assertTrue(openAi.lastRequest.input.contains("\"hasSelectedNeedTag\":true"))
+        assertFalse(openAi.lastRequest.input.contains("hasSelectedNeedTag"))
     }
 
     @Test
@@ -111,7 +111,7 @@ class OpenAiUserInputAnalysisServiceTest {
 
         requireNotNull(result)
         assertTrue(openAi.lastRequest.input.contains("오늘 힘들다"))
-        assertTrue(openAi.lastRequest.input.contains("\"hasSelectedNeedTag\":true"))
+        assertFalse(openAi.lastRequest.input.contains("hasSelectedNeedTag"))
         assertEquals(USER_INPUT_ANALYSIS_MODEL, openAi.lastRequest.model)
     }
 
@@ -313,6 +313,7 @@ class OpenAiUserInputAnalysisServiceTest {
         fun assertFalsePromptContainsSelectedTags(input: String) {
             assertFalse(input.contains("selectedEmotionTagCodes"))
             assertFalse(input.contains("selectedNeedTagCode"))
+            assertFalse(input.contains("hasSelectedNeedTag"))
             assertFalse(input.contains("EMOTION_SELECTED"))
             assertFalse(input.contains("NEED_SELECTED"))
         }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisServiceTest.kt
@@ -59,7 +59,6 @@ class OpenAiUserInputAnalysisServiceTest {
         assertTrue(openAi.lastRequest.input.contains("\"hasSelectedNeedTag\":false"))
         assertEquals(USER_INPUT_ANALYSIS_MODEL, openAi.lastRequest.model)
         assertEquals("user-input-analysis-v1-gpt-5-mini", openAi.lastRequest.promptCacheKey)
-        assertEquals(USER_INPUT_ANALYSIS_MAX_OUTPUT_TOKENS, openAi.lastRequest.maxOutputTokens)
         assertTrue(
             openAi.lastRequest.text.format
                 .toString()
@@ -168,7 +167,6 @@ class OpenAiUserInputAnalysisServiceTest {
         const val NEED_TAG_ID = 10L
         const val CONTEXT_TAG_ID = 20L
         const val USER_INPUT_ANALYSIS_MODEL = "gpt-5-mini"
-        const val USER_INPUT_ANALYSIS_MAX_OUTPUT_TOKENS = 800
         const val OPEN_AI_INPUT_TOKENS = 120L
         const val OPEN_AI_CACHED_TOKENS = 80L
         const val OPEN_AI_OUTPUT_TOKENS = 40L

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
@@ -101,6 +101,24 @@ class RecommendationResultComposerTest {
         assertEquals(1.0, result?.mainQuote?.score?.semanticScore)
     }
 
+    @Test
+    fun `분석 대상 텍스트가 있으면 LLM 분석이 실패해도 분석 로그를 남긴다`() {
+        val composer = composer()
+
+        val result =
+            composer.compose(
+                input = recommendationInputWithoutAnalysis(diaryText = "행복해서!"),
+                effectiveTags = effectiveTags,
+                candidates = (1L..10L).map { quoteId -> candidate(quoteId, roleTagId = quoteId) },
+                moodTagIdByCode = emptyMap(),
+            )
+
+        assertEquals("gpt-5-mini", result?.analysisLog?.llmModel)
+        assertEquals(1, result?.analysisLog?.llmModelVersion)
+        assertEquals(null, result?.analysisLog?.canonicalIntent)
+        assertEquals(null, result?.analysisLog?.embeddingInputText)
+    }
+
     private class FakeRecommendationCandidateProvider(
         private val randomCandidates: List<RecommendationCandidate> = emptyList(),
     ) : RecommendationCandidateProvider {
@@ -208,6 +226,17 @@ class RecommendationResultComposerTest {
                         canonicalIntent = canonicalIntent,
                         tagCandidates = emptyList(),
                     ),
+            )
+
+        fun recommendationInputWithoutAnalysis(diaryText: String): RecommendationInput =
+            RecommendationInput(
+                userId = USER_ID,
+                emotionRangeId = EMOTION_RANGE_ID,
+                emotionTags = listOf(tag(EMOTION_TAG_ID, TagType.EMOTION, "EMOTION_ANXIOUS")),
+                needTag = tag(NEED_TAG_ID, TagType.NEED, "NEED_COMFORT"),
+                feelingText = null,
+                diaryText = diaryText,
+                analysis = null,
             )
 
         fun candidate(

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchemaTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchemaTest.kt
@@ -22,14 +22,13 @@ class UserInputParseSchemaTest {
     }
 
     @Test
-    fun `schema는 tag type별 후보 배열을 최상위 필수로 둔다`() {
+    fun `schema는 canonicalIntent와 tag type별 후보 배열을 최상위 필수로 둔다`() {
         val schemaBody = userInputParseSchema(tagGroups)["schema"] as Map<*, *>
         val required = schemaBody["required"] as List<*>
 
         assertTrue(
             required.containsAll(
                 listOf(
-                    "intentType",
                     "canonicalIntent",
                     "emotionTagCandidates",
                     "needTagCandidates",
@@ -39,6 +38,7 @@ class UserInputParseSchemaTest {
                 ),
             ),
         )
+        assertFalse(required.contains("intentType"))
         assertFalse(required.contains("tagCandidates"))
         assertFalse(required.contains("quoteId"))
     }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchemaTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchemaTest.kt
@@ -53,6 +53,33 @@ class UserInputParseSchemaTest {
         assertTrue(schema.contains("NEED_CODE"))
     }
 
+    @Test
+    fun `emotion 후보 priority는 primary를 허용하지 않는다`() {
+        val priorityEnum = priorityEnumOf("emotionTagCandidates")
+
+        assertFalse(priorityEnum.contains("PRIMARY"))
+        assertTrue(priorityEnum.contains("SECONDARY"))
+        assertTrue(priorityEnum.contains("BACKGROUND"))
+    }
+
+    @Test
+    fun `need 후보 priority는 primary를 허용한다`() {
+        val priorityEnum = priorityEnumOf("needTagCandidates")
+
+        assertTrue(priorityEnum.contains("PRIMARY"))
+    }
+
+    private fun priorityEnumOf(fieldName: String): List<*> {
+        val schemaBody = userInputParseSchema(tagGroups)["schema"] as Map<*, *>
+        val properties = schemaBody["properties"] as Map<*, *>
+        val candidateSchema = properties[fieldName] as Map<*, *>
+        val itemSchema = candidateSchema["items"] as Map<*, *>
+        val itemProperties = itemSchema["properties"] as Map<*, *>
+        val prioritySchema = itemProperties["priority"] as Map<*, *>
+
+        return prioritySchema["enum"] as List<*>
+    }
+
     private companion object {
         val tagGroups: Map<TagType, List<TagOption>> =
             TagType.entries.associateWith { type ->


### PR DESCRIPTION
## 변경 내용

사용자 입력 LLM 분석 시, 선택된 needTag 여부를 명시적으로 전달하도록 수정했습니다.

* `hasSelectedNeedTag` 값을 LLM 요청 컨텍스트에 추가
* LLM이 needTag 선택 여부를 추론하지 않도록 변경
* 사용자가 선택한 감정 태그는 LLM 결과에서 `PRIMARY`로 내려오지 않도록 규칙 추가
* 선택 태그와 LLM 분석 태그의 역할을 더 명확히 분리

## 변경 이유

사용자가 직접 선택한 태그는 이미 확정된 입력이므로, LLM이 이를 다시 판단하거나 동일한 우선순위로 반환할 필요가 없습니다.

특히 needTag 선택 여부를 LLM이 문맥으로 추론하게 두면 결과가 불안정해질 수 있어, 서버에서 `hasSelectedNeedTag`를 명시적으로 전달하도록 했습니다.

또한 감정 태그는 사용자가 직접 선택한 값이 가장 우선되어야 하므로, LLM이 감정 태그를 반환하더라도 `PRIMARY`가 아닌 보조 태그로만 내려오도록 규칙을 추가했습니다.

## 기대 효과

* selected tag와 analyzed tag의 책임 분리
* LLM 분석 결과의 일관성 개선
* 사용자가 직접 선택한 감정/필요 태그의 우선순위 보장
* 중복 태그 및 과도한 primary 태그 반환 방지

## 테스트

* 사용자가 needTag를 선택한 경우 `hasSelectedNeedTag=true`로 전달되는지 확인
* 사용자가 needTag를 선택하지 않은 경우 `hasSelectedNeedTag=false`로 전달되는지 확인
* 선택된 감정 태그가 LLM 결과에서 `PRIMARY`로 반환되지 않는지 확인
* 기존 추천 플로우가 정상 동작하는지 확인
