### PR TITLE
Feat/#153/recommendation response time optimization

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/repository/TagRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/repository/TagRepository.kt
@@ -89,6 +89,7 @@ class TagRepository(
             .select(
                 TagTable.ID,
                 TagTable.TYPE,
+                TagTable.EMOTION_RANGE_ID,
                 TagTable.CODE,
                 TagTable.LABEL,
                 TagTable.DESCRIPTION,
@@ -127,6 +128,7 @@ class TagRepository(
             code = record[TagTable.CODE]!!,
             label = record[TagTable.LABEL]!!,
             description = record[TagTable.DESCRIPTION],
+            emotionRangeId = record[TagTable.EMOTION_RANGE_ID],
         )
 
     private fun tagFields(): List<Field<*>> =

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/dto/TagOption.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/quotemetadata/dto/TagOption.kt
@@ -8,4 +8,5 @@ data class TagOption(
     val code: String,
     val label: String,
     val description: String?,
+    val emotionRangeId: Long? = null,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/TagCandidate.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/TagCandidate.kt
@@ -9,5 +9,4 @@ data class TagCandidate(
     val type: TagType,
     val source: TagCandidateSource,
     val priority: TagCandidatePriority,
-    val confidence: Double,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/policy/EffectiveTagPolicy.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/policy/EffectiveTagPolicy.kt
@@ -35,8 +35,7 @@ object EffectiveTagPolicy {
 
     fun effectiveImportance(candidate: TagCandidate): Double =
         sourceWeights.getValue(candidate.source) *
-            priorityWeights.getValue(candidate.priority) *
-            candidate.confidence.coerceIn(0.0, 1.0)
+            priorityWeights.getValue(candidate.priority)
 
     fun mergeImportance(importances: List<Double>): Double =
         USER_SELECTED_IMPORTANCE -

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepository.kt
@@ -22,6 +22,11 @@ interface RecommendationCandidateProvider {
         limit: Int = DEFAULT_CANDIDATE_LIMIT,
     ): List<RecommendationCandidate>
 
+    fun findCandidatesByEmotionRangeId(
+        emotionRangeId: Long,
+        limit: Int = DEFAULT_CANDIDATE_LIMIT,
+    ): List<RecommendationCandidate>
+
     fun findRelaxedCandidates(limit: Int = DEFAULT_CANDIDATE_LIMIT): List<RecommendationCandidate>
 
     fun findRandomCandidates(limit: Int = DEFAULT_CANDIDATE_LIMIT): List<RecommendationCandidate>
@@ -34,6 +39,7 @@ interface RecommendationCandidateProvider {
 }
 
 @Repository
+@Suppress("TooManyFunctions")
 class RecommendationCandidateRepository(
     private val dsl: DSLContext,
 ) : RecommendationCandidateProvider {
@@ -63,6 +69,40 @@ class RecommendationCandidateRepository(
             .fetch()
             .toRecommendationCandidates()
     }
+
+    override fun findCandidatesByEmotionRangeId(
+        emotionRangeId: Long,
+        limit: Int,
+    ): List<RecommendationCandidate> =
+        dsl
+            .select(CANDIDATE_ROW_FIELDS)
+            .from(
+                dsl
+                    .select(QuoteTable.ID.`as`(CANDIDATE_QUOTE_ID_NAME))
+                    .from(QuoteTable.QUOTES)
+                    .join(BookTable.BOOKS)
+                    .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+                    .join(QuoteMetadataTable.QUOTE_METADATA)
+                    .on(QuoteMetadataTable.QUOTE_ID.eq(QuoteTable.ID))
+                    .where(activeQuoteAndBookCondition())
+                    .and(emotionRangeMatchExists(emotionRangeId))
+                    .orderBy(QuoteTable.ID.asc())
+                    .limit(limit)
+                    .asTable(CANDIDATE_QUOTE_IDS_TABLE),
+            ).join(QuoteTable.QUOTES)
+            .on(QuoteTable.ID.eq(CANDIDATE_QUOTE_ID))
+            .join(BookTable.BOOKS)
+            .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+            .join(QuoteMetadataTable.QUOTE_METADATA)
+            .on(QuoteMetadataTable.QUOTE_ID.eq(QuoteTable.ID))
+            .join(QuoteMetadataTagTable.QUOTE_METADATA_TAGS)
+            .on(QuoteMetadataTagTable.QUOTE_METADATA_ID.eq(QuoteMetadataTable.ID))
+            .join(TagTable.TAGS)
+            .on(TagTable.ID.eq(QuoteMetadataTagTable.TAG_ID))
+            .where(activeTagCondition())
+            .orderBy(QuoteTable.ID.asc())
+            .fetch()
+            .toRecommendationCandidates()
 
     override fun findRelaxedCandidates(limit: Int): List<RecommendationCandidate> =
         dsl
@@ -103,6 +143,8 @@ class RecommendationCandidateRepository(
                     .from(QuoteTable.QUOTES)
                     .join(BookTable.BOOKS)
                     .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
+                    .join(QuoteMetadataTable.QUOTE_METADATA)
+                    .on(QuoteMetadataTable.QUOTE_ID.eq(QuoteTable.ID))
                     .where(activeQuoteAndBookCondition())
                     .orderBy(DSL.rand())
                     .limit(limit)
@@ -111,12 +153,13 @@ class RecommendationCandidateRepository(
             .on(QuoteTable.ID.eq(CANDIDATE_QUOTE_ID))
             .join(BookTable.BOOKS)
             .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
-            .leftJoin(QuoteMetadataTable.QUOTE_METADATA)
+            .join(QuoteMetadataTable.QUOTE_METADATA)
             .on(QuoteMetadataTable.QUOTE_ID.eq(QuoteTable.ID))
-            .leftJoin(QuoteMetadataTagTable.QUOTE_METADATA_TAGS)
+            .join(QuoteMetadataTagTable.QUOTE_METADATA_TAGS)
             .on(QuoteMetadataTagTable.QUOTE_METADATA_ID.eq(QuoteMetadataTable.ID))
-            .leftJoin(TagTable.TAGS)
-            .on(TagTable.ID.eq(QuoteMetadataTagTable.TAG_ID).and(activeTagCondition()))
+            .join(TagTable.TAGS)
+            .on(TagTable.ID.eq(QuoteMetadataTagTable.TAG_ID))
+            .where(activeTagCondition())
             .orderBy(QuoteTable.ID.asc())
             .fetch()
             .toRecommendationCandidates()
@@ -177,6 +220,19 @@ class RecommendationCandidateRepository(
                 .where(QuoteMetadataTagTable.QUOTE_METADATA_ID.eq(QuoteMetadataTable.ID))
                 .and(TagTable.ID.`in`(hardFilterTagIds))
                 .and(TagTable.TYPE.`in`(hardFilterTypeNames))
+                .and(activeTagCondition()),
+        )
+
+    private fun emotionRangeMatchExists(emotionRangeId: Long): Condition =
+        DSL.exists(
+            DSL
+                .selectOne()
+                .from(QuoteMetadataTagTable.QUOTE_METADATA_TAGS)
+                .join(TagTable.TAGS)
+                .on(TagTable.ID.eq(QuoteMetadataTagTable.TAG_ID))
+                .where(QuoteMetadataTagTable.QUOTE_METADATA_ID.eq(QuoteMetadataTable.ID))
+                .and(TagTable.TYPE.eq(TagType.EMOTION.name))
+                .and(TagTable.EMOTION_RANGE_ID.eq(emotionRangeId))
                 .and(activeTagCondition()),
         )
 

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisService.kt
@@ -10,6 +10,8 @@ import com.firstpenguin.app.domain.recommendation.model.UserInputAnalysis
 import com.firstpenguin.app.global.enums.TagType
 import org.springframework.stereotype.Service
 
+private typealias TagOptionGroups = Map<TagType, List<TagOption>>
+
 @Service
 class OpenAiUserInputAnalysisService(
     private val tagRepository: TagRepository,
@@ -29,7 +31,7 @@ class OpenAiUserInputAnalysisService(
         }
 
     private fun analyzeOrThrow(input: RecommendationInput): UserInputAnalysis {
-        val tagGroups = findTagGroups()
+        val tagGroups = findTagGroups(input)
         val request = requestBuilder.build(input, tagGroups)
         val response =
             measureRecommendationElapsed {
@@ -41,10 +43,11 @@ class OpenAiUserInputAnalysisService(
             .withOpenAiUsage(request.model, response.value, response.elapsedMs)
     }
 
-    private fun findTagGroups(): Map<TagType, List<TagOption>> =
+    private fun findTagGroups(input: RecommendationInput): TagOptionGroups =
         tagRepository
             .getActiveTagsByType()
-            .onlyUserInputParseTagGroups()
+            .filterKeys(USER_INPUT_PARSE_TAG_TYPES::contains)
+            .onlyInputEmotionRange(input)
 
     private fun RecommendationInput.hasText(): Boolean = feelingText.hasValue() || diaryText.hasValue()
 
@@ -52,8 +55,12 @@ class OpenAiUserInputAnalysisService(
 
     private fun String?.hasValue(): Boolean = normalizedText() != null
 
-    private fun Map<TagType, List<TagOption>>.onlyUserInputParseTagGroups(): Map<TagType, List<TagOption>> =
-        filterKeys { type -> type in USER_INPUT_PARSE_TAG_TYPES }
+    private fun TagOptionGroups.onlyInputEmotionRange(input: RecommendationInput): TagOptionGroups =
+        mapValues { (type, options) ->
+            if (type != TagType.EMOTION) return@mapValues options
+
+            options.filter { option -> option.emotionRangeId == input.emotionRangeId }
+        }
 
     private fun UserInputAnalysis.withOpenAiUsage(
         model: String,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackService.kt
@@ -4,6 +4,7 @@ import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
 import com.firstpenguin.app.domain.recommendation.model.RankedRecommendationQuote
 import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
 import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidateSource
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
 import com.firstpenguin.app.domain.recommendation.model.SourcedRecommendationCandidate
 import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
 import com.firstpenguin.app.global.enums.TagType
@@ -14,6 +15,7 @@ class RecommendationFallbackService(
     private val candidateProvider: RecommendationCandidateProvider,
 ) {
     fun supplementCandidates(
+        input: RecommendationInput,
         effectiveTags: List<EffectiveTag>,
         existingCandidates: List<RecommendationCandidate>,
         rankedQuotes: List<RankedRecommendationQuote> = emptyList(),
@@ -25,7 +27,7 @@ class RecommendationFallbackService(
         val accumulator = CandidateAccumulator(existingCandidates)
         if (!forceFallback && accumulator.isEnough(minimumCandidateCount)) return accumulator.toList()
 
-        val fallbackSteps = fallbackSteps(effectiveTags, semanticCandidates)
+        val fallbackSteps = fallbackSteps(input, effectiveTags, semanticCandidates)
 
         fallbackSteps
             .takeUntilEnough(
@@ -38,17 +40,18 @@ class RecommendationFallbackService(
     }
 
     private fun fallbackSteps(
+        input: RecommendationInput,
         effectiveTags: List<EffectiveTag>,
         semanticCandidates: () -> List<RecommendationCandidate>,
     ): List<FallbackStep> =
         listOf(
+            fallbackStep(RecommendationCandidateSource.FALLBACK_EMOTION) {
+                candidateProvider.findCandidatesByEmotionRangeId(input.emotionRangeId, FALLBACK_FETCH_LIMIT)
+            },
+            fallbackStep(RecommendationCandidateSource.FALLBACK_SEMANTIC, semanticCandidates),
             fallbackStep(RecommendationCandidateSource.FALLBACK_NEED) {
                 candidateProvider.findCandidates(effectiveTags.only(TagType.NEED), FALLBACK_FETCH_LIMIT)
             },
-            fallbackStep(RecommendationCandidateSource.FALLBACK_EMOTION) {
-                candidateProvider.findCandidates(effectiveTags.only(TagType.EMOTION), FALLBACK_FETCH_LIMIT)
-            },
-            fallbackStep(RecommendationCandidateSource.FALLBACK_SEMANTIC, semanticCandidates),
             fallbackStep(RecommendationCandidateSource.FALLBACK_RELAXED) {
                 candidateProvider.findRelaxedCandidates(FALLBACK_FETCH_LIMIT)
             },

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
@@ -60,6 +60,7 @@ class RecommendationResultComposer(
             rank(input, effectiveTags, primaryCandidates, moodTagIdByCode, tagRarityWeights, userEmbedding)
         val supplementedCandidates =
             findSupplementedCandidates(
+                input = input,
                 effectiveTags = effectiveTags,
                 candidates = candidates,
                 initialRankedQuotes = initialRankedQuotes,
@@ -81,12 +82,14 @@ class RecommendationResultComposer(
     }
 
     private fun findSupplementedCandidates(
+        input: RecommendationInput,
         effectiveTags: List<EffectiveTag>,
         candidates: List<RecommendationCandidate>,
         initialRankedQuotes: List<RankedRecommendationQuote>,
         userEmbedding: UserSemanticEmbedding?,
     ): List<SourcedRecommendationCandidate> =
         fallbackService.supplementCandidates(
+            input = input,
             effectiveTags = effectiveTags,
             existingCandidates = candidates,
             rankedQuotes = initialRankedQuotes,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationSemanticService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationSemanticService.kt
@@ -105,6 +105,6 @@ class RecommendationSemanticService(
 
     private companion object {
         const val SEMANTIC_FALLBACK_LIMIT = 300
-        const val EMBEDDING_TIMEOUT_MILLIS = 1_000L
+        const val EMBEDDING_TIMEOUT_MILLIS = 1_500L
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseRequestBuilder.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseRequestBuilder.kt
@@ -40,7 +40,7 @@ private val USER_INPUT_PARSE_PROMPT_GUIDE =
 - 한국어 한 문장으로 작성하라.
 - 사용자의 현재 마음과 원하는 도움을 요약하라.
 - quote, 문장, 추천 결과를 설명하지 마라.
-- tagCode나 label을 단순 나열하지 마라.
+- tagCode를 단순 나열하지 마라.
 - 35~90자 사이를 권장한다.
 - 좋은 형태: 실패한 뒤 불안하고 위축된 마음을 다독이며 다시 관점을 정리하고 싶다
 - 나쁜 형태: 이 사용자에게 위로와 관점 전환 태그가 적합하다
@@ -104,7 +104,6 @@ class UserInputParseRequestBuilder(
 
     private fun TagOption.toPayload(): Map<String, String> =
         mapOf(
-            "label" to label,
             "tagCode" to code,
             "description" to description.orEmpty(),
         )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchema.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchema.kt
@@ -31,11 +31,11 @@ private fun userInputParseObjectSchema(tagGroups: Map<TagType, List<TagOption>>)
 private fun requiredUserInputParseFields(): List<String> =
     listOf(
         "canonicalIntent",
-        "emotionTagCandidates",
         "needTagCandidates",
         "situationTagCandidates",
         "contextTagCandidates",
         "roleTagCandidates",
+        "emotionTagCandidates",
     )
 
 private fun userInputParseProperties(tagGroups: Map<TagType, List<TagOption>>): Map<String, Any> =
@@ -46,13 +46,6 @@ private fun userInputParseProperties(tagGroups: Map<TagType, List<TagOption>>): 
                 "description" to "사용자의 현재 마음과 원하는 도움을 요약한 한국어 한 문장",
                 "minLength" to CANONICAL_INTENT_MIN_LENGTH,
                 "maxLength" to CANONICAL_INTENT_MAX_LENGTH,
-            ),
-        "emotionTagCandidates" to
-            tagCandidatesSchema(
-                options = tagGroups.getValue(TagType.EMOTION),
-                description = "텍스트에 명확히 드러난 사용자 감정 보조 후보. PRIMARY priority를 사용하지 않는다.",
-                maxItems = EMOTION_TAG_MAX_ITEMS,
-                priorities = listOf(TagCandidatePriority.SECONDARY, TagCandidatePriority.BACKGROUND),
             ),
         "needTagCandidates" to
             tagCandidatesSchema(
@@ -78,6 +71,13 @@ private fun userInputParseProperties(tagGroups: Map<TagType, List<TagOption>>): 
                 description = "사용자가 원하는 문장의 역할 후보. 명확한 경우에만 반환한다.",
                 maxItems = ROLE_TAG_MAX_ITEMS,
             ),
+        "emotionTagCandidates" to
+            tagCandidatesSchema(
+                options = tagGroups.getValue(TagType.EMOTION),
+                description = "텍스트에 명확히 드러난 사용자 감정 보조 후보. PRIMARY priority를 사용하지 않는다.",
+                maxItems = EMOTION_TAG_MAX_ITEMS,
+                priorities = listOf(TagCandidatePriority.SECONDARY, TagCandidatePriority.BACKGROUND),
+            ),
     )
 
 private fun tagCandidatesSchema(
@@ -100,7 +100,7 @@ private fun tagCandidateSchema(
     mapOf(
         "type" to "object",
         "additionalProperties" to false,
-        "required" to listOf("tagCode", "source", "priority", "confidence"),
+        "required" to listOf("tagCode", "source", "priority"),
         "properties" to tagCandidateProperties(options, priorities),
     )
 
@@ -123,13 +123,6 @@ private fun tagCandidateProperties(
             enumSchema(
                 values = priorities.map { priority -> priority.name },
                 description = "같은 카테고리 안에서 추천 엔진에 전달할 우선순위",
-            ),
-        "confidence" to
-            mapOf(
-                "type" to "number",
-                "description" to "텍스트 근거가 얼마나 명확한지 0.0부터 1.0 사이로 표현한다.",
-                "minimum" to 0.0,
-                "maximum" to 1.0,
             ),
     )
 

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseTagTypes.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseTagTypes.kt
@@ -4,9 +4,9 @@ import com.firstpenguin.app.global.enums.TagType
 
 internal val USER_INPUT_PARSE_TAG_TYPES =
     listOf(
-        TagType.EMOTION,
         TagType.NEED,
         TagType.SITUATION,
         TagType.CONTEXT,
         TagType.ROLE,
+        TagType.EMOTION,
     )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputTagCandidateMapper.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputTagCandidateMapper.kt
@@ -38,26 +38,23 @@ class UserInputTagCandidateMapper {
             val tagCode = requiredText("tagCode")
             val source = TagCandidateSource.valueOf(requiredText("source"))
             val priority = TagCandidatePriority.valueOf(requiredText("priority"))
-            val confidence = path("confidence").asDouble().coerceIn(0.0, 1.0)
             val tagOption = tagOptionByCode[tagCode] ?: return@runCatching null
 
-            if (!isResolvable(tagCode, tagType, source, confidence, selectedCodes, tagOption)) {
+            if (!isResolvable(tagCode, tagType, source, selectedCodes, tagOption)) {
                 return@runCatching null
             }
 
-            tagOption.toTagCandidate(input, source, priority, confidence)
+            tagOption.toTagCandidate(input, source, priority)
         }.getOrNull()
 
     private fun isResolvable(
         tagCode: String,
         tagType: TagType,
         source: TagCandidateSource,
-        confidence: Double,
         selectedCodes: Set<String>,
         tagOption: TagOption,
     ): Boolean =
-        confidence >= MIN_CONFIDENCE &&
-            tagType in USER_INPUT_PARSE_TAG_TYPES &&
+        tagType in USER_INPUT_PARSE_TAG_TYPES &&
             source != TagCandidateSource.USER_SELECTED &&
             tagCode !in selectedCodes &&
             tagOption.type == tagType
@@ -66,7 +63,6 @@ class UserInputTagCandidateMapper {
         input: RecommendationInput,
         source: TagCandidateSource,
         priority: TagCandidatePriority,
-        confidence: Double,
     ): TagCandidate =
         TagCandidate(
             tagId = id,
@@ -75,7 +71,6 @@ class UserInputTagCandidateMapper {
             type = type,
             source = source,
             priority = priority.normalized(input, type, source),
-            confidence = confidence,
         )
 
     private fun TagCandidatePriority.normalized(
@@ -123,7 +118,6 @@ class UserInputTagCandidateMapper {
             ?: error("Missing required text field: $fieldName")
 
     private companion object {
-        const val MIN_CONFIDENCE = 0.3
         const val BACKGROUND_RANK = 1
         const val SECONDARY_RANK = 2
         const val PRIMARY_RANK = 3

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/repository/RecommendationCandidateRepositoryTest.kt
@@ -63,6 +63,24 @@ class RecommendationCandidateRepositoryTest {
     }
 
     @Test
+    fun `emotion range 기반 fallback 후보를 조회한다`() {
+        val capturedQuery =
+            captureQuery { dsl ->
+                RecommendationCandidateRepository(dsl).findCandidatesByEmotionRangeId(
+                    emotionRangeId = EMOTION_RANGE_ID,
+                    limit = LIMIT,
+                )
+            }
+        val normalizedSql = capturedQuery.sql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("join \"quote_metadata\""), normalizedSql)
+        assertTrue(normalizedSql.contains("\"tags\".\"type\" = ?"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"tags\".\"emotion_range_id\" = ?"), normalizedSql)
+        assertTrue(capturedQuery.bindings.contains(TagType.EMOTION.name))
+        assertTrue(capturedQuery.bindings.contains(EMOTION_RANGE_ID))
+    }
+
+    @Test
     fun `조회 row를 후보 단위로 묶어 태그 타입별 id를 채운다`() {
         val candidates =
             findCandidatesWithResult { dsl ->
@@ -243,6 +261,7 @@ class RecommendationCandidateRepositoryTest {
         const val NEED_TAG_ID = 32L
         const val MOOD_TAG_ID = 33L
         const val CONTEXT_TAG_ID = 34L
+        const val EMOTION_RANGE_ID = 1L
         const val CANDIDATE_ROW_COUNT = 4
         const val QUOTE_CONTENT = "좋은 문장"
         const val BOOK_TITLE = "좋은 책"

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/EffectiveTagBuilderTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/EffectiveTagBuilderTest.kt
@@ -9,7 +9,6 @@ import com.firstpenguin.app.domain.recommendation.model.TagCandidateSource
 import com.firstpenguin.app.domain.recommendation.model.UserInputAnalysis
 import com.firstpenguin.app.global.enums.TagType
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
@@ -17,32 +16,31 @@ class EffectiveTagBuilderTest {
     private val effectiveTagBuilder = EffectiveTagBuilder()
 
     @Test
-    fun `선택 태그는 1점으로 반영하고 낮은 LLM 후보는 제거한다`() {
+    fun `선택 태그는 1점으로 반영하고 LLM 후보는 source와 priority로 반영한다`() {
         val input =
             recommendationInput(
                 emotionTags = listOf(tag(1L, TagType.EMOTION, "EMOTION_SELF_BLAME")),
                 needTag = tag(2L, TagType.NEED, "NEED_COMFORT"),
                 tagCandidates =
                     listOf(
-                        tagCandidate(3L, TagType.SITUATION, "SITUATION_FAILURE_MISTAKE", confidence = 0.95),
+                        tagCandidate(3L, TagType.SITUATION, "SITUATION_FAILURE_MISTAKE"),
                         tagCandidate(
                             tagId = 4L,
                             type = TagType.CONTEXT,
                             code = "CONTEXT_RAIN",
                             source = TagCandidateSource.DIARY_TEXT,
                             priority = TagCandidatePriority.BACKGROUND,
-                            confidence = 0.5,
                         ),
                     ),
             )
 
         val result = effectiveTagBuilder.build(input).associateBy { tag -> tag.tagId }
 
-        assertEquals(3, result.size)
+        assertEquals(4, result.size)
         assertEquals(1.0, result.getValue(1L).importance, DELTA)
         assertEquals(1.0, result.getValue(2L).importance, DELTA)
-        assertEquals(0.8075, result.getValue(3L).importance, DELTA)
-        assertFalse(result.containsKey(4L))
+        assertEquals(0.85, result.getValue(3L).importance, DELTA)
+        assertEquals(0.165, result.getValue(4L).importance, DELTA)
     }
 
     @Test
@@ -52,7 +50,7 @@ class EffectiveTagBuilderTest {
                 emotionTags = listOf(tag(1L, TagType.EMOTION, "EMOTION_SELF_BLAME")),
                 tagCandidates =
                     listOf(
-                        tagCandidate(1L, TagType.EMOTION, "EMOTION_SELF_BLAME", confidence = 0.8),
+                        tagCandidate(1L, TagType.EMOTION, "EMOTION_SELF_BLAME"),
                     ),
             )
 
@@ -90,7 +88,6 @@ class EffectiveTagBuilderTest {
         code: String,
         source: TagCandidateSource = TagCandidateSource.FEELING_TEXT,
         priority: TagCandidatePriority = TagCandidatePriority.PRIMARY,
-        confidence: Double,
     ): TagCandidate =
         TagCandidate(
             tagId = tagId,
@@ -99,7 +96,6 @@ class EffectiveTagBuilderTest {
             type = type,
             source = source,
             priority = priority,
-            confidence = confidence,
         )
 
     private fun tag(

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/OpenAiUserInputAnalysisServiceTest.kt
@@ -65,6 +65,9 @@ class OpenAiUserInputAnalysisServiceTest {
                 .toString()
                 .contains("CONTEXT_RAIN"),
         )
+        assertTrue(openAi.lastRequest.input.contains("EMOTION_ANXIOUS"))
+        assertFalse(openAi.lastRequest.input.contains("EMOTION_OTHER_RANGE"))
+        assertFalse(openAi.lastRequest.input.contains("\"label\""))
     }
 
     @Test
@@ -92,8 +95,17 @@ class OpenAiUserInputAnalysisServiceTest {
 
         service.analyze(recommendationInput(feelingText = "비 오는 출근길에 마음이 불안해"))
 
-        assertTrue(openAi.lastRequest.input.indexOf("[허용 태그 목록]") < openAi.lastRequest.input.indexOf("[분석 대상 사용자 입력]"))
-        assertTrue(openAi.lastRequest.input.indexOf("CONTEXT_RAIN") < openAi.lastRequest.input.indexOf("비 오는 출근길"))
+        val prompt = openAi.lastRequest.input
+        val stableTagIndex = prompt.indexOf("[허용 태그 목록]")
+        val userInputIndex = prompt.indexOf("[분석 대상 사용자 입력]")
+
+        assertTrue(stableTagIndex < userInputIndex)
+        assertFalse(prompt.contains("[허용 감정 태그 목록]"))
+        assertTrue(prompt.indexOf("NEED_COMFORT") < prompt.indexOf("EMOTION_ANXIOUS"))
+        assertTrue(prompt.indexOf("ROLE_EMPATHY") < prompt.indexOf("EMOTION_ANXIOUS"))
+        assertTrue(prompt.indexOf("CONTEXT_RAIN") < prompt.indexOf("비 오는 출근길"))
+        assertTrue(prompt.indexOf("CONTEXT_RAIN") < prompt.indexOf("EMOTION_ANXIOUS"))
+        assertTrue(prompt.indexOf("EMOTION_ANXIOUS") < prompt.indexOf("비 오는 출근길"))
     }
 
     @Test
@@ -187,8 +199,7 @@ class OpenAiUserInputAnalysisServiceTest {
                 {
                   "tagCode": "NEED_COMFORT",
                   "source": "FEELING_TEXT",
-                  "priority": "PRIMARY",
-                  "confidence": 0.88
+                  "priority": "PRIMARY"
                 }
               ],
               "situationTagCandidates": [],
@@ -196,8 +207,7 @@ class OpenAiUserInputAnalysisServiceTest {
                 {
                   "tagCode": "CONTEXT_RAIN",
                   "source": "FEELING_TEXT",
-                  "priority": "PRIMARY",
-                  "confidence": 0.92
+                  "priority": "PRIMARY"
                 }
               ],
               "roleTagCandidates": []
@@ -276,6 +286,7 @@ class OpenAiUserInputAnalysisServiceTest {
         fun tagResult(dsl: DSLContext): Result<Record> =
             dsl.newResult(*TAG_FIELDS).apply {
                 add(tagRecord(dsl, 1L, TagType.EMOTION, "EMOTION_ANXIOUS"))
+                add(tagRecord(dsl, 2L, TagType.EMOTION, "EMOTION_OTHER_RANGE", emotionRangeId = OTHER_EMOTION_RANGE_ID))
                 add(tagRecord(dsl, NEED_TAG_ID, TagType.NEED, "NEED_COMFORT"))
                 add(tagRecord(dsl, 11L, TagType.SITUATION, "SITUATION_FAILURE_MISTAKE"))
                 add(tagRecord(dsl, CONTEXT_TAG_ID, TagType.CONTEXT, "CONTEXT_RAIN"))
@@ -287,10 +298,12 @@ class OpenAiUserInputAnalysisServiceTest {
             id: Long,
             type: TagType,
             code: String,
+            emotionRangeId: Long? = if (type == TagType.EMOTION) EMOTION_RANGE_ID else null,
         ): Record =
             dsl.newRecord(*TAG_FIELDS).apply {
                 set(TagTable.ID, id)
                 set(TagTable.TYPE, type.name)
+                set(TagTable.EMOTION_RANGE_ID, emotionRangeId)
                 set(TagTable.CODE, code)
                 set(TagTable.LABEL, code)
                 set(TagTable.DESCRIPTION, code)
@@ -335,11 +348,13 @@ class OpenAiUserInputAnalysisServiceTest {
                 createdAt = CREATED_AT,
             )
 
-        const val TAG_ROW_COUNT = 5
+        const val TAG_ROW_COUNT = 6
+        const val OTHER_EMOTION_RANGE_ID = 2L
         val TAG_FIELDS: Array<Field<*>> =
             arrayOf(
                 TagTable.ID,
                 TagTable.TYPE,
+                TagTable.EMOTION_RANGE_ID,
                 TagTable.CODE,
                 TagTable.LABEL,
                 TagTable.DESCRIPTION,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationFallbackServiceTest.kt
@@ -4,6 +4,7 @@ import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
 import com.firstpenguin.app.domain.recommendation.model.RankedRecommendationQuote
 import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidate
 import com.firstpenguin.app.domain.recommendation.model.RecommendationCandidateSource
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
 import com.firstpenguin.app.domain.recommendation.model.RecommendationScoreBreakdown
 import com.firstpenguin.app.domain.recommendation.repository.RecommendationCandidateProvider
 import com.firstpenguin.app.global.enums.TagType
@@ -22,6 +23,7 @@ class RecommendationFallbackServiceTest {
 
         val result =
             service.supplementCandidates(
+                input = recommendationInput(),
                 effectiveTags = effectiveTags,
                 existingCandidates = existingCandidates,
                 rankedQuotes = listOf(rankedQuote(existingCandidates.first(), finalScore = HIGH_SCORE)),
@@ -32,7 +34,7 @@ class RecommendationFallbackServiceTest {
     }
 
     @Test
-    fun `후보가 부족하면 need emotion relaxed random 순서로 보강한다`() {
+    fun `후보가 부족하면 emotion range semantic need relaxed random 순서로 보강한다`() {
         val provider =
             FakeRecommendationCandidateProvider(
                 needCandidates = listOf(candidate(1L), candidate(2L)),
@@ -44,12 +46,16 @@ class RecommendationFallbackServiceTest {
 
         val result =
             service.supplementCandidates(
+                input = recommendationInput(),
                 effectiveTags = effectiveTags,
                 existingCandidates = listOf(candidate(1L)),
             )
 
-        assertEquals(listOf("NEED", "EMOTION", "RELAXED", "RANDOM"), provider.calls)
-        assertEquals((1L..10L).toList(), result.map { candidate -> candidate.quoteId })
+        assertEquals(listOf("EMOTION_RANGE", "NEED", "RELAXED", "RANDOM"), provider.calls)
+        assertEquals(
+            listOf(1L, 3L, 2L, 4L, 5L, 6L, 7L, 8L, 9L, 10L),
+            result.map { candidate -> candidate.quoteId },
+        )
         assertEquals(RecommendationCandidateSource.PRIMARY, result.first().source)
         assertEquals(RecommendationCandidateSource.FALLBACK_RANDOM, result.last().source)
     }
@@ -66,6 +72,7 @@ class RecommendationFallbackServiceTest {
 
         val result =
             service.supplementCandidates(
+                input = recommendationInput(),
                 effectiveTags = effectiveTags,
                 existingCandidates = listOf(candidate(1L)),
                 semanticCandidates = {
@@ -74,22 +81,22 @@ class RecommendationFallbackServiceTest {
                 },
             )
 
-        assertEquals(listOf("NEED", "EMOTION", "SEMANTIC", "RELAXED", "RANDOM"), events)
+        assertEquals(listOf("EMOTION_RANGE", "SEMANTIC", "NEED", "RELAXED", "RANDOM"), events)
         assertEquals((1L..10L).toList(), result.map { candidate -> candidate.quoteId })
     }
 
     @Test
-    fun `need emotion fallback은 해당 타입 effectiveTag만 전달한다`() {
+    fun `need fallback은 need effectiveTag만 전달한다`() {
         val provider = FakeRecommendationCandidateProvider(randomCandidates = (1L..10L).map(::candidate))
         val service = RecommendationFallbackService(provider)
 
         service.supplementCandidates(
+            input = recommendationInput(),
             effectiveTags = effectiveTags,
             existingCandidates = emptyList(),
         )
 
-        assertEquals(listOf(TagType.NEED), provider.capturedTypes[0])
-        assertEquals(listOf(TagType.EMOTION), provider.capturedTypes[1])
+        assertEquals(listOf(TagType.NEED), provider.capturedTypes.single())
     }
 
     @Test
@@ -106,13 +113,17 @@ class RecommendationFallbackServiceTest {
 
         val result =
             service.supplementCandidates(
+                input = recommendationInput(),
                 effectiveTags = effectiveTags,
                 existingCandidates = existingCandidates,
                 rankedQuotes = listOf(rankedQuote(existingCandidates.first(), finalScore = LOW_SCORE)),
             )
 
-        assertEquals(listOf("NEED", "EMOTION", "RELAXED", "RANDOM"), provider.calls)
-        assertEquals((1L..14L).toList(), result.map { candidate -> candidate.quoteId })
+        assertEquals(listOf("EMOTION_RANGE", "NEED", "RELAXED", "RANDOM"), provider.calls)
+        assertEquals(
+            listOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 12L, 11L, 13L, 14L),
+            result.map { candidate -> candidate.quoteId },
+        )
     }
 
     private class FakeRecommendationCandidateProvider(
@@ -149,6 +160,15 @@ class RecommendationFallbackServiceTest {
             }
         }
 
+        override fun findCandidatesByEmotionRangeId(
+            emotionRangeId: Long,
+            limit: Int,
+        ): List<RecommendationCandidate> {
+            record("EMOTION_RANGE")
+
+            return emotionCandidates
+        }
+
         override fun findRelaxedCandidates(limit: Int): List<RecommendationCandidate> {
             record("RELAXED")
 
@@ -171,6 +191,9 @@ class RecommendationFallbackServiceTest {
 
     private companion object {
         const val BOOK_ID = 100L
+        const val USER_ID = 1L
+        const val EMOTION_VALUE = 1
+        const val EMOTION_RANGE_ID = 1L
         const val NEED_TAG_ID = 101L
         const val EMOTION_TAG_ID = 201L
         const val CONTEXT_TAG_ID = 301L
@@ -182,6 +205,18 @@ class RecommendationFallbackServiceTest {
                 effectiveTag(NEED_TAG_ID, TagType.NEED),
                 effectiveTag(EMOTION_TAG_ID, TagType.EMOTION),
                 effectiveTag(CONTEXT_TAG_ID, TagType.CONTEXT),
+            )
+
+        fun recommendationInput(): RecommendationInput =
+            RecommendationInput(
+                userId = USER_ID,
+                emotionValue = EMOTION_VALUE,
+                emotionRangeId = EMOTION_RANGE_ID,
+                emotionTags = emptyList(),
+                needTag = null,
+                feelingText = null,
+                diaryText = null,
+                analysis = null,
             )
 
         fun effectiveTag(

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
@@ -74,7 +74,7 @@ class RecommendationResultComposerTest {
                 moodTagIdByCode = emptyMap(),
             )
 
-        assertEquals(listOf("NEED", "EMOTION", "RELAXED", "RANDOM"), provider.calls)
+        assertEquals(listOf("EMOTION_RANGE", "NEED", "RELAXED", "RANDOM"), provider.calls)
         assertEquals((1L..10L).toList(), result?.quotes?.map { quote -> quote.quoteId })
         assertEquals(RecommendationCandidateSource.PRIMARY, result?.quotes?.first()?.source)
         assertEquals(RecommendationCandidateSource.FALLBACK_RANDOM, result?.quotes?.last()?.source)
@@ -153,6 +153,15 @@ class RecommendationResultComposerTest {
             limit: Int,
         ): List<RecommendationCandidate> {
             calls.add(effectiveTags.firstOrNull()?.type?.name ?: "EMPTY")
+
+            return emptyList()
+        }
+
+        override fun findCandidatesByEmotionRangeId(
+            emotionRangeId: Long,
+            limit: Int,
+        ): List<RecommendationCandidate> {
+            calls.add("EMOTION_RANGE")
 
             return emptyList()
         }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseOutputParserTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseOutputParserTest.kt
@@ -88,12 +88,11 @@ class UserInputParseOutputParserTest {
     }
 
     @Test
-    fun `지원하지 않는 tagType이나 낮은 confidence 후보는 제외한다`() {
+    fun `지원하지 않는 tagType 후보는 제외한다`() {
         val result =
             outputParser.parse(
                 outputText(
                     candidate("MOOD_CALM", TagType.MOOD),
-                    candidate("CONTEXT_RAIN", TagType.CONTEXT, confidence = 0.1),
                 ),
                 input,
                 tagGroups,
@@ -155,15 +154,13 @@ class UserInputParseOutputParserTest {
         fun candidate(
             code: String,
             type: TagType,
-            confidence: Double = 0.9,
         ): Pair<TagType, String> =
             type to
                 """
                 {
                   "tagCode": "$code",
                   "source": "FEELING_TEXT",
-                  "priority": "PRIMARY",
-                  "confidence": $confidence
+                  "priority": "PRIMARY"
                 }
                 """.trimIndent()
 

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchemaTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/UserInputParseSchemaTest.kt
@@ -30,14 +30,15 @@ class UserInputParseSchemaTest {
             required.containsAll(
                 listOf(
                     "canonicalIntent",
-                    "emotionTagCandidates",
                     "needTagCandidates",
                     "situationTagCandidates",
                     "contextTagCandidates",
                     "roleTagCandidates",
+                    "emotionTagCandidates",
                 ),
             ),
         )
+        assertTrue(required.indexOf("roleTagCandidates") < required.indexOf("emotionTagCandidates"))
         assertFalse(required.contains("intentType"))
         assertFalse(required.contains("tagCandidates"))
         assertFalse(required.contains("quoteId"))
@@ -51,6 +52,7 @@ class UserInputParseSchemaTest {
         assertTrue(schema.contains("EMOTION_CODE"))
         assertTrue(schema.contains("needTagCandidates"))
         assertTrue(schema.contains("NEED_CODE"))
+        assertTrue(schema.indexOf("NEED_CODE") < schema.indexOf("EMOTION_CODE"))
     }
 
     @Test
@@ -69,15 +71,30 @@ class UserInputParseSchemaTest {
         assertTrue(priorityEnum.contains("PRIMARY"))
     }
 
+    @Test
+    fun `tag candidate schema는 confidence를 요구하지 않는다`() {
+        val itemSchema = itemSchemaOf("needTagCandidates")
+        val required = itemSchema["required"] as List<*>
+        val properties = itemSchema["properties"] as Map<*, *>
+
+        assertFalse(required.contains("confidence"))
+        assertFalse(properties.containsKey("confidence"))
+    }
+
     private fun priorityEnumOf(fieldName: String): List<*> {
-        val schemaBody = userInputParseSchema(tagGroups)["schema"] as Map<*, *>
-        val properties = schemaBody["properties"] as Map<*, *>
-        val candidateSchema = properties[fieldName] as Map<*, *>
-        val itemSchema = candidateSchema["items"] as Map<*, *>
+        val itemSchema = itemSchemaOf(fieldName)
         val itemProperties = itemSchema["properties"] as Map<*, *>
         val prioritySchema = itemProperties["priority"] as Map<*, *>
 
         return prioritySchema["enum"] as List<*>
+    }
+
+    private fun itemSchemaOf(fieldName: String): Map<*, *> {
+        val schemaBody = userInputParseSchema(tagGroups)["schema"] as Map<*, *>
+        val properties = schemaBody["properties"] as Map<*, *>
+        val candidateSchema = properties[fieldName] as Map<*, *>
+
+        return candidateSchema["items"] as Map<*, *>
     }
 
     private companion object {


### PR DESCRIPTION
- emotionRangeId 에 속한 emotionTag 만 보내고, confidence 제거 
- emotion range → semantic → need → relaxed → metadata random 로 fallback 수정