### PR TITLE
feat: 발견탭 문장 감정 응답 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
@@ -15,6 +15,8 @@ data class DiscoveryQuoteResponse(
     val bookId: Long,
     @field:Schema(description = "이 문장을 추천받은 사용자 ID", example = "1")
     val recommendedUserId: Long,
+    @field:Schema(description = "이 문장을 추천받은 사용자 닉네임", example = "첫번째펭귄")
+    val recommendedUserNickname: String,
     @field:Schema(description = "문장 내용", example = "새는 알에서 나오려고 투쟁한다.")
     val content: String,
     @field:Schema(description = "책 제목", example = "데미안")
@@ -50,6 +52,7 @@ data class DiscoveryQuoteResponse(
                 quoteId = quote.quoteId,
                 bookId = quote.bookId,
                 recommendedUserId = quote.recommendedUserId,
+                recommendedUserNickname = quote.recommendedUserNickname,
                 content = quote.content,
                 title = quote.title,
                 author = quote.author,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
@@ -3,6 +3,7 @@ package com.firstpenguin.app.domain.discovery.dto
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.firstpenguin.app.domain.discovery.model.DiscoveryNeedTag
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuote
+import com.firstpenguin.app.domain.emotion.model.EmotionLevel
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -26,6 +27,17 @@ data class DiscoveryQuoteResponse(
     val genre: String?,
     @field:Schema(description = "추천 당시 선택한 NEED 태그. 선택 태그가 없으면 null", nullable = true)
     val needTag: DiscoveryNeedTagResponse?,
+    @field:Schema(
+        description =
+            "추천 당시 입력한 감정 단계. " +
+                "1=아주 별로에요, 2=별로에요, 3=약간 별로에요, 4=그저그래요, 5=나쁘지 않아요, " +
+                "6=꽤 괜찮아요, 7=약간 기분 좋아요, 8=기분 좋아요, 9=아주 기분 좋아요!",
+        example = "7",
+        allowableValues = ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    )
+    val emotionValue: Int,
+    @field:Schema(description = "추천 당시 입력한 감정 단계 표시 문구", example = "약간 기분 좋아요")
+    val emotionLabel: String,
     @field:Schema(description = "문장이 추천 이력에 등록된 시각", example = "2026-06-05T12:34:56")
     val recommendedAt: LocalDateTime,
     @get:JsonProperty("isScrapped")
@@ -44,6 +56,8 @@ data class DiscoveryQuoteResponse(
                 bookCoverImageUrl = quote.bookCoverImageUrl,
                 genre = quote.genre,
                 needTag = quote.needTag?.let(DiscoveryNeedTagResponse::from),
+                emotionValue = quote.emotionValue,
+                emotionLabel = EmotionLevel.from(quote.emotionValue).label,
                 recommendedAt = quote.recommendedAt,
                 isScrapped = quote.isScrapped,
             )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
@@ -12,6 +12,7 @@ data class DiscoveryQuote(
     val bookCoverImageUrl: String,
     val genre: String?,
     val needTag: DiscoveryNeedTag?,
+    val emotionValue: Int,
     val recommendedAt: LocalDateTime,
     val isScrapped: Boolean,
     val scrapCount: Int,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuote.kt
@@ -6,6 +6,7 @@ data class DiscoveryQuote(
     val quoteId: Long,
     val bookId: Long,
     val recommendedUserId: Long,
+    val recommendedUserNickname: String,
     val content: String,
     val title: String,
     val author: String,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
@@ -14,6 +14,7 @@ import com.firstpenguin.app.domain.quote.repository.QuoteTable
 import com.firstpenguin.app.domain.recommendation.repository.table.RecommendationQuoteTable
 import com.firstpenguin.app.domain.recommendation.repository.table.RecommendationTable
 import com.firstpenguin.app.domain.recommendation.repository.table.RecommendationTagTable
+import com.firstpenguin.app.domain.user.repository.UserTable
 import com.firstpenguin.app.global.enums.TagType
 import org.jooq.Condition
 import org.jooq.DSLContext
@@ -83,6 +84,8 @@ class DiscoveryRepository(
     ) = dsl
         .select(discoveryQuoteFields(rankedRecommendationEvents, needTags, scrapCount))
         .from(rankedRecommendationEvents)
+        .join(UserTable.USERS)
+        .on(UserTable.ID.eq(recommendedUserId(rankedRecommendationEvents)))
         .join(QuoteTable.QUOTES)
         .on(QuoteTable.ID.eq(recommendedQuoteId(rankedRecommendationEvents)))
         .join(BookTable.BOOKS)
@@ -224,6 +227,7 @@ class DiscoveryRepository(
             quoteId = record.get(QuoteTable.ID),
             bookId = record.get(BookTable.ID),
             recommendedUserId = record.get(RECOMMENDED_USER_ID_FIELD),
+            recommendedUserNickname = record.get(UserTable.NICKNAME),
             content = record.get(QuoteTable.CONTENT),
             title = record.get(BookTable.TITLE),
             author = record.get(BookTable.AUTHOR),
@@ -313,6 +317,7 @@ class DiscoveryRepository(
             QuoteTable.ID,
             BookTable.ID,
             recommendedUserId(rankedRecommendationEvents),
+            UserTable.NICKNAME,
             QuoteTable.CONTENT,
             BookTable.TITLE,
             BookTable.AUTHOR,
@@ -332,7 +337,10 @@ class DiscoveryRepository(
 
     private fun recommendedUserId(table: Table<*>): Field<Long> = table.field(RECOMMENDED_USER_ID, Long::class.java)!!
 
-    private fun recommendedEmotionValue(table: Table<*>): Field<Int> = table.field(RECOMMENDED_EMOTION_VALUE, Int::class.java)!!
+    private fun recommendedEmotionValue(table: Table<*>): Field<Int> {
+        val fieldName = RECOMMENDED_EMOTION_VALUE
+        return table.field(fieldName, Int::class.java)!!
+    }
 
     private fun at(table: Table<*>): Field<LocalDateTime> = table.field(RECOMMENDED_AT, LocalDateTime::class.java)!!
 

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepository.kt
@@ -230,6 +230,7 @@ class DiscoveryRepository(
             bookCoverImageUrl = record.get(BookTable.COVER_IMAGE_URL),
             genre = record.get(BookTable.CATEGORY),
             needTag = toNeedTag(record),
+            emotionValue = record.get(RECOMMENDED_EMOTION_VALUE_FIELD),
             recommendedAt = record.get(RECOMMENDED_AT_FIELD),
             isScrapped = record.get(IS_SCRAPPED_FIELD),
             scrapCount = record.get(SCRAP_COUNT_FIELD),
@@ -249,6 +250,7 @@ class DiscoveryRepository(
                 RecommendationTable.ID.`as`(RECOMMENDATION_ID),
                 RecommendationTable.QUOTE_ID.`as`(RECOMMENDED_QUOTE_ID),
                 RecommendationTable.USER_ID.`as`(RECOMMENDED_USER_ID),
+                RecommendationTable.EMOTION_VALUE.`as`(RECOMMENDED_EMOTION_VALUE),
                 RecommendationTable.CREATED_AT.`as`(RECOMMENDED_AT),
             ).from(RecommendationTable.RECOMMENDATIONS)
             .unionAll(
@@ -257,6 +259,7 @@ class DiscoveryRepository(
                         RecommendationQuoteTable.RECOMMENDATION_ID.`as`(RECOMMENDATION_ID),
                         RecommendationQuoteTable.QUOTE_ID.`as`(RECOMMENDED_QUOTE_ID),
                         RecommendationTable.USER_ID.`as`(RECOMMENDED_USER_ID),
+                        RecommendationTable.EMOTION_VALUE.`as`(RECOMMENDED_EMOTION_VALUE),
                         RecommendationQuoteTable.CREATED_AT.`as`(RECOMMENDED_AT),
                     ).from(RecommendationQuoteTable.RECOMMENDATION_QUOTES)
                     .join(RecommendationTable.RECOMMENDATIONS)
@@ -269,6 +272,7 @@ class DiscoveryRepository(
                 recommendationId(recommendationEvents),
                 recommendedQuoteId(recommendationEvents),
                 recommendedUserId(recommendationEvents),
+                recommendedEmotionValue(recommendationEvents),
                 at(recommendationEvents),
                 DSL
                     .rowNumber()
@@ -316,6 +320,7 @@ class DiscoveryRepository(
             BookTable.CATEGORY,
             needTagId(needTags),
             needTagLabel(needTags),
+            recommendedEmotionValue(rankedRecommendationEvents),
             at(rankedRecommendationEvents),
             IS_SCRAPPED_FIELD,
             scrapCount,
@@ -326,6 +331,8 @@ class DiscoveryRepository(
     private fun recommendedQuoteId(table: Table<*>): Field<Long> = table.field(RECOMMENDED_QUOTE_ID, Long::class.java)!!
 
     private fun recommendedUserId(table: Table<*>): Field<Long> = table.field(RECOMMENDED_USER_ID, Long::class.java)!!
+
+    private fun recommendedEmotionValue(table: Table<*>): Field<Int> = table.field(RECOMMENDED_EMOTION_VALUE, Int::class.java)!!
 
     private fun at(table: Table<*>): Field<LocalDateTime> = table.field(RECOMMENDED_AT, LocalDateTime::class.java)!!
 
@@ -355,6 +362,7 @@ class DiscoveryRepository(
         const val RECOMMENDATION_ID = "recommendation_id"
         const val RECOMMENDED_QUOTE_ID = "quote_id"
         const val RECOMMENDED_USER_ID = "recommended_user_id"
+        const val RECOMMENDED_EMOTION_VALUE = "emotion_value"
         const val RECOMMENDED_AT = "recommended_at"
         const val RECOMMENDATION_RANK = "recommendation_rank"
         const val NEED_TAG_RECOMMENDATION_ID = "need_tag_recommendation_id"
@@ -366,6 +374,7 @@ class DiscoveryRepository(
         const val LATEST_RECOMMENDATION_RANK = 1
 
         val RECOMMENDED_USER_ID_FIELD: Field<Long> = DSL.field(RECOMMENDED_USER_ID, Long::class.java)
+        val RECOMMENDED_EMOTION_VALUE_FIELD: Field<Int> = DSL.field(RECOMMENDED_EMOTION_VALUE, Int::class.java)
         val RECOMMENDED_AT_FIELD: Field<LocalDateTime> = DSL.field(RECOMMENDED_AT, LocalDateTime::class.java)
         val NEED_TAG_ID_FIELD: Field<Long> = DSL.field(NEED_TAG_ID, Long::class.java)
         val NEED_TAG_LABEL_FIELD: Field<String> = DSL.field(NEED_TAG_LABEL, String::class.java)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/model/EmotionLevel.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/model/EmotionLevel.kt
@@ -1,0 +1,23 @@
+package com.firstpenguin.app.domain.emotion.model
+
+enum class EmotionLevel(
+    val value: Int,
+    val label: String,
+) {
+    VERY_BAD(1, "아주 별로에요"),
+    BAD(2, "별로에요"),
+    SLIGHTLY_BAD(3, "약간 별로에요"),
+    SO_SO(4, "그저그래요"),
+    NOT_BAD(5, "나쁘지 않아요"),
+    PRETTY_GOOD(6, "꽤 괜찮아요"),
+    SLIGHTLY_HAPPY(7, "약간 기분 좋아요"),
+    HAPPY(8, "기분 좋아요"),
+    VERY_HAPPY(9, "아주 기분 좋아요!"),
+    ;
+
+    companion object {
+        fun from(value: Int): EmotionLevel =
+            entries.find { it.value == value }
+                ?: throw IllegalArgumentException("Invalid emotion value: $value")
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/model/EmotionLevel.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/emotion/model/EmotionLevel.kt
@@ -1,5 +1,6 @@
 package com.firstpenguin.app.domain.emotion.model
 
+@Suppress("MagicNumber")
 enum class EmotionLevel(
     val value: Int,
     val label: String,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
@@ -39,6 +39,7 @@ class DiscoveryRepositoryTest {
         assertFalse(normalizedSql.contains("daily_recommendation_quotes"), normalizedSql)
         assertFalse(normalizedSql.contains("daily_recommendation_id"), normalizedSql)
         assertTrue(normalizedSql.contains("recommended_user_id"), normalizedSql)
+        assertTrue(normalizedSql.contains("emotion_value"), normalizedSql)
         assertTrue(normalizedSql.contains("recommended_at"), normalizedSql)
         assertTrue(normalizedSql.contains("quote_scraps"), normalizedSql)
         assertTrue(normalizedSql.contains("is_scrapped"), normalizedSql)
@@ -231,6 +232,7 @@ class DiscoveryRepositoryTest {
                 BookTable.CATEGORY,
                 DSL.field("need_tag_id", Long::class.java),
                 DSL.field("need_tag_label", String::class.java),
+                DSL.field("emotion_value", Int::class.java),
                 DSL.field("recommended_at", LocalDateTime::class.java),
                 QuoteScrapTable.ID.isNotNull.`as`("is_scrapped"),
                 DSL.field("scrap_count", Int::class.java),

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/repository/DiscoveryRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchCursor
 import com.firstpenguin.app.domain.discovery.model.DiscoveryQuoteSearchSort
 import com.firstpenguin.app.domain.quote.repository.QuoteScrapTable
 import com.firstpenguin.app.domain.quote.repository.QuoteTable
+import com.firstpenguin.app.domain.user.repository.UserTable
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.SQLDialect
@@ -39,6 +40,8 @@ class DiscoveryRepositoryTest {
         assertFalse(normalizedSql.contains("daily_recommendation_quotes"), normalizedSql)
         assertFalse(normalizedSql.contains("daily_recommendation_id"), normalizedSql)
         assertTrue(normalizedSql.contains("recommended_user_id"), normalizedSql)
+        assertTrue(normalizedSql.contains("join \"users\""), normalizedSql)
+        assertTrue(normalizedSql.contains("\"users\".\"nickname\""), normalizedSql)
         assertTrue(normalizedSql.contains("emotion_value"), normalizedSql)
         assertTrue(normalizedSql.contains("recommended_at"), normalizedSql)
         assertTrue(normalizedSql.contains("quote_scraps"), normalizedSql)
@@ -225,6 +228,7 @@ class DiscoveryRepositoryTest {
                 QuoteTable.ID,
                 BookTable.ID,
                 DSL.field("recommended_user_id", Long::class.java),
+                UserTable.NICKNAME,
                 QuoteTable.CONTENT,
                 BookTable.TITLE,
                 BookTable.AUTHOR,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
@@ -40,6 +40,8 @@ class DiscoveryUseCaseTest {
         assertEquals(1, response.quotes.size)
         assertEquals(RECOMMENDED_USER_ID, response.quotes.first().recommendedUserId)
         assertEquals(RECOMMENDED_AT, response.quotes.first().recommendedAt)
+        assertEquals(EMOTION_VALUE, response.quotes.first().emotionValue)
+        assertEquals(EMOTION_LABEL, response.quotes.first().emotionLabel)
         assertEquals(GENRE, response.quotes.first().genre)
         assertEquals(
             NEED_TAG_ID,
@@ -302,6 +304,7 @@ class DiscoveryUseCaseTest {
             bookCoverImageUrl = "https://cdn.example.com/book-cover-placeholder.png",
             genre = GENRE,
             needTag = DiscoveryNeedTag(NEED_TAG_ID, NEED_TAG_LABEL),
+            emotionValue = EMOTION_VALUE,
             recommendedAt = RECOMMENDED_AT,
             isScrapped = isScrapped,
             scrapCount = scrapCount,
@@ -331,6 +334,8 @@ class DiscoveryUseCaseTest {
         const val NEED_TAG_ID = 49L
         const val NEED_TAG_LABEL = "공감해주는 문장"
         const val GENRE = "한국소설"
+        const val EMOTION_VALUE = 7
+        const val EMOTION_LABEL = "약간 기분 좋아요"
         const val SEARCH_QUERY = "새"
         const val SCRAP_COUNT = 3
         val RECOMMENDED_AT: LocalDateTime = LocalDateTime.of(2026, 6, 5, 12, 34, 56)

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
@@ -39,6 +39,7 @@ class DiscoveryUseCaseTest {
 
         assertEquals(1, response.quotes.size)
         assertEquals(RECOMMENDED_USER_ID, response.quotes.first().recommendedUserId)
+        assertEquals(RECOMMENDED_USER_NICKNAME, response.quotes.first().recommendedUserNickname)
         assertEquals(RECOMMENDED_AT, response.quotes.first().recommendedAt)
         assertEquals(EMOTION_VALUE, response.quotes.first().emotionValue)
         assertEquals(EMOTION_LABEL, response.quotes.first().emotionLabel)
@@ -298,6 +299,7 @@ class DiscoveryUseCaseTest {
             quoteId = quoteId,
             bookId = BOOK_ID,
             recommendedUserId = RECOMMENDED_USER_ID,
+            recommendedUserNickname = RECOMMENDED_USER_NICKNAME,
             content = "새는 알에서 나오려고 투쟁한다.",
             title = "데미안",
             author = "헤르만 헤세",
@@ -331,6 +333,7 @@ class DiscoveryUseCaseTest {
         const val QUOTE_ID = 10L
         const val BOOK_ID = 100L
         const val RECOMMENDED_USER_ID = 200L
+        const val RECOMMENDED_USER_NICKNAME = "문장수집가"
         const val NEED_TAG_ID = 49L
         const val NEED_TAG_LABEL = "공감해주는 문장"
         const val GENRE = "한국소설"

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/emotion/model/EmotionLevelTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/emotion/model/EmotionLevelTest.kt
@@ -1,0 +1,29 @@
+package com.firstpenguin.app.domain.emotion.model
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class EmotionLevelTest {
+    @Test
+    fun `감정 단계 값으로 표시 문구를 조회한다`() {
+        val labels =
+            (1..9).map { value ->
+                EmotionLevel.from(value).label
+            }
+
+        assertEquals(
+            listOf(
+                "아주 별로에요",
+                "별로에요",
+                "약간 별로에요",
+                "그저그래요",
+                "나쁘지 않아요",
+                "꽤 괜찮아요",
+                "약간 기분 좋아요",
+                "기분 좋아요",
+                "아주 기분 좋아요!",
+            ),
+            labels,
+        )
+    }
+}


### PR DESCRIPTION
## 📢 요약
- 발견탭 문장 응답(`DiscoveryQuoteResponse`)에 추천 당시 감정 단계 값/표시 문구와 추천 사용자 닉네임을 추가했습니다.
- `recommendations.emotion_value`와 `users.nickname`을 발견탭 목록/문장 검색 조회 경로에 포함했습니다.
- `EmotionLevel` enum으로 1~9 감정 단계와 표시 문구를 서버에서 관리하도록 했습니다.

🔗 연관 이슈: Resolves #172

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
응답 필드 예시:

```json
{
  "recommendedUserId": 200,
  "recommendedUserNickname": "문장수집가",
  "emotionValue": 7,
  "emotionLabel": "약간 기분 좋아요"
}
```

검증:
- `./gradlew test` 통과
- `./gradlew detekt` 통과
- pre-push hook: `./gradlew test` 통과

## 📜 기타
- 프론트는 추천 사용자 표시에는 `recommendedUserNickname`을 사용하면 됩니다.
- 감정 단계/아이콘/색상 분기는 `emotionValue`, 화면 표시 문구는 `emotionLabel`을 사용하면 됩니다.
