### PR TITLE
refactor: 발견탭 감정 응답 구조 객체화

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/dto/DiscoveryQuoteResponse.kt
@@ -29,17 +29,8 @@ data class DiscoveryQuoteResponse(
     val genre: String?,
     @field:Schema(description = "추천 당시 선택한 NEED 태그. 선택 태그가 없으면 null", nullable = true)
     val needTag: DiscoveryNeedTagResponse?,
-    @field:Schema(
-        description =
-            "추천 당시 입력한 감정 단계. " +
-                "1=아주 별로에요, 2=별로에요, 3=약간 별로에요, 4=그저그래요, 5=나쁘지 않아요, " +
-                "6=꽤 괜찮아요, 7=약간 기분 좋아요, 8=기분 좋아요, 9=아주 기분 좋아요!",
-        example = "7",
-        allowableValues = ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
-    )
-    val emotionValue: Int,
-    @field:Schema(description = "추천 당시 입력한 감정 단계 표시 문구", example = "약간 기분 좋아요")
-    val emotionLabel: String,
+    @field:Schema(description = "추천 당시 입력한 감정 단계")
+    val emotion: DiscoveryEmotionResponse,
     @field:Schema(description = "문장이 추천 이력에 등록된 시각", example = "2026-06-05T12:34:56")
     val recommendedAt: LocalDateTime,
     @get:JsonProperty("isScrapped")
@@ -59,10 +50,32 @@ data class DiscoveryQuoteResponse(
                 bookCoverImageUrl = quote.bookCoverImageUrl,
                 genre = quote.genre,
                 needTag = quote.needTag?.let(DiscoveryNeedTagResponse::from),
-                emotionValue = quote.emotionValue,
-                emotionLabel = EmotionLevel.from(quote.emotionValue).label,
+                emotion = DiscoveryEmotionResponse.from(EmotionLevel.from(quote.emotionValue)),
                 recommendedAt = quote.recommendedAt,
                 isScrapped = quote.isScrapped,
+            )
+    }
+}
+
+@Schema(description = "추천 당시 입력한 감정 단계 응답")
+data class DiscoveryEmotionResponse(
+    @field:Schema(
+        description =
+            "추천 당시 입력한 감정 단계 값. " +
+                "1=아주 별로에요, 2=별로에요, 3=약간 별로에요, 4=그저그래요, 5=나쁘지 않아요, " +
+                "6=꽤 괜찮아요, 7=약간 기분 좋아요, 8=기분 좋아요, 9=아주 기분 좋아요!",
+        example = "7",
+        allowableValues = ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    )
+    val value: Int,
+    @field:Schema(description = "추천 당시 입력한 감정 단계 표시 문구", example = "약간 기분 좋아요")
+    val label: String,
+) {
+    companion object {
+        fun from(emotionLevel: EmotionLevel): DiscoveryEmotionResponse =
+            DiscoveryEmotionResponse(
+                value = emotionLevel.value,
+                label = emotionLevel.label,
             )
     }
 }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
@@ -41,8 +41,18 @@ class DiscoveryUseCaseTest {
         assertEquals(RECOMMENDED_USER_ID, response.quotes.first().recommendedUserId)
         assertEquals(RECOMMENDED_USER_NICKNAME, response.quotes.first().recommendedUserNickname)
         assertEquals(RECOMMENDED_AT, response.quotes.first().recommendedAt)
-        assertEquals(EMOTION_VALUE, response.quotes.first().emotionValue)
-        assertEquals(EMOTION_LABEL, response.quotes.first().emotionLabel)
+        assertEquals(
+            EMOTION_VALUE,
+            response.quotes
+                .first()
+                .emotion.value,
+        )
+        assertEquals(
+            EMOTION_LABEL,
+            response.quotes
+                .first()
+                .emotion.label,
+        )
         assertEquals(GENRE, response.quotes.first().genre)
         assertEquals(
             NEED_TAG_ID,


### PR DESCRIPTION
## 📢 요약
- 발견탭 문장 응답의 감정 필드를 `emotionValue`, `emotionLabel` flat 구조에서 `emotion.value`, `emotion.label` 객체 구조로 변경했습니다.
- `needTag`처럼 관련 값을 하나의 응답 객체로 묶어 프론트에서 감정 값을 일관되게 다룰 수 있도록 했습니다.

🔗 연관 이슈: Related #172

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] 문서 업데이트

## 📸 스크린샷 / 테스트 결과
응답 필드 예시:

```json
{
  "emotion": {
    "value": 1,
    "label": "아주 별로에요"
  }
}
```

검증:
- `./gradlew test` 통과
- `./gradlew detekt` 통과
- pre-push hook: `./gradlew test` 통과

## 📜 기타
- 기존 `emotionValue`, `emotionLabel` 응답 필드는 제거되고 `emotion.value`, `emotion.label`로 대체됩니다.
