### PR TITLE
feat: 발견탭 문장 검색 API 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
@@ -82,7 +82,7 @@ class DiscoveryController(
         @Parameter(hidden = true)
         @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
         @Parameter(description = "검색어. 문장 내용에서만 검색한다.", example = "투쟁")
-        @RequestParam query: String?,
+        @RequestParam(required = false) query: String?,
         @Parameter(
             description = "검색 정렬. 생략하면 최신순이다.",
             example = "latest",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
@@ -66,4 +66,62 @@ class DiscoveryController(
             cursor = cursor,
             genre = genre,
         )
+
+    @Operation(
+        summary = "발견탭 문장 검색 API",
+        description =
+            "추천 이력이 있는 문장을 문장 내용 기준으로 검색한다. " +
+                "검색어는 `quotes.content`에만 적용하고, 책 제목/저자/닉네임/감정 값은 검색하지 않는다. " +
+                "`sort`는 생략하면 최신순이며, `scrapCount`를 전달하면 스크랩 많은순으로 조회한다. " +
+                "`genre`는 생략하거나 `전체`이면 전체 장르를 조회한다. " +
+                "다음 페이지는 직전 응답의 `nextCursor` 값을 그대로 전달한다.",
+        security = [SecurityRequirement(name = "bearerAuth")],
+    )
+    @GetMapping("/quotes/search")
+    fun searchDiscoveryQuotes(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
+        @Parameter(description = "검색어. 문장 내용에서만 검색한다.", example = "투쟁")
+        @RequestParam query: String?,
+        @Parameter(
+            description = "검색 정렬. 생략하면 최신순이다.",
+            example = "latest",
+            schema = Schema(allowableValues = ["latest", "scrapCount"]),
+        )
+        @RequestParam(required = false) sort: String?,
+        @Parameter(
+            description =
+                "다음 페이지 조회 커서. 첫 페이지에서는 생략한다. " +
+                    "직전 응답의 `nextCursor` 값을 그대로 전달하며, sort가 바뀌면 재사용하지 않는다.",
+            example = "MjA5OS0wNi0wNVQxMjozNDo1NnwxMA",
+        )
+        @RequestParam(required = false) cursor: String?,
+        @Parameter(
+            description = "책 장르 필터. 생략하거나 `전체`이면 전체 장르를 조회한다.",
+            example = "한국소설",
+            schema =
+                Schema(
+                    allowableValues = [
+                        "전체",
+                        "한국소설",
+                        "일본소설",
+                        "영미소설",
+                        "판타지",
+                        "고전문학",
+                        "인문",
+                        "철학",
+                        "에세이•시",
+                        "영화•드라마 원작",
+                    ],
+                ),
+        )
+        @RequestParam(required = false) genre: String?,
+    ): DiscoveryQuotesResponse =
+        discoveryUseCase.searchDiscoveryQuotes(
+            userId = authenticatedUser.id,
+            query = query,
+            sort = sort,
+            cursor = cursor,
+            genre = genre,
+        )
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
@@ -1,6 +1,7 @@
 package com.firstpenguin.app.domain.discovery.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.firstpenguin.app.domain.discovery.model.DiscoveryNeedTag
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
@@ -23,6 +24,8 @@ data class DiscoveryQuoteResponse(
     val bookCoverImageUrl: String,
     @field:Schema(description = "책 장르", example = "한국소설", nullable = true)
     val genre: String?,
+    @field:Schema(description = "추천 당시 선택한 NEED 태그. 선택 태그가 없으면 null", nullable = true)
+    val needTag: DiscoveryNeedTagResponse?,
     @field:Schema(description = "문장이 추천 이력에 등록된 시각", example = "2026-06-05T12:34:56")
     val recommendedAt: LocalDateTime,
     @get:JsonProperty("isScrapped")
@@ -40,8 +43,25 @@ data class DiscoveryQuoteResponse(
                 author = quote.author,
                 bookCoverImageUrl = quote.bookCoverImageUrl,
                 genre = quote.genre,
+                needTag = quote.needTag?.let(DiscoveryNeedTagResponse::from),
                 recommendedAt = quote.recommendedAt,
                 isScrapped = quote.isScrapped,
+            )
+    }
+}
+
+@Schema(description = "추천 당시 선택한 NEED 태그 응답")
+data class DiscoveryNeedTagResponse(
+    @field:Schema(description = "NEED 태그 ID", example = "49")
+    val id: Long,
+    @field:Schema(description = "NEED 태그 라벨", example = "공감해주는 문장")
+    val label: String,
+) {
+    companion object {
+        fun from(needTag: DiscoveryNeedTag): DiscoveryNeedTagResponse =
+            DiscoveryNeedTagResponse(
+                id = needTag.id,
+                label = needTag.label,
             )
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
@@ -11,6 +11,13 @@ data class DiscoveryQuote(
     val author: String,
     val bookCoverImageUrl: String,
     val genre: String?,
+    val needTag: DiscoveryNeedTag?,
     val recommendedAt: LocalDateTime,
     val isScrapped: Boolean,
+    val scrapCount: Int,
+)
+
+data class DiscoveryNeedTag(
+    val id: Long,
+    val label: String,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuoteSearchCriteria.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuoteSearchCriteria.kt
@@ -1,0 +1,10 @@
+package com.firstpenguin.app.domain.discovery.model
+
+data class DiscoveryQuoteSearchCriteria(
+    val userId: Long,
+    val query: String,
+    val sort: DiscoveryQuoteSearchSort,
+    val cursor: DiscoveryQuoteSearchCursor?,
+    val genre: DiscoveryGenre?,
+    val limit: Int,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuoteSearchCursor.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuoteSearchCursor.kt
@@ -1,0 +1,112 @@
+package com.firstpenguin.app.domain.discovery.model
+
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Base64
+
+data class DiscoveryQuoteSearchCursor(
+    val recommendedAt: LocalDateTime,
+    val quoteId: Long,
+    val scrapCount: Int?,
+) {
+    fun encode(sort: DiscoveryQuoteSearchSort): String {
+        val rawCursor = rawCursor(sort)
+
+        return encoder.encodeToString(rawCursor.toByteArray(Charsets.UTF_8))
+    }
+
+    private fun rawCursor(sort: DiscoveryQuoteSearchSort): String =
+        when (sort) {
+            DiscoveryQuoteSearchSort.LATEST -> latestCursorParts().joinToString(DELIMITER)
+            DiscoveryQuoteSearchSort.SCRAP_COUNT -> scrapCountCursorParts().joinToString(DELIMITER)
+        }
+
+    private fun latestCursorParts(): List<Any> =
+        listOf(
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(recommendedAt),
+            quoteId,
+        )
+
+    private fun scrapCountCursorParts(): List<Any> =
+        listOf(
+            requireNotNull(scrapCount),
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(recommendedAt),
+            quoteId,
+        )
+
+    companion object {
+        fun from(
+            quote: DiscoveryQuote,
+            sort: DiscoveryQuoteSearchSort,
+        ): DiscoveryQuoteSearchCursor =
+            DiscoveryQuoteSearchCursor(
+                recommendedAt = quote.recommendedAt,
+                quoteId = quote.quoteId,
+                scrapCount = quote.scrapCount.takeIf { sort == DiscoveryQuoteSearchSort.SCRAP_COUNT },
+            )
+
+        fun parse(
+            cursor: String?,
+            sort: DiscoveryQuoteSearchSort,
+        ): DiscoveryQuoteSearchCursor? {
+            if (cursor.isNullOrBlank()) return null
+
+            return runCatching { decode(cursor, sort) }
+                .getOrElse { throw CustomException(ErrorCode.INVALID_INPUT) }
+        }
+
+        private fun decode(
+            cursor: String,
+            sort: DiscoveryQuoteSearchSort,
+        ): DiscoveryQuoteSearchCursor {
+            val parts = String(decoder.decode(cursor), Charsets.UTF_8).split(DELIMITER)
+            return when (sort) {
+                DiscoveryQuoteSearchSort.LATEST -> decodeLatest(parts)
+                DiscoveryQuoteSearchSort.SCRAP_COUNT -> decodeScrapCount(parts)
+            }
+        }
+
+        private fun decodeLatest(parts: List<String>): DiscoveryQuoteSearchCursor {
+            if (parts.size != LATEST_CURSOR_PART_COUNT) {
+                throw IllegalArgumentException("Invalid latest search cursor format")
+            }
+
+            return DiscoveryQuoteSearchCursor(
+                recommendedAt = parseAt(parts[LATEST_RECOMMENDED_AT_INDEX]),
+                quoteId = parts[LATEST_QUOTE_ID_INDEX].toLong(),
+                scrapCount = null,
+            )
+        }
+
+        private fun decodeScrapCount(parts: List<String>): DiscoveryQuoteSearchCursor {
+            if (parts.size != SCRAP_COUNT_CURSOR_PART_COUNT) {
+                throw IllegalArgumentException("Invalid scrap count search cursor format")
+            }
+
+            return DiscoveryQuoteSearchCursor(
+                scrapCount = parts[SCRAP_COUNT_INDEX].toInt(),
+                recommendedAt = parseAt(parts[SCRAP_COUNT_RECOMMENDED_AT_INDEX]),
+                quoteId = parts[SCRAP_COUNT_QUOTE_ID_INDEX].toLong(),
+            )
+        }
+
+        private fun parseAt(value: String): LocalDateTime {
+            val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+            return LocalDateTime.parse(value, formatter)
+        }
+
+        private const val DELIMITER = "|"
+        private const val LATEST_CURSOR_PART_COUNT = 2
+        private const val SCRAP_COUNT_CURSOR_PART_COUNT = 3
+        private const val LATEST_RECOMMENDED_AT_INDEX = 0
+        private const val LATEST_QUOTE_ID_INDEX = 1
+        private const val SCRAP_COUNT_INDEX = 0
+        private const val SCRAP_COUNT_RECOMMENDED_AT_INDEX = 1
+        private const val SCRAP_COUNT_QUOTE_ID_INDEX = 2
+
+        private val encoder = Base64.getUrlEncoder().withoutPadding()
+        private val decoder = Base64.getUrlDecoder()
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuoteSearchSort.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuoteSearchSort.kt
@@ -1,0 +1,22 @@
+package com.firstpenguin.app.domain.discovery.model
+
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+
+enum class DiscoveryQuoteSearchSort(
+    val value: String,
+) {
+    LATEST("latest"),
+    SCRAP_COUNT("scrapCount"),
+    ;
+
+    companion object {
+        fun parse(sort: String?): DiscoveryQuoteSearchSort {
+            val normalizedSort = sort?.trim()
+            if (normalizedSort.isNullOrBlank()) return LATEST
+
+            return entries.find { entry -> entry.value == normalizedSort }
+                ?: throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
@@ -3,21 +3,29 @@ package com.firstpenguin.app.domain.discovery.repository
 import com.firstpenguin.app.domain.book.repository.BookTable
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
+import com.firstpenguin.app.domain.discovery.model.DiscoveryNeedTag
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
+import com.firstpenguin.app.domain.emotion.repository.table.TagTable
 import com.firstpenguin.app.domain.quote.repository.QuoteScrapTable
 import com.firstpenguin.app.domain.quote.repository.QuoteTable
 import com.firstpenguin.app.domain.recommendation.repository.table.RecommendationQuoteTable
 import com.firstpenguin.app.domain.recommendation.repository.table.RecommendationTable
+import com.firstpenguin.app.domain.recommendation.repository.table.RecommendationTagTable
+import com.firstpenguin.app.global.enums.TagType
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
+import org.jooq.SortField
 import org.jooq.Table
 import org.jooq.impl.DSL
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
 @Repository
+@Suppress("TooManyFunctions")
 class DiscoveryRepository(
     private val dsl: DSLContext,
 ) {
@@ -31,36 +39,89 @@ class DiscoveryRepository(
 
         val recommendationEvents = recommendationEvents()
         val rankedRecommendationEvents = rankedRecommendationEvents(recommendationEvents)
-        val recommendedQuoteId = recommendedQuoteId(rankedRecommendationEvents)
+        val needTags = recommendationNeedTags()
+        val scrapCount = DSL.inline(0).`as`(SCRAP_COUNT)
 
-        return dsl
-            .select(discoveryQuoteFields(rankedRecommendationEvents))
-            .from(rankedRecommendationEvents)
-            .join(QuoteTable.QUOTES)
-            .on(QuoteTable.ID.eq(recommendedQuoteId))
-            .join(BookTable.BOOKS)
-            .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
-            .leftJoin(QuoteScrapTable.QUOTE_SCRAPS)
-            .on(QuoteScrapTable.QUOTE_ID.eq(QuoteTable.ID))
-            .and(QuoteScrapTable.USER_ID.eq(userId))
+        return baseDiscoveryQuery(userId, rankedRecommendationEvents, needTags, scrapCount)
             .where(latestRecommendedQuoteCondition(rankedRecommendationEvents, cursor))
-            .and(QuoteTable.DELETED_AT.isNull)
-            .and(BookTable.DELETED_AT.isNull)
-            .and(genre?.let { selectedGenre -> BookTable.CATEGORY.eq(selectedGenre.value) } ?: DSL.noCondition())
-            .orderBy(at(rankedRecommendationEvents).desc(), QuoteTable.ID.desc())
+            .and(activeQuoteCondition(genre))
+            .orderBy(latestOrderBy(rankedRecommendationEvents))
             .limit(limit)
             .fetch(::toDiscoveryQuote)
     }
+
+    fun searchRecommendedQuotes(
+        userId: Long,
+        query: String,
+        sort: DiscoveryQuoteSearchSort,
+        cursor: DiscoveryQuoteSearchCursor?,
+        genre: DiscoveryGenre?,
+        limit: Int,
+    ): List<DiscoveryQuote> {
+        if (limit <= 0) return emptyList()
+
+        val recommendationEvents = recommendationEvents()
+        val rankedRecommendationEvents = rankedRecommendationEvents(recommendationEvents)
+        val needTags = recommendationNeedTags()
+        val quoteScrapCounts = quoteScrapCounts()
+        val scrapCount = scrapCount(quoteScrapCounts)
+
+        return baseDiscoverySearchQuery(userId, rankedRecommendationEvents, needTags, quoteScrapCounts, scrapCount)
+            .where(latestRecommendationRankCondition(rankedRecommendationEvents))
+            .and(activeQuoteCondition(genre))
+            .and(QuoteTable.CONTENT.containsIgnoreCase(query))
+            .and(searchCursorCondition(sort, rankedRecommendationEvents, scrapCount, cursor))
+            .orderBy(searchOrderBy(sort, rankedRecommendationEvents, scrapCount))
+            .limit(limit)
+            .fetch(::toDiscoveryQuote)
+    }
+
+    private fun baseDiscoveryQuery(
+        userId: Long,
+        rankedRecommendationEvents: Table<*>,
+        needTags: Table<*>,
+        scrapCount: Field<Int>,
+    ) = dsl
+        .select(discoveryQuoteFields(rankedRecommendationEvents, needTags, scrapCount))
+        .from(rankedRecommendationEvents)
+        .join(QuoteTable.QUOTES)
+        .on(QuoteTable.ID.eq(recommendedQuoteId(rankedRecommendationEvents)))
+        .join(BookTable.BOOKS)
+        .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+        .leftJoin(QuoteScrapTable.QUOTE_SCRAPS)
+        .on(QuoteScrapTable.QUOTE_ID.eq(QuoteTable.ID))
+        .and(QuoteScrapTable.USER_ID.eq(userId))
+        .leftJoin(needTags)
+        .on(needTagRecommendationId(needTags).eq(recommendationId(rankedRecommendationEvents)))
+
+    private fun baseDiscoverySearchQuery(
+        userId: Long,
+        rankedRecommendationEvents: Table<*>,
+        needTags: Table<*>,
+        quoteScrapCounts: Table<*>,
+        scrapCount: Field<Int>,
+    ) = baseDiscoveryQuery(userId, rankedRecommendationEvents, needTags, scrapCount)
+        .leftJoin(quoteScrapCounts)
+        .on(scrapCountQuoteId(quoteScrapCounts).eq(QuoteTable.ID))
 
     private fun latestRecommendedQuoteCondition(
         rankedRecommendationEvents: Table<*>,
         cursor: DiscoveryCursor?,
     ): Condition {
-        val latestCondition = recommendationRank(rankedRecommendationEvents).eq(LATEST_RECOMMENDATION_RANK)
+        val latestCondition = latestRecommendationRankCondition(rankedRecommendationEvents)
         if (cursor == null) return latestCondition
 
         return latestCondition.and(cursorCondition(rankedRecommendationEvents, cursor))
     }
+
+    private fun latestRecommendationRankCondition(rankedRecommendationEvents: Table<*>): Condition =
+        recommendationRank(rankedRecommendationEvents).eq(LATEST_RECOMMENDATION_RANK)
+
+    private fun activeQuoteCondition(genre: DiscoveryGenre?): Condition =
+        QuoteTable.DELETED_AT
+            .isNull
+            .and(BookTable.DELETED_AT.isNull)
+            .and(genre?.let { selectedGenre -> BookTable.CATEGORY.eq(selectedGenre.value) } ?: DSL.noCondition())
 
     private fun cursorCondition(
         rankedRecommendationEvents: Table<*>,
@@ -69,6 +130,82 @@ class DiscoveryRepository(
         at(rankedRecommendationEvents)
             .lt(cursor.recommendedAt)
             .or(at(rankedRecommendationEvents).eq(cursor.recommendedAt).and(QuoteTable.ID.lt(cursor.quoteId)))
+
+    private fun searchCursorCondition(
+        sort: DiscoveryQuoteSearchSort,
+        rankedRecommendationEvents: Table<*>,
+        scrapCount: Field<Int>,
+        cursor: DiscoveryQuoteSearchCursor?,
+    ): Condition {
+        if (cursor == null) return DSL.noCondition()
+
+        return when (sort) {
+            DiscoveryQuoteSearchSort.LATEST -> {
+                latestSearchCursorCondition(rankedRecommendationEvents, cursor)
+            }
+
+            DiscoveryQuoteSearchSort.SCRAP_COUNT -> {
+                scrapCountCursorCondition(
+                    rankedRecommendationEvents,
+                    scrapCount,
+                    cursor,
+                )
+            }
+        }
+    }
+
+    private fun latestSearchCursorCondition(
+        rankedRecommendationEvents: Table<*>,
+        cursor: DiscoveryQuoteSearchCursor,
+    ): Condition =
+        cursorCondition(
+            rankedRecommendationEvents = rankedRecommendationEvents,
+            cursor = DiscoveryCursor(cursor.recommendedAt, cursor.quoteId),
+        )
+
+    private fun scrapCountCursorCondition(
+        rankedRecommendationEvents: Table<*>,
+        scrapCount: Field<Int>,
+        cursor: DiscoveryQuoteSearchCursor,
+    ): Condition =
+        scrapCount
+            .lt(requireNotNull(cursor.scrapCount))
+            .or(
+                scrapCount
+                    .eq(cursor.scrapCount)
+                    .and(scrapCountTieBreakerCondition(rankedRecommendationEvents, cursor)),
+            )
+
+    private fun scrapCountTieBreakerCondition(
+        rankedRecommendationEvents: Table<*>,
+        cursor: DiscoveryQuoteSearchCursor,
+    ): Condition =
+        at(rankedRecommendationEvents)
+            .lt(cursor.recommendedAt)
+            .or(at(rankedRecommendationEvents).eq(cursor.recommendedAt).and(QuoteTable.ID.lt(cursor.quoteId)))
+
+    private fun latestOrderBy(rankedRecommendationEvents: Table<*>): List<SortField<*>> =
+        listOf(at(rankedRecommendationEvents).desc(), QuoteTable.ID.desc())
+
+    private fun searchOrderBy(
+        sort: DiscoveryQuoteSearchSort,
+        rankedRecommendationEvents: Table<*>,
+        scrapCount: Field<Int>,
+    ): List<SortField<*>> =
+        when (sort) {
+            DiscoveryQuoteSearchSort.LATEST -> latestOrderBy(rankedRecommendationEvents)
+            DiscoveryQuoteSearchSort.SCRAP_COUNT -> scrapCountOrderBy(rankedRecommendationEvents, scrapCount)
+        }
+
+    private fun scrapCountOrderBy(
+        rankedRecommendationEvents: Table<*>,
+        scrapCount: Field<Int>,
+    ): List<SortField<*>> =
+        listOf(
+            scrapCount.desc(),
+            at(rankedRecommendationEvents).desc(),
+            QuoteTable.ID.desc(),
+        )
 
     private fun toDiscoveryQuote(record: Record): DiscoveryQuote =
         DiscoveryQuote(
@@ -80,13 +217,24 @@ class DiscoveryRepository(
             author = record.get(BookTable.AUTHOR),
             bookCoverImageUrl = record.get(BookTable.COVER_IMAGE_URL),
             genre = record.get(BookTable.CATEGORY),
+            needTag = toNeedTag(record),
             recommendedAt = record.get(RECOMMENDED_AT_FIELD),
             isScrapped = record.get(IS_SCRAPPED_FIELD),
+            scrapCount = record.get(SCRAP_COUNT_FIELD),
         )
+
+    private fun toNeedTag(record: Record): DiscoveryNeedTag? =
+        record.get(NEED_TAG_ID_FIELD)?.let { needTagId ->
+            DiscoveryNeedTag(
+                id = needTagId,
+                label = record.get(NEED_TAG_LABEL_FIELD),
+            )
+        }
 
     private fun recommendationEvents(): Table<*> =
         DSL
             .select(
+                RecommendationTable.ID.`as`(RECOMMENDATION_ID),
                 RecommendationTable.QUOTE_ID.`as`(RECOMMENDED_QUOTE_ID),
                 RecommendationTable.USER_ID.`as`(RECOMMENDED_USER_ID),
                 RecommendationTable.CREATED_AT.`as`(RECOMMENDED_AT),
@@ -94,6 +242,7 @@ class DiscoveryRepository(
             .unionAll(
                 DSL
                     .select(
+                        RecommendationQuoteTable.RECOMMENDATION_ID.`as`(RECOMMENDATION_ID),
                         RecommendationQuoteTable.QUOTE_ID.`as`(RECOMMENDED_QUOTE_ID),
                         RecommendationTable.USER_ID.`as`(RECOMMENDED_USER_ID),
                         RecommendationQuoteTable.CREATED_AT.`as`(RECOMMENDED_AT),
@@ -105,6 +254,7 @@ class DiscoveryRepository(
     private fun rankedRecommendationEvents(recommendationEvents: Table<*>): Table<*> =
         DSL
             .select(
+                recommendationId(recommendationEvents),
                 recommendedQuoteId(recommendationEvents),
                 recommendedUserId(recommendationEvents),
                 at(recommendationEvents),
@@ -117,7 +267,32 @@ class DiscoveryRepository(
             ).from(recommendationEvents)
             .asTable(RANKED_RECOMMENDATION_EVENTS)
 
-    private fun discoveryQuoteFields(rankedRecommendationEvents: Table<*>): List<Field<*>> =
+    private fun recommendationNeedTags(): Table<*> =
+        DSL
+            .select(
+                RecommendationTagTable.RECOMMENDATION_ID.`as`(NEED_TAG_RECOMMENDATION_ID),
+                TagTable.ID.`as`(NEED_TAG_ID),
+                TagTable.LABEL.`as`(NEED_TAG_LABEL),
+            ).from(RecommendationTagTable.RECOMMENDATION_TAGS)
+            .join(TagTable.TAGS)
+            .on(TagTable.ID.eq(RecommendationTagTable.TAG_ID))
+            .where(TagTable.TYPE.eq(TagType.NEED.name))
+            .asTable(RECOMMENDATION_NEED_TAGS)
+
+    private fun quoteScrapCounts(): Table<*> =
+        DSL
+            .select(
+                QuoteScrapTable.QUOTE_ID.`as`(SCRAP_COUNT_QUOTE_ID),
+                DSL.count(QuoteScrapTable.ID).`as`(SCRAP_COUNT),
+            ).from(QuoteScrapTable.QUOTE_SCRAPS)
+            .groupBy(QuoteScrapTable.QUOTE_ID)
+            .asTable(QUOTE_SCRAP_COUNTS)
+
+    private fun discoveryQuoteFields(
+        rankedRecommendationEvents: Table<*>,
+        needTags: Table<*>,
+        scrapCount: Field<Int>,
+    ): List<Field<*>> =
         listOf(
             QuoteTable.ID,
             BookTable.ID,
@@ -127,9 +302,14 @@ class DiscoveryRepository(
             BookTable.AUTHOR,
             BookTable.COVER_IMAGE_URL,
             BookTable.CATEGORY,
+            needTagId(needTags),
+            needTagLabel(needTags),
             at(rankedRecommendationEvents),
             IS_SCRAPPED_FIELD,
+            scrapCount,
         )
+
+    private fun recommendationId(table: Table<*>): Field<Long> = table.field(RECOMMENDATION_ID, Long::class.java)!!
 
     private fun recommendedQuoteId(table: Table<*>): Field<Long> = table.field(RECOMMENDED_QUOTE_ID, Long::class.java)!!
 
@@ -139,17 +319,44 @@ class DiscoveryRepository(
 
     private fun recommendationRank(table: Table<*>): Field<Int> = table.field(RECOMMENDATION_RANK, Int::class.java)!!
 
+    private fun needTagRecommendationId(table: Table<*>): Field<Long> {
+        val fieldName = NEED_TAG_RECOMMENDATION_ID
+        return table.field(fieldName, Long::class.java)!!
+    }
+
+    private fun needTagId(table: Table<*>): Field<Long> = table.field(NEED_TAG_ID, Long::class.java)!!
+
+    private fun needTagLabel(table: Table<*>): Field<String> = table.field(NEED_TAG_LABEL, String::class.java)!!
+
+    private fun scrapCountQuoteId(table: Table<*>): Field<Long> = table.field(SCRAP_COUNT_QUOTE_ID, Long::class.java)!!
+
+    private fun scrapCount(table: Table<*>): Field<Int> {
+        val count = table.field(SCRAP_COUNT, Int::class.java)
+        return DSL.coalesce(count, 0).`as`(SCRAP_COUNT)
+    }
+
     private companion object {
         const val RECOMMENDATION_EVENTS = "recommendation_events"
         const val RANKED_RECOMMENDATION_EVENTS = "ranked_recommendation_events"
+        const val RECOMMENDATION_NEED_TAGS = "recommendation_need_tags"
+        const val QUOTE_SCRAP_COUNTS = "quote_scrap_counts"
+        const val RECOMMENDATION_ID = "recommendation_id"
         const val RECOMMENDED_QUOTE_ID = "quote_id"
         const val RECOMMENDED_USER_ID = "recommended_user_id"
         const val RECOMMENDED_AT = "recommended_at"
         const val RECOMMENDATION_RANK = "recommendation_rank"
+        const val NEED_TAG_RECOMMENDATION_ID = "need_tag_recommendation_id"
+        const val NEED_TAG_ID = "need_tag_id"
+        const val NEED_TAG_LABEL = "need_tag_label"
+        const val SCRAP_COUNT_QUOTE_ID = "scrap_count_quote_id"
+        const val SCRAP_COUNT = "scrap_count"
         const val LATEST_RECOMMENDATION_RANK = 1
 
         val RECOMMENDED_USER_ID_FIELD: Field<Long> = DSL.field(RECOMMENDED_USER_ID, Long::class.java)
         val RECOMMENDED_AT_FIELD: Field<LocalDateTime> = DSL.field(RECOMMENDED_AT, LocalDateTime::class.java)
+        val NEED_TAG_ID_FIELD: Field<Long> = DSL.field(NEED_TAG_ID, Long::class.java)
+        val NEED_TAG_LABEL_FIELD: Field<String> = DSL.field(NEED_TAG_LABEL, String::class.java)
         val IS_SCRAPPED_FIELD: Field<Boolean> = QuoteScrapTable.ID.isNotNull.`as`("is_scrapped")
+        val SCRAP_COUNT_FIELD: Field<Int> = DSL.field(SCRAP_COUNT, Int::class.java)
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
@@ -5,6 +5,7 @@ import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryNeedTag
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCriteria
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
 import com.firstpenguin.app.domain.emotion.repository.table.TagTable
@@ -50,15 +51,8 @@ class DiscoveryRepository(
             .fetch(::toDiscoveryQuote)
     }
 
-    fun searchRecommendedQuotes(
-        userId: Long,
-        query: String,
-        sort: DiscoveryQuoteSearchSort,
-        cursor: DiscoveryQuoteSearchCursor?,
-        genre: DiscoveryGenre?,
-        limit: Int,
-    ): List<DiscoveryQuote> {
-        if (limit <= 0) return emptyList()
+    fun searchRecommendedQuotes(criteria: DiscoveryQuoteSearchCriteria): List<DiscoveryQuote> {
+        if (criteria.limit <= 0) return emptyList()
 
         val recommendationEvents = recommendationEvents()
         val rankedRecommendationEvents = rankedRecommendationEvents(recommendationEvents)
@@ -66,13 +60,18 @@ class DiscoveryRepository(
         val quoteScrapCounts = quoteScrapCounts()
         val scrapCount = scrapCount(quoteScrapCounts)
 
-        return baseDiscoverySearchQuery(userId, rankedRecommendationEvents, needTags, quoteScrapCounts, scrapCount)
-            .where(latestRecommendationRankCondition(rankedRecommendationEvents))
-            .and(activeQuoteCondition(genre))
-            .and(QuoteTable.CONTENT.containsIgnoreCase(query))
-            .and(searchCursorCondition(sort, rankedRecommendationEvents, scrapCount, cursor))
-            .orderBy(searchOrderBy(sort, rankedRecommendationEvents, scrapCount))
-            .limit(limit)
+        return baseDiscoverySearchQuery(
+            criteria.userId,
+            rankedRecommendationEvents,
+            needTags,
+            quoteScrapCounts,
+            scrapCount,
+        ).where(latestRecommendationRankCondition(rankedRecommendationEvents))
+            .and(activeQuoteCondition(criteria.genre))
+            .and(searchContentCondition(criteria.query))
+            .and(searchCursorCondition(criteria.sort, rankedRecommendationEvents, scrapCount, criteria.cursor))
+            .orderBy(searchOrderBy(criteria.sort, rankedRecommendationEvents, scrapCount))
+            .limit(criteria.limit)
             .fetch(::toDiscoveryQuote)
     }
 
@@ -122,6 +121,13 @@ class DiscoveryRepository(
             .isNull
             .and(BookTable.DELETED_AT.isNull)
             .and(genre?.let { selectedGenre -> BookTable.CATEGORY.eq(selectedGenre.value) } ?: DSL.noCondition())
+
+    private fun searchContentCondition(query: String): Condition =
+        DSL.condition(
+            "{0} ilike {1}",
+            QuoteTable.CONTENT,
+            DSL.value("%$query%"),
+        )
 
     private fun cursorCondition(
         rankedRecommendationEvents: Table<*>,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
@@ -124,10 +124,16 @@ class DiscoveryRepository(
 
     private fun searchContentCondition(query: String): Condition =
         DSL.condition(
-            "{0} ilike {1}",
+            "{0} ilike {1} escape '!'",
             QuoteTable.CONTENT,
-            DSL.value("%$query%"),
+            DSL.value("%${escapeLikePattern(query)}%"),
         )
+
+    private fun escapeLikePattern(query: String): String =
+        query
+            .replace(LIKE_ESCAPE, "$LIKE_ESCAPE$LIKE_ESCAPE")
+            .replace("%", "$LIKE_ESCAPE%")
+            .replace("_", "${LIKE_ESCAPE}_")
 
     private fun cursorCondition(
         rankedRecommendationEvents: Table<*>,
@@ -356,6 +362,7 @@ class DiscoveryRepository(
         const val NEED_TAG_LABEL = "need_tag_label"
         const val SCRAP_COUNT_QUOTE_ID = "scrap_count_quote_id"
         const val SCRAP_COUNT = "scrap_count"
+        const val LIKE_ESCAPE = "!"
         const val LATEST_RECOMMENDATION_RANK = 1
 
         val RECOMMENDED_USER_ID_FIELD: Field<Long> = DSL.field(RECOMMENDED_USER_ID, Long::class.java)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/service/DiscoveryService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/service/DiscoveryService.kt
@@ -3,8 +3,7 @@ package com.firstpenguin.app.domain.discovery.service
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
-import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
-import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCriteria
 import com.firstpenguin.app.domain.discovery.repository.DiscoveryRepository
 import org.springframework.stereotype.Service
 
@@ -25,20 +24,6 @@ class DiscoveryService(
             limit = limit,
         )
 
-    fun searchRecommendedQuotes(
-        userId: Long,
-        query: String,
-        sort: DiscoveryQuoteSearchSort,
-        cursor: DiscoveryQuoteSearchCursor?,
-        genre: DiscoveryGenre?,
-        limit: Int,
-    ): List<DiscoveryQuote> =
-        discoveryRepository.searchRecommendedQuotes(
-            userId = userId,
-            query = query,
-            sort = sort,
-            cursor = cursor,
-            genre = genre,
-            limit = limit,
-        )
+    fun searchRecommendedQuotes(criteria: DiscoveryQuoteSearchCriteria): List<DiscoveryQuote> =
+        discoveryRepository.searchRecommendedQuotes(criteria)
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/service/DiscoveryService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/service/DiscoveryService.kt
@@ -3,6 +3,8 @@ package com.firstpenguin.app.domain.discovery.service
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
 import com.firstpenguin.app.domain.discovery.repository.DiscoveryRepository
 import org.springframework.stereotype.Service
 
@@ -18,6 +20,23 @@ class DiscoveryService(
     ): List<DiscoveryQuote> =
         discoveryRepository.findRecommendedQuotes(
             userId = userId,
+            cursor = cursor,
+            genre = genre,
+            limit = limit,
+        )
+
+    fun searchRecommendedQuotes(
+        userId: Long,
+        query: String,
+        sort: DiscoveryQuoteSearchSort,
+        cursor: DiscoveryQuoteSearchCursor?,
+        genre: DiscoveryGenre?,
+        limit: Int,
+    ): List<DiscoveryQuote> =
+        discoveryRepository.searchRecommendedQuotes(
+            userId = userId,
+            query = query,
+            sort = sort,
             cursor = cursor,
             genre = genre,
             limit = limit,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCase.kt
@@ -5,7 +5,11 @@ import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuotesResponse
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
 import com.firstpenguin.app.domain.discovery.service.DiscoveryService
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -23,7 +27,24 @@ class DiscoveryUseCase(
         genre: String?,
     ): DiscoveryQuotesResponse {
         val quotes = fetchQuotesWithNextPageCheck(userId, cursor, genre)
-        return toDiscoveryQuotesResponse(quotes)
+        return toDiscoveryQuotesResponse(quotes) { quote -> DiscoveryCursor.from(quote).encode() }
+    }
+
+    @Transactional(readOnly = true)
+    fun searchDiscoveryQuotes(
+        userId: Long,
+        query: String?,
+        sort: String?,
+        cursor: String?,
+        genre: String?,
+    ): DiscoveryQuotesResponse {
+        val searchSort = DiscoveryQuoteSearchSort.parse(sort)
+        val quotes = fetchSearchQuotesWithNextPageCheck(userId, query, searchSort, cursor, genre)
+        return toDiscoveryQuotesResponse(quotes) { quote ->
+            DiscoveryQuoteSearchCursor
+                .from(quote, searchSort)
+                .encode(searchSort)
+        }
     }
 
     private fun fetchQuotesWithNextPageCheck(
@@ -38,11 +59,34 @@ class DiscoveryUseCase(
             limit = DISCOVERY_QUOTE_COUNT + NEXT_PAGE_CHECK_COUNT,
         )
 
-    private fun toDiscoveryQuotesResponse(quotes: List<DiscoveryQuote>): DiscoveryQuotesResponse {
+    private fun fetchSearchQuotesWithNextPageCheck(
+        userId: Long,
+        query: String?,
+        sort: DiscoveryQuoteSearchSort,
+        cursor: String?,
+        genre: String?,
+    ): List<DiscoveryQuote> =
+        discoveryService.searchRecommendedQuotes(
+            userId = userId,
+            query = normalizeQuery(query),
+            sort = sort,
+            cursor = DiscoveryQuoteSearchCursor.parse(cursor, sort),
+            genre = DiscoveryGenre.parse(genre),
+            limit = DISCOVERY_QUOTE_COUNT + NEXT_PAGE_CHECK_COUNT,
+        )
+
+    private fun normalizeQuery(query: String?): String =
+        query?.trim()?.takeIf { text -> text.isNotBlank() }
+            ?: throw CustomException(ErrorCode.INVALID_INPUT)
+
+    private fun toDiscoveryQuotesResponse(
+        quotes: List<DiscoveryQuote>,
+        cursorEncoder: (DiscoveryQuote) -> String,
+    ): DiscoveryQuotesResponse {
         val pageQuotes = quotes.take(DISCOVERY_QUOTE_COUNT)
         return DiscoveryQuotesResponse(
             quotes = pageQuotes.map(DiscoveryQuoteResponse::from),
-            nextCursor = nextCursor(pageQuotes, quotes),
+            nextCursor = nextCursor(pageQuotes, quotes, cursorEncoder),
             hasNext = quotes.size > DISCOVERY_QUOTE_COUNT,
         )
     }
@@ -50,9 +94,10 @@ class DiscoveryUseCase(
     private fun nextCursor(
         pageQuotes: List<DiscoveryQuote>,
         quotes: List<DiscoveryQuote>,
+        cursorEncoder: (DiscoveryQuote) -> String,
     ): String? {
         if (quotes.size <= DISCOVERY_QUOTE_COUNT) return null
 
-        return pageQuotes.lastOrNull()?.let { quote -> DiscoveryCursor.from(quote).encode() }
+        return pageQuotes.lastOrNull()?.let(cursorEncoder)
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCase.kt
@@ -5,6 +5,7 @@ import com.firstpenguin.app.domain.discovery.dto.DiscoveryQuotesResponse
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCriteria
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
 import com.firstpenguin.app.domain.discovery.service.DiscoveryService
@@ -67,12 +68,14 @@ class DiscoveryUseCase(
         genre: String?,
     ): List<DiscoveryQuote> =
         discoveryService.searchRecommendedQuotes(
-            userId = userId,
-            query = normalizeQuery(query),
-            sort = sort,
-            cursor = DiscoveryQuoteSearchCursor.parse(cursor, sort),
-            genre = DiscoveryGenre.parse(genre),
-            limit = DISCOVERY_QUOTE_COUNT + NEXT_PAGE_CHECK_COUNT,
+            DiscoveryQuoteSearchCriteria(
+                userId = userId,
+                query = normalizeQuery(query),
+                sort = sort,
+                cursor = DiscoveryQuoteSearchCursor.parse(cursor, sort),
+                genre = DiscoveryGenre.parse(genre),
+                limit = DISCOVERY_QUOTE_COUNT + NEXT_PAGE_CHECK_COUNT,
+            ),
         )
 
     private fun normalizeQuery(query: String?): String =

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
@@ -106,6 +106,7 @@ class DiscoveryRepositoryTest {
         val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
 
         assertTrue(normalizedSql.contains("\"quotes\".\"content\" ilike"), normalizedSql)
+        assertTrue(normalizedSql.contains("escape '!'"), normalizedSql)
         assertFalse(normalizedSql.contains("\"books\".\"title\" ilike"), normalizedSql)
         assertFalse(normalizedSql.contains("\"books\".\"author\" ilike"), normalizedSql)
         assertFalse(normalizedSql.contains("\"users\".\"nickname\" ilike"), normalizedSql)
@@ -115,6 +116,21 @@ class DiscoveryRepositoryTest {
             ),
             normalizedSql,
         )
+    }
+
+    @Test
+    fun `검색어 메타문자는 LIKE 패턴에서 이스케이프한다`() {
+        val capturedQuery =
+            captureQuery { dsl ->
+                DiscoveryRepository(dsl).searchRecommendedQuotes(
+                    searchCriteria(query = SEARCH_META_QUERY),
+                )
+            }
+        val normalizedSql = capturedQuery.sql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("\"quotes\".\"content\" ilike"), normalizedSql)
+        assertTrue(normalizedSql.contains("escape '!'"), normalizedSql)
+        assertTrue(capturedQuery.bindings.contains(ESCAPED_SEARCH_META_QUERY), capturedQuery.bindings.toString())
     }
 
     @Test
@@ -155,40 +171,52 @@ class DiscoveryRepositoryTest {
         assertTrue(normalizedSql.contains("\"quotes\".\"id\" < ?"), normalizedSql)
     }
 
-    private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {
+    private fun captureSql(repositoryCall: (DSLContext) -> Unit): String = captureQuery(repositoryCall).sql
+
+    private fun captureQuery(repositoryCall: (DSLContext) -> Unit): CapturedQuery {
         var capturedSql = ""
+        var capturedBindings = emptyList<Any?>()
         lateinit var dsl: DSLContext
         val connection =
             MockConnection(
                 MockDataProvider { context ->
                     capturedSql = context.sql()
+                    capturedBindings = context.bindings().toList()
                     arrayOf(MockResult(0, dsl.newResult(*DISCOVERY_QUOTE_FIELDS)))
                 },
             )
         dsl = DSL.using(connection, SQLDialect.POSTGRES)
         repositoryCall(dsl)
-        return capturedSql
+        return CapturedQuery(capturedSql, capturedBindings)
     }
 
     private fun searchCriteria(
+        query: String = SEARCH_QUERY,
         sort: DiscoveryQuoteSearchSort = DiscoveryQuoteSearchSort.LATEST,
         cursor: DiscoveryQuoteSearchCursor? = null,
         genre: DiscoveryGenre? = null,
     ): DiscoveryQuoteSearchCriteria =
         DiscoveryQuoteSearchCriteria(
             userId = USER_ID,
-            query = SEARCH_QUERY,
+            query = query,
             sort = sort,
             cursor = cursor,
             genre = genre,
             limit = DISCOVERY_QUOTE_FETCH_COUNT,
         )
 
+    private data class CapturedQuery(
+        val sql: String,
+        val bindings: List<Any?>,
+    )
+
     private companion object {
         const val USER_ID = 1L
         const val DISCOVERY_QUOTE_FETCH_COUNT = 11
         const val QUOTE_ID = 10L
         const val SEARCH_QUERY = "새"
+        const val SEARCH_META_QUERY = "100%_!"
+        const val ESCAPED_SEARCH_META_QUERY = "%100!%!_!!%"
         const val SCRAP_COUNT = 3
         val RECOMMENDED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 5, 12, 34, 56)
         val DISCOVERY_QUOTE_FIELDS: Array<Field<*>> =

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
@@ -3,6 +3,8 @@ package com.firstpenguin.app.domain.discovery.repository
 import com.firstpenguin.app.domain.book.repository.BookTable
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
 import com.firstpenguin.app.domain.quote.repository.QuoteScrapTable
 import com.firstpenguin.app.domain.quote.repository.QuoteTable
 import org.jooq.DSLContext
@@ -39,6 +41,10 @@ class DiscoveryRepositoryTest {
         assertTrue(normalizedSql.contains("recommended_at"), normalizedSql)
         assertTrue(normalizedSql.contains("quote_scraps"), normalizedSql)
         assertTrue(normalizedSql.contains("is_scrapped"), normalizedSql)
+        assertTrue(normalizedSql.contains("recommendation_tags"), normalizedSql)
+        assertTrue(normalizedSql.contains("need_tag_id"), normalizedSql)
+        assertTrue(normalizedSql.contains("need_tag_label"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"tags\".\"type\" = ?"), normalizedSql)
         assertTrue(normalizedSql.contains("\"quote_scraps\".\"user_id\" = ?"), normalizedSql)
         assertTrue(normalizedSql.contains("row_number()"), normalizedSql)
         assertTrue(normalizedSql.contains(" union all "), normalizedSql)
@@ -88,6 +94,73 @@ class DiscoveryRepositoryTest {
         assertTrue(normalizedSql.contains("\"books\".\"category\" = ?"), normalizedSql)
     }
 
+    @Test
+    fun `검색어가 있으면 문장 내용 검색 조건을 추가한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                DiscoveryRepository(dsl).searchRecommendedQuotes(
+                    userId = USER_ID,
+                    query = SEARCH_QUERY,
+                    sort = DiscoveryQuoteSearchSort.LATEST,
+                    cursor = null,
+                    genre = null,
+                    limit = DISCOVERY_QUOTE_FETCH_COUNT,
+                )
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("\"quotes\".\"content\""), normalizedSql)
+        assertTrue(normalizedSql.contains("like"), normalizedSql)
+        assertTrue(
+            normalizedSql.contains(
+                "order by \"ranked_recommendation_events\".\"recommended_at\" desc, \"quotes\".\"id\" desc",
+            ),
+            normalizedSql,
+        )
+    }
+
+    @Test
+    fun `스크랩순 검색은 스크랩 수 집계와 정렬을 추가한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                DiscoveryRepository(dsl).searchRecommendedQuotes(
+                    userId = USER_ID,
+                    query = SEARCH_QUERY,
+                    sort = DiscoveryQuoteSearchSort.SCRAP_COUNT,
+                    cursor = null,
+                    genre = DiscoveryGenre.KOREAN_NOVEL,
+                    limit = DISCOVERY_QUOTE_FETCH_COUNT,
+                )
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("quote_scrap_counts"), normalizedSql)
+        assertTrue(normalizedSql.contains("count(\"quote_scraps\".\"id\")"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"books\".\"category\" = ?"), normalizedSql)
+        assertTrue(normalizedSql.contains("order by \"scrap_count\" desc"), normalizedSql)
+    }
+
+    @Test
+    fun `스크랩순 검색 커서가 있으면 스크랩 수와 최신순 보조 조건을 추가한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                DiscoveryRepository(dsl).searchRecommendedQuotes(
+                    userId = USER_ID,
+                    query = SEARCH_QUERY,
+                    sort = DiscoveryQuoteSearchSort.SCRAP_COUNT,
+                    cursor = DiscoveryQuoteSearchCursor(RECOMMENDED_AT, QUOTE_ID, SCRAP_COUNT),
+                    genre = null,
+                    limit = DISCOVERY_QUOTE_FETCH_COUNT,
+                )
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("\"scrap_count\" < ?"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"scrap_count\" = ?"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"recommended_at\" < cast(? as timestamp)"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"quotes\".\"id\" < ?"), normalizedSql)
+    }
+
     private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {
         var capturedSql = ""
         lateinit var dsl: DSLContext
@@ -107,6 +180,8 @@ class DiscoveryRepositoryTest {
         const val USER_ID = 1L
         const val DISCOVERY_QUOTE_FETCH_COUNT = 11
         const val QUOTE_ID = 10L
+        const val SEARCH_QUERY = "새"
+        const val SCRAP_COUNT = 3
         val RECOMMENDED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 5, 12, 34, 56)
         val DISCOVERY_QUOTE_FIELDS: Array<Field<*>> =
             arrayOf(
@@ -118,8 +193,11 @@ class DiscoveryRepositoryTest {
                 BookTable.AUTHOR,
                 BookTable.COVER_IMAGE_URL,
                 BookTable.CATEGORY,
+                DSL.field("need_tag_id", Long::class.java),
+                DSL.field("need_tag_label", String::class.java),
                 DSL.field("recommended_at", LocalDateTime::class.java),
                 QuoteScrapTable.ID.isNotNull.`as`("is_scrapped"),
+                DSL.field("scrap_count", Int::class.java),
             )
     }
 }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.firstpenguin.app.domain.discovery.repository
 import com.firstpenguin.app.domain.book.repository.BookTable
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCriteria
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
 import com.firstpenguin.app.domain.quote.repository.QuoteScrapTable
@@ -99,18 +100,15 @@ class DiscoveryRepositoryTest {
         val capturedSql =
             captureSql { dsl ->
                 DiscoveryRepository(dsl).searchRecommendedQuotes(
-                    userId = USER_ID,
-                    query = SEARCH_QUERY,
-                    sort = DiscoveryQuoteSearchSort.LATEST,
-                    cursor = null,
-                    genre = null,
-                    limit = DISCOVERY_QUOTE_FETCH_COUNT,
+                    searchCriteria(),
                 )
             }
         val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
 
-        assertTrue(normalizedSql.contains("\"quotes\".\"content\""), normalizedSql)
-        assertTrue(normalizedSql.contains("like"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"quotes\".\"content\" ilike"), normalizedSql)
+        assertFalse(normalizedSql.contains("\"books\".\"title\" ilike"), normalizedSql)
+        assertFalse(normalizedSql.contains("\"books\".\"author\" ilike"), normalizedSql)
+        assertFalse(normalizedSql.contains("\"users\".\"nickname\" ilike"), normalizedSql)
         assertTrue(
             normalizedSql.contains(
                 "order by \"ranked_recommendation_events\".\"recommended_at\" desc, \"quotes\".\"id\" desc",
@@ -124,12 +122,10 @@ class DiscoveryRepositoryTest {
         val capturedSql =
             captureSql { dsl ->
                 DiscoveryRepository(dsl).searchRecommendedQuotes(
-                    userId = USER_ID,
-                    query = SEARCH_QUERY,
-                    sort = DiscoveryQuoteSearchSort.SCRAP_COUNT,
-                    cursor = null,
-                    genre = DiscoveryGenre.KOREAN_NOVEL,
-                    limit = DISCOVERY_QUOTE_FETCH_COUNT,
+                    searchCriteria(
+                        sort = DiscoveryQuoteSearchSort.SCRAP_COUNT,
+                        genre = DiscoveryGenre.KOREAN_NOVEL,
+                    ),
                 )
             }
         val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
@@ -145,12 +141,10 @@ class DiscoveryRepositoryTest {
         val capturedSql =
             captureSql { dsl ->
                 DiscoveryRepository(dsl).searchRecommendedQuotes(
-                    userId = USER_ID,
-                    query = SEARCH_QUERY,
-                    sort = DiscoveryQuoteSearchSort.SCRAP_COUNT,
-                    cursor = DiscoveryQuoteSearchCursor(RECOMMENDED_AT, QUOTE_ID, SCRAP_COUNT),
-                    genre = null,
-                    limit = DISCOVERY_QUOTE_FETCH_COUNT,
+                    searchCriteria(
+                        sort = DiscoveryQuoteSearchSort.SCRAP_COUNT,
+                        cursor = DiscoveryQuoteSearchCursor(RECOMMENDED_AT, QUOTE_ID, SCRAP_COUNT),
+                    ),
                 )
             }
         val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
@@ -175,6 +169,20 @@ class DiscoveryRepositoryTest {
         repositoryCall(dsl)
         return capturedSql
     }
+
+    private fun searchCriteria(
+        sort: DiscoveryQuoteSearchSort = DiscoveryQuoteSearchSort.LATEST,
+        cursor: DiscoveryQuoteSearchCursor? = null,
+        genre: DiscoveryGenre? = null,
+    ): DiscoveryQuoteSearchCriteria =
+        DiscoveryQuoteSearchCriteria(
+            userId = USER_ID,
+            query = SEARCH_QUERY,
+            sort = sort,
+            cursor = cursor,
+            genre = genre,
+            limit = DISCOVERY_QUOTE_FETCH_COUNT,
+        )
 
     private companion object {
         const val USER_ID = 1L

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
 import com.firstpenguin.app.domain.discovery.model.DiscoveryNeedTag
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCriteria
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
 import com.firstpenguin.app.domain.discovery.service.DiscoveryService
@@ -177,12 +178,7 @@ class DiscoveryUseCaseTest {
         Mockito
             .`when`(
                 discoveryService.searchRecommendedQuotes(
-                    USER_ID,
-                    SEARCH_QUERY,
-                    DiscoveryQuoteSearchSort.LATEST,
-                    null,
-                    null,
-                    DISCOVERY_QUOTE_FETCH_COUNT,
+                    searchCriteria(),
                 ),
             ).thenReturn(listOf(quote))
 
@@ -212,12 +208,11 @@ class DiscoveryUseCaseTest {
         Mockito
             .`when`(
                 discoveryService.searchRecommendedQuotes(
-                    USER_ID,
-                    SEARCH_QUERY,
-                    DiscoveryQuoteSearchSort.SCRAP_COUNT,
-                    DiscoveryQuoteSearchCursor(RECOMMENDED_AT, QUOTE_ID, SCRAP_COUNT),
-                    DiscoveryGenre.KOREAN_NOVEL,
-                    DISCOVERY_QUOTE_FETCH_COUNT,
+                    searchCriteria(
+                        sort = DiscoveryQuoteSearchSort.SCRAP_COUNT,
+                        cursor = DiscoveryQuoteSearchCursor(RECOMMENDED_AT, QUOTE_ID, SCRAP_COUNT),
+                        genre = DiscoveryGenre.KOREAN_NOVEL,
+                    ),
                 ),
             ).thenReturn(listOf(quote))
 
@@ -242,12 +237,7 @@ class DiscoveryUseCaseTest {
         Mockito
             .`when`(
                 discoveryService.searchRecommendedQuotes(
-                    USER_ID,
-                    SEARCH_QUERY,
-                    DiscoveryQuoteSearchSort.SCRAP_COUNT,
-                    null,
-                    null,
-                    DISCOVERY_QUOTE_FETCH_COUNT,
+                    searchCriteria(sort = DiscoveryQuoteSearchSort.SCRAP_COUNT),
                 ),
             ).thenReturn(quotes)
 
@@ -315,6 +305,20 @@ class DiscoveryUseCaseTest {
             recommendedAt = RECOMMENDED_AT,
             isScrapped = isScrapped,
             scrapCount = scrapCount,
+        )
+
+    private fun searchCriteria(
+        sort: DiscoveryQuoteSearchSort = DiscoveryQuoteSearchSort.LATEST,
+        cursor: DiscoveryQuoteSearchCursor? = null,
+        genre: DiscoveryGenre? = null,
+    ): DiscoveryQuoteSearchCriteria =
+        DiscoveryQuoteSearchCriteria(
+            userId = USER_ID,
+            query = SEARCH_QUERY,
+            sort = sort,
+            cursor = cursor,
+            genre = genre,
+            limit = DISCOVERY_QUOTE_FETCH_COUNT,
         )
 
     private companion object {

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
@@ -2,7 +2,10 @@ package com.firstpenguin.app.domain.discovery.usecase
 
 import com.firstpenguin.app.domain.discovery.model.DiscoveryCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryGenre
+import com.firstpenguin.app.domain.discovery.model.DiscoveryNeedTag
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
+import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
 import com.firstpenguin.app.domain.discovery.service.DiscoveryService
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
@@ -37,6 +40,20 @@ class DiscoveryUseCaseTest {
         assertEquals(RECOMMENDED_USER_ID, response.quotes.first().recommendedUserId)
         assertEquals(RECOMMENDED_AT, response.quotes.first().recommendedAt)
         assertEquals(GENRE, response.quotes.first().genre)
+        assertEquals(
+            NEED_TAG_ID,
+            response.quotes
+                .first()
+                .needTag
+                ?.id,
+        )
+        assertEquals(
+            NEED_TAG_LABEL,
+            response.quotes
+                .first()
+                .needTag
+                ?.label,
+        )
         assertFalse(response.quotes.first().isScrapped)
         assertFalse(response.hasNext)
         assertNull(response.nextCursor)
@@ -154,9 +171,136 @@ class DiscoveryUseCaseTest {
         assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
     }
 
+    @Test
+    fun `검색어로 검색하면 기본 최신순으로 조회하고 발견탭 응답을 반환한다`() {
+        val quote = discoveryQuote(QUOTE_ID)
+        Mockito
+            .`when`(
+                discoveryService.searchRecommendedQuotes(
+                    USER_ID,
+                    SEARCH_QUERY,
+                    DiscoveryQuoteSearchSort.LATEST,
+                    null,
+                    null,
+                    DISCOVERY_QUOTE_FETCH_COUNT,
+                ),
+            ).thenReturn(listOf(quote))
+
+        val response =
+            discoveryUseCase.searchDiscoveryQuotes(
+                USER_ID,
+                SEARCH_QUERY,
+                sort = null,
+                cursor = null,
+                genre = null,
+            )
+
+        assertEquals(1, response.quotes.size)
+        assertEquals(
+            NEED_TAG_LABEL,
+            response.quotes
+                .first()
+                .needTag
+                ?.label,
+        )
+        assertFalse(response.hasNext)
+    }
+
+    @Test
+    fun `스크랩순 검색은 스크랩수 커서를 파싱해 서비스에 전달한다`() {
+        val quote = discoveryQuote(QUOTE_ID, scrapCount = SCRAP_COUNT)
+        Mockito
+            .`when`(
+                discoveryService.searchRecommendedQuotes(
+                    USER_ID,
+                    SEARCH_QUERY,
+                    DiscoveryQuoteSearchSort.SCRAP_COUNT,
+                    DiscoveryQuoteSearchCursor(RECOMMENDED_AT, QUOTE_ID, SCRAP_COUNT),
+                    DiscoveryGenre.KOREAN_NOVEL,
+                    DISCOVERY_QUOTE_FETCH_COUNT,
+                ),
+            ).thenReturn(listOf(quote))
+
+        val response =
+            discoveryUseCase.searchDiscoveryQuotes(
+                USER_ID,
+                SEARCH_QUERY,
+                sort = "scrapCount",
+                cursor = EXPECTED_SCRAP_COUNT_CURSOR,
+                genre = GENRE,
+            )
+
+        assertEquals(1, response.quotes.size)
+    }
+
+    @Test
+    fun `검색 결과가 11개면 정렬 기준에 맞는 다음 커서를 만든다`() {
+        val quotes =
+            (1L..DISCOVERY_QUOTE_FETCH_COUNT).map { quoteId ->
+                discoveryQuote(quoteId, scrapCount = SCRAP_COUNT)
+            }
+        Mockito
+            .`when`(
+                discoveryService.searchRecommendedQuotes(
+                    USER_ID,
+                    SEARCH_QUERY,
+                    DiscoveryQuoteSearchSort.SCRAP_COUNT,
+                    null,
+                    null,
+                    DISCOVERY_QUOTE_FETCH_COUNT,
+                ),
+            ).thenReturn(quotes)
+
+        val response =
+            discoveryUseCase.searchDiscoveryQuotes(
+                USER_ID,
+                SEARCH_QUERY,
+                sort = "scrapCount",
+                cursor = null,
+                genre = null,
+            )
+
+        assertEquals(DISCOVERY_QUOTE_COUNT, response.quotes.size)
+        assertEquals(EXPECTED_SCRAP_COUNT_CURSOR, response.nextCursor)
+        assertEquals(true, response.hasNext)
+    }
+
+    @Test
+    fun `빈 검색어가 들어오면 예외가 발생한다`() {
+        val exception =
+            org.junit.jupiter.api.assertThrows<CustomException> {
+                discoveryUseCase.searchDiscoveryQuotes(
+                    USER_ID,
+                    query = "  ",
+                    sort = null,
+                    cursor = null,
+                    genre = null,
+                )
+            }
+
+        assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
+    }
+
+    @Test
+    fun `유효하지 않은 검색 정렬이 들어오면 예외가 발생한다`() {
+        val exception =
+            org.junit.jupiter.api.assertThrows<CustomException> {
+                discoveryUseCase.searchDiscoveryQuotes(
+                    USER_ID,
+                    SEARCH_QUERY,
+                    sort = "oldest",
+                    cursor = null,
+                    genre = null,
+                )
+            }
+
+        assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
+    }
+
     private fun discoveryQuote(
         quoteId: Long,
         isScrapped: Boolean = false,
+        scrapCount: Int = 0,
     ): DiscoveryQuote =
         DiscoveryQuote(
             quoteId = quoteId,
@@ -167,8 +311,10 @@ class DiscoveryUseCaseTest {
             author = "헤르만 헤세",
             bookCoverImageUrl = "https://cdn.example.com/book-cover-placeholder.png",
             genre = GENRE,
+            needTag = DiscoveryNeedTag(NEED_TAG_ID, NEED_TAG_LABEL),
             recommendedAt = RECOMMENDED_AT,
             isScrapped = isScrapped,
+            scrapCount = scrapCount,
         )
 
     private companion object {
@@ -178,8 +324,13 @@ class DiscoveryUseCaseTest {
         const val QUOTE_ID = 10L
         const val BOOK_ID = 100L
         const val RECOMMENDED_USER_ID = 200L
+        const val NEED_TAG_ID = 49L
+        const val NEED_TAG_LABEL = "공감해주는 문장"
         const val GENRE = "한국소설"
+        const val SEARCH_QUERY = "새"
+        const val SCRAP_COUNT = 3
         val RECOMMENDED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 5, 12, 34, 56)
         const val EXPECTED_NEXT_CURSOR = "MjAyNi0wNi0wNVQxMjozNDo1NnwxMA"
+        const val EXPECTED_SCRAP_COUNT_CURSOR = "M3wyMDI2LTA2LTA1VDEyOjM0OjU2fDEw"
     }
 }


### PR DESCRIPTION
## 변경 사항

- `GET /discovery/quotes/search` API를 추가했습니다.
- 검색어는 문장 내용(`quotes.content`)에만 적용합니다.
- `sort` 기본값은 `latest`이며, `scrapCount` 정렬을 지원합니다.
- `genre` 필터와 커서 기반 페이지네이션을 지원합니다.
- 발견탭 공통 응답에 추천 당시 선택한 `needTag(id, label)`를 추가했습니다.

## 검증

- `cd app && ./gradlew testClasses`
- `cd app && ./gradlew lintKotlin`
- `cd app && ./gradlew detekt`
- `cd app && ./gradlew test --tests 'com.firstpenguin.app.domain.discovery.*'`\n- push 전 훅: `cd app && ./gradlew clean test`\n\n🔗 연관 이슈: Resolves #161