### PR TITLE
✨ feat: 추천 처리 로직을 비동기로 전환

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationEngine.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationEngine.kt
@@ -1,12 +1,9 @@
 package com.firstpenguin.app.domain.recommendation.service
 
-import com.firstpenguin.app.domain.emotion.repository.TagRepository
 import com.firstpenguin.app.domain.emotion.service.EmotionService
 import com.firstpenguin.app.domain.recommendation.dto.RecommendationRequest
 import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
 import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
-import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
-import com.firstpenguin.app.domain.recommendation.repository.RecommendationTagRarityRepository
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.stereotype.Service
@@ -16,29 +13,26 @@ private const val RECOMMENDATION_RESULT_QUOTE_COUNT = 10
 @Service
 class RecommendationEngine(
     private val emotionService: EmotionService,
-    private val tagRepository: TagRepository,
     private val userInputAnalysisService: UserInputAnalysisService,
     private val effectiveTagBuilder: EffectiveTagBuilder,
-    private val candidateProvider: RecommendationCandidateProvider,
-    private val tagRarityRepository: RecommendationTagRarityRepository,
+    private val prefetcher: RecommendationEnginePrefetcher,
     private val resultComposer: RecommendationResultComposer,
 ) {
     fun recommend(
         userId: Long,
         request: RecommendationRequest,
     ): RecommendationResult {
-        val input = buildInput(userId, request).withAnalysis()
-        val effectiveTags = effectiveTagBuilder.build(input)
-        val candidates = candidateProvider.findCandidates(effectiveTags)
-        val moodTagIdByCode = tagRepository.getActiveMoodTagIdByCode()
-        val tagRarityWeights = tagRarityRepository.findMetadataTagRarityWeights()
+        val input = buildInput(userId, request)
+        val prefetch = prefetcher.start(effectiveTagBuilder.build(input))
+        val analyzedInput = input.withAnalysis()
+        val effectiveTags = effectiveTagBuilder.build(analyzedInput)
         val result =
             resultComposer.compose(
-                input = input,
+                input = analyzedInput,
                 effectiveTags = effectiveTags,
-                candidates = candidates,
-                moodTagIdByCode = moodTagIdByCode,
-                tagRarityWeights = tagRarityWeights,
+                candidates = prefetch.candidates(),
+                moodTagIdByCode = prefetch.moodTagIdByCode(),
+                tagRarityWeights = prefetch.tagRarityWeights(),
             ) ?: notEnoughQuotes()
 
         return result

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationEnginePrefetcher.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationEnginePrefetcher.kt
@@ -1,0 +1,51 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import com.firstpenguin.app.domain.emotion.repository.TagRepository
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
+import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
+import com.firstpenguin.app.domain.recommendation.repository.RecommendationTagRarityRepository
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executor
+
+@Component
+class RecommendationEnginePrefetcher(
+    private val candidateProvider: RecommendationCandidateProvider,
+    private val tagRepository: TagRepository,
+    private val tagRarityRepository: RecommendationTagRarityRepository,
+    @Qualifier(RECOMMENDATION_PREFETCH_EXECUTOR_NAME) private val executor: Executor,
+) {
+    fun start(selectedEffectiveTags: Collection<EffectiveTag>): RecommendationEnginePrefetch =
+        RecommendationEnginePrefetch(
+            candidates = async { candidateProvider.findCandidates(selectedEffectiveTags) },
+            moodTagIdByCode = async { tagRepository.getActiveMoodTagIdByCode() },
+            tagRarityWeights = async { tagRarityRepository.findMetadataTagRarityWeights() },
+        )
+
+    private fun <T> async(block: () -> T): CompletableFuture<T> = CompletableFuture.supplyAsync(block, executor)
+}
+
+class RecommendationEnginePrefetch(
+    private val candidates: CompletableFuture<List<RecommendationCandidate>>,
+    private val moodTagIdByCode: CompletableFuture<Map<String, Long>>,
+    private val tagRarityWeights: CompletableFuture<Map<Long, Double>>,
+) {
+    fun candidates(): List<RecommendationCandidate> = candidates.await()
+
+    fun moodTagIdByCode(): Map<String, Long> = moodTagIdByCode.await()
+
+    fun tagRarityWeights(): Map<Long, Double> = tagRarityWeights.await()
+}
+
+private fun <T> CompletableFuture<T>.await(): T =
+    try {
+        get()
+    } catch (exception: InterruptedException) {
+        Thread.currentThread().interrupt()
+        throw exception
+    } catch (exception: ExecutionException) {
+        throw exception.cause ?: exception
+    }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationExecutorConfig.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationExecutorConfig.kt
@@ -1,0 +1,28 @@
+package com.firstpenguin.app.domain.recommendation.service
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+const val RECOMMENDATION_PREFETCH_EXECUTOR_NAME = "recommendationPrefetchExecutor"
+
+@Configuration
+class RecommendationExecutorConfig {
+    @Bean(name = [RECOMMENDATION_PREFETCH_EXECUTOR_NAME])
+    fun recommendationPrefetchExecutor(): Executor =
+        ThreadPoolTaskExecutor().apply {
+            corePoolSize = CORE_POOL_SIZE
+            maxPoolSize = MAX_POOL_SIZE
+            queueCapacity = QUEUE_CAPACITY
+            setThreadNamePrefix(THREAD_NAME_PREFIX)
+            initialize()
+        }
+
+    private companion object {
+        const val CORE_POOL_SIZE = 4
+        const val MAX_POOL_SIZE = 8
+        const val QUEUE_CAPACITY = 100
+        const val THREAD_NAME_PREFIX = "recommendation-prefetch-"
+    }
+}


### PR DESCRIPTION
1. request -> selected emotion/need 기반 input 생성
2. selected effectiveTags로 후보 조회 prefetch 시작
3. mood tag id map prefetch 시작
4. tag rarity weight prefetch 시작
5. 메인 스레드에서 LLM 분석
6. LLM 분석 결과까지 합쳐 effectiveTags 재계산
    1. LLM 결과 수신
    -> EffectiveTagBuilder가 selected tag + LLM tagCandidates 병합
    -> MetadataScorer에서 IntentTypePolicy.resolve(input, effectiveTags)
    -> context effective tag 있으면 CONTEXT_BASED
    -> situation effective tag 있으면 SITUATION_BASED
    -> 둘 다 있으면 MIXED
    -> 그 외 emotion/need 중심이면 EMOTION_NEED_BASED
7. 미리 가져온 후보/mood/rarity로 ranking