### PR TITLE
feat: 회원 탈퇴 요청 기능 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/service/RefreshTokenService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/service/RefreshTokenService.kt
@@ -36,7 +36,7 @@ class RefreshTokenService(
         val storedToken = findStoredTokenOrDeleteAll(refreshToken, claims.userId)
         validateStoredToken(storedToken.id, storedToken.expiresAt)
 
-        val user = userService.getById(claims.userId)
+        val user = userService.getAuthenticatableById(claims.userId)
         val newRefreshToken = jwtTokenProvider.createRefreshToken(user.id)
         refreshTokenRepository.updateToken(
             id = storedToken.id,
@@ -52,6 +52,10 @@ class RefreshTokenService(
 
     fun logout(refreshToken: String) {
         refreshTokenRepository.deleteByTokenHash(jwtTokenProvider.hash(refreshToken))
+    }
+
+    fun logoutAll(userId: Long) {
+        refreshTokenRepository.deleteByUserId(userId)
     }
 
     private fun findStoredTokenOrDeleteAll(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/controller/UserController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/controller/UserController.kt
@@ -1,6 +1,7 @@
 package com.firstpenguin.app.domain.user.controller
 
 import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
+import com.firstpenguin.app.domain.auth.token.RefreshTokenCookieManager
 import com.firstpenguin.app.domain.user.dto.UpdateUserRequest
 import com.firstpenguin.app.domain.user.dto.UserResponse
 import com.firstpenguin.app.domain.user.usecase.UserUseCase
@@ -13,8 +14,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -25,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/users")
 @Tag(name = "사용자", description = "로그인한 사용자 정보 API")
 class UserController(
+    private val refreshTokenCookieManager: RefreshTokenCookieManager,
     private val userUseCase: UserUseCase,
 ) {
     @GetMapping("/me")
@@ -110,6 +115,38 @@ class UserController(
         @RequestBody request: UpdateUserRequest,
     ): UserResponse = userUseCase.updateMe(authenticatedUser.id, request)
 
+    @DeleteMapping("/me")
+    @Operation(
+        summary = "회원 탈퇴 요청",
+        description = WITHDRAW_ME_DESCRIPTION,
+        security = [SecurityRequirement(name = "bearerAuth")],
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "회원 탈퇴 요청 성공. refresh token 쿠키가 만료됩니다."),
+            ApiResponse(
+                responseCode = "401",
+                description = "access token이 없거나, 만료되었거나, 유효하지 않습니다.",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ErrorResponse::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun withdrawMe(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
+    ): ResponseEntity<Unit> {
+        userUseCase.withdrawMe(authenticatedUser.id)
+        return ResponseEntity
+            .noContent()
+            .header(HttpHeaders.SET_COOKIE, refreshTokenCookieManager.expire().toString())
+            .build()
+    }
+
     private companion object {
         const val ME_DESCRIPTION =
             "Authorization 헤더에 `Bearer {accessToken}` 형식으로 access token을 담아 호출합니다. " +
@@ -121,5 +158,10 @@ class UserController(
                 "nickname, profileImageId 중 하나 이상은 반드시 포함해야 합니다. " +
                 "생략하거나 null인 필드는 변경하지 않습니다. 프로필 이미지 제거(null로 초기화)는 현재 미지원입니다. " +
                 "profileImageId는 `POST /images/presigned-url`로 발급받은 imageId를 사용합니다."
+
+        const val WITHDRAW_ME_DESCRIPTION =
+            "회원 탈퇴를 요청하고 현재 사용자의 모든 refresh token을 삭제합니다. " +
+                "탈퇴 요청 후 30일 동안 같은 OAuth 계정으로 로그인하면 탈퇴 요청이 자동 취소됩니다. " +
+                "30일 이후 탈퇴 확정 처리는 별도 스케줄러에서 수행합니다."
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/model/User.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/model/User.kt
@@ -7,6 +7,8 @@ data class User(
     val nickname: String,
     val profileImageId: Long?,
     val status: UserStatus,
+    val withdrawalRequestedAt: LocalDateTime?,
+    val withdrawalDueAt: LocalDateTime?,
     val deletedAt: LocalDateTime?,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/model/UserStatus.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/model/UserStatus.kt
@@ -3,5 +3,6 @@ package com.firstpenguin.app.domain.user.model
 enum class UserStatus {
     ACTIVE,
     BLOCKED,
+    WITHDRAWAL_REQUESTED,
     DELETED,
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserRepository.kt
@@ -45,6 +45,37 @@ class UserRepository(
         step.where(UserTable.ID.eq(id)).execute()
     }
 
+    fun requestWithdrawal(
+        id: Long,
+        requestedAt: LocalDateTime,
+        dueAt: LocalDateTime,
+    ): Int =
+        dsl
+            .update(UserTable.USERS)
+            .set(UserTable.STATUS, UserStatus.WITHDRAWAL_REQUESTED.name)
+            .set(UserTable.WITHDRAWAL_REQUESTED_AT, requestedAt)
+            .set(UserTable.WITHDRAWAL_DUE_AT, dueAt)
+            .set(UserTable.UPDATED_AT, requestedAt)
+            .where(UserTable.ID.eq(id))
+            .and(UserTable.STATUS.eq(UserStatus.ACTIVE.name))
+            .execute()
+
+    fun reactivateWithdrawalRequested(
+        id: Long,
+        now: LocalDateTime,
+    ): User? =
+        dsl
+            .update(UserTable.USERS)
+            .set(UserTable.STATUS, UserStatus.ACTIVE.name)
+            .set(UserTable.WITHDRAWAL_REQUESTED_AT, null as LocalDateTime?)
+            .set(UserTable.WITHDRAWAL_DUE_AT, null as LocalDateTime?)
+            .set(UserTable.UPDATED_AT, now)
+            .where(UserTable.ID.eq(id))
+            .and(UserTable.STATUS.eq(UserStatus.WITHDRAWAL_REQUESTED.name))
+            .and(UserTable.WITHDRAWAL_DUE_AT.gt(now))
+            .returningResult(USER_FIELDS)
+            .fetchOne(::toUser)
+
     fun existsByNickname(
         nickname: String,
         excludedUserId: Long,
@@ -64,6 +95,8 @@ class UserRepository(
             nickname = record.get(UserTable.NICKNAME),
             profileImageId = record.get(UserTable.PROFILE_IMAGE_ID),
             status = UserStatus.valueOf(record.get(UserTable.STATUS)),
+            withdrawalRequestedAt = record.get(UserTable.WITHDRAWAL_REQUESTED_AT),
+            withdrawalDueAt = record.get(UserTable.WITHDRAWAL_DUE_AT),
             deletedAt = record.get(UserTable.DELETED_AT),
             createdAt = record.get(UserTable.CREATED_AT),
             updatedAt = record.get(UserTable.UPDATED_AT),
@@ -76,6 +109,8 @@ class UserRepository(
                 UserTable.NICKNAME,
                 UserTable.PROFILE_IMAGE_ID,
                 UserTable.STATUS,
+                UserTable.WITHDRAWAL_REQUESTED_AT,
+                UserTable.WITHDRAWAL_DUE_AT,
                 UserTable.DELETED_AT,
                 UserTable.CREATED_AT,
                 UserTable.UPDATED_AT,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserRepository.kt
@@ -52,10 +52,7 @@ class UserRepository(
     ): Int =
         dsl
             .update(UserTable.USERS)
-            .set(UserTable.STATUS, UserStatus.WITHDRAWAL_REQUESTED.name)
-            .set(UserTable.WITHDRAWAL_REQUESTED_AT, requestedAt)
-            .set(UserTable.WITHDRAWAL_DUE_AT, dueAt)
-            .set(UserTable.UPDATED_AT, requestedAt)
+            .set(withdrawalRequestValues(requestedAt, dueAt))
             .where(UserTable.ID.eq(id))
             .and(UserTable.STATUS.eq(UserStatus.ACTIVE.name))
             .execute()
@@ -66,10 +63,7 @@ class UserRepository(
     ): User? =
         dsl
             .update(UserTable.USERS)
-            .set(UserTable.STATUS, UserStatus.ACTIVE.name)
-            .set(UserTable.WITHDRAWAL_REQUESTED_AT, null as LocalDateTime?)
-            .set(UserTable.WITHDRAWAL_DUE_AT, null as LocalDateTime?)
-            .set(UserTable.UPDATED_AT, now)
+            .set(withdrawalCancelValues(now))
             .where(UserTable.ID.eq(id))
             .and(UserTable.STATUS.eq(UserStatus.WITHDRAWAL_REQUESTED.name))
             .and(UserTable.WITHDRAWAL_DUE_AT.gt(now))
@@ -87,6 +81,25 @@ class UserRepository(
                 .where(UserTable.NICKNAME.eq(nickname))
                 .and(UserTable.ID.ne(excludedUserId))
                 .and(UserTable.DELETED_AT.isNull),
+        )
+
+    private fun withdrawalRequestValues(
+        requestedAt: LocalDateTime,
+        dueAt: LocalDateTime,
+    ): Map<Field<*>, Any?> =
+        mapOf(
+            UserTable.STATUS to UserStatus.WITHDRAWAL_REQUESTED.name,
+            UserTable.WITHDRAWAL_REQUESTED_AT to requestedAt,
+            UserTable.WITHDRAWAL_DUE_AT to dueAt,
+            UserTable.UPDATED_AT to requestedAt,
+        )
+
+    private fun withdrawalCancelValues(now: LocalDateTime): Map<Field<*>, Any?> =
+        mapOf(
+            UserTable.STATUS to UserStatus.ACTIVE.name,
+            UserTable.WITHDRAWAL_REQUESTED_AT to null,
+            UserTable.WITHDRAWAL_DUE_AT to null,
+            UserTable.UPDATED_AT to now,
         )
 
     private fun toUser(record: Record): User =

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserTable.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserTable.kt
@@ -9,6 +9,8 @@ internal object UserTable {
     val NICKNAME = DSL.field(DSL.name("users", "nickname"), String::class.java)
     val PROFILE_IMAGE_ID = DSL.field(DSL.name("users", "profile_image_id"), Long::class.java)
     val STATUS = DSL.field(DSL.name("users", "status"), String::class.java)
+    val WITHDRAWAL_REQUESTED_AT = DSL.field(DSL.name("users", "withdrawal_requested_at"), LocalDateTime::class.java)
+    val WITHDRAWAL_DUE_AT = DSL.field(DSL.name("users", "withdrawal_due_at"), LocalDateTime::class.java)
     val DELETED_AT = DSL.field(DSL.name("users", "deleted_at"), LocalDateTime::class.java)
     val CREATED_AT = DSL.field(DSL.name("users", "created_at"), LocalDateTime::class.java)
     val UPDATED_AT = DSL.field(DSL.name("users", "updated_at"), LocalDateTime::class.java)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/OAuthUserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/OAuthUserService.kt
@@ -48,9 +48,15 @@ class OAuthUserService(
     ): User {
         val account = getActiveOAuthAccount(profile)
         validateOAuthAccountMatchesUser(account, user)
-        validateAuthenticatableStatus(user)
+        val loginUser =
+            if (user.status == UserStatus.WITHDRAWAL_REQUESTED) {
+                userRepository.reactivateWithdrawalRequested(user.id, LocalDateTime.now()) ?: user
+            } else {
+                user
+            }
+        validateAuthenticatableStatus(loginUser)
         updateOAuthAccountLogin(account, profile)
-        return user
+        return loginUser
     }
 
     private fun createOAuthAccount(
@@ -95,6 +101,7 @@ class OAuthUserService(
         when (status) {
             UserStatus.ACTIVE -> null
             UserStatus.BLOCKED -> ErrorCode.AUTH_USER_BLOCKED
+            UserStatus.WITHDRAWAL_REQUESTED -> ErrorCode.AUTH_USER_DELETED
             UserStatus.DELETED -> ErrorCode.AUTH_USER_DELETED
         }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
@@ -42,12 +42,10 @@ class UserService(
     }
 
     fun requestWithdrawal(userId: Long) {
-        val user = getById(userId)
-        validateAuthenticatableStatus(user)
-
+        val user = getAuthenticatableById(userId)
         val now = LocalDateTime.now()
         val updatedCount = userRepository.requestWithdrawal(user.id, now, now.plusDays(WITHDRAWAL_GRACE_DAYS))
-        if (updatedCount == 0) throw CustomException(ErrorCode.USER_NOT_FOUND)
+        if (updatedCount == 0) throw CustomException(ErrorCode.USER_WITHDRAWAL_REQUEST_FAILED)
     }
 
     private fun validateNicknameAvailable(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/service/UserService.kt
@@ -7,12 +7,19 @@ import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 @Service
 class UserService(
     private val userRepository: UserRepository,
 ) {
     fun getById(id: Long): User = userRepository.findById(id) ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+    fun getAuthenticatableById(id: Long): User {
+        val user = userRepository.findById(id) ?: throw CustomException(ErrorCode.AUTH_USER_NOT_FOUND)
+        validateAuthenticatableStatus(user)
+        return user
+    }
 
     fun validateAuthenticatableUser(userId: Long) {
         val user = userRepository.findById(userId) ?: throw CustomException(ErrorCode.AUTH_USER_NOT_FOUND)
@@ -32,6 +39,15 @@ class UserService(
             if (nickname == null) throw e
             throw CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS).also { it.initCause(e) }
         }
+    }
+
+    fun requestWithdrawal(userId: Long) {
+        val user = getById(userId)
+        validateAuthenticatableStatus(user)
+
+        val now = LocalDateTime.now()
+        val updatedCount = userRepository.requestWithdrawal(user.id, now, now.plusDays(WITHDRAWAL_GRACE_DAYS))
+        if (updatedCount == 0) throw CustomException(ErrorCode.USER_NOT_FOUND)
     }
 
     private fun validateNicknameAvailable(
@@ -56,10 +72,12 @@ class UserService(
         when (status) {
             UserStatus.ACTIVE -> null
             UserStatus.BLOCKED -> ErrorCode.AUTH_USER_BLOCKED
+            UserStatus.WITHDRAWAL_REQUESTED -> ErrorCode.AUTH_USER_DELETED
             UserStatus.DELETED -> ErrorCode.AUTH_USER_DELETED
         }
 
     private companion object {
+        const val WITHDRAWAL_GRACE_DAYS = 30L
         val RESERVED_NICKNAMES = setOf("개발자")
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCase.kt
@@ -1,5 +1,6 @@
 package com.firstpenguin.app.domain.user.usecase
 
+import com.firstpenguin.app.domain.auth.service.RefreshTokenService
 import com.firstpenguin.app.domain.image.service.ImageService
 import com.firstpenguin.app.domain.user.dto.UpdateUserRequest
 import com.firstpenguin.app.domain.user.dto.UserResponse
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 class UserUseCase(
     private val imageService: ImageService,
     private val oAuthUserService: OAuthUserService,
+    private val refreshTokenService: RefreshTokenService,
     private val userService: UserService,
 ) {
     @Transactional(readOnly = true)
@@ -36,5 +38,11 @@ class UserUseCase(
         request.profileImageId?.let { imageService.validateExists(it) }
         userService.updateProfile(userId, request.nickname, request.profileImageId)
         return getMe(userId)
+    }
+
+    @Transactional
+    fun withdrawMe(userId: Long) {
+        userService.requestWithdrawal(userId)
+        refreshTokenService.logoutAll(userId)
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/global/exception/ErrorCode.kt
@@ -31,6 +31,7 @@ enum class ErrorCode(
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
     NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다"),
     NICKNAME_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용 가능한 닉네임 생성에 실패했습니다"),
+    USER_WITHDRAWAL_REQUEST_FAILED(HttpStatus.CONFLICT, "회원 탈퇴 요청을 처리할 수 없습니다"),
 
     // Emotion
     EMOTION_RANGE_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 감정 분류가 존재하지 않습니다."),

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/service/RefreshTokenServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/service/RefreshTokenServiceTest.kt
@@ -1,0 +1,96 @@
+package com.firstpenguin.app.domain.auth.service
+
+import com.firstpenguin.app.domain.auth.config.AuthProperties
+import com.firstpenguin.app.domain.auth.model.RefreshToken
+import com.firstpenguin.app.domain.auth.model.TokenClaims
+import com.firstpenguin.app.domain.auth.repository.RefreshTokenRepository
+import com.firstpenguin.app.domain.auth.token.JwtTokenProvider
+import com.firstpenguin.app.domain.user.model.User
+import com.firstpenguin.app.domain.user.model.UserStatus
+import com.firstpenguin.app.domain.user.service.UserService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+class RefreshTokenServiceTest {
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var userService: UserService
+    private lateinit var refreshTokenService: RefreshTokenService
+
+    @BeforeEach
+    fun setUp() {
+        refreshTokenRepository = Mockito.mock(RefreshTokenRepository::class.java)
+        jwtTokenProvider = Mockito.mock(JwtTokenProvider::class.java)
+        userService = Mockito.mock(UserService::class.java)
+        refreshTokenService =
+            RefreshTokenService(
+                refreshTokenRepository,
+                jwtTokenProvider,
+                userService,
+                AuthProperties(),
+            )
+    }
+
+    @Test
+    fun `refresh token 재발급 시 인증 가능한 사용자를 조회한다`() {
+        val user = user()
+        Mockito.`when`(jwtTokenProvider.validateRefreshToken(REFRESH_TOKEN)).thenReturn(TokenClaims(USER_ID))
+        Mockito.`when`(jwtTokenProvider.hash(REFRESH_TOKEN)).thenReturn(OLD_TOKEN_HASH)
+        Mockito.`when`(refreshTokenRepository.findByTokenHash(OLD_TOKEN_HASH)).thenReturn(refreshToken())
+        Mockito.`when`(userService.getAuthenticatableById(USER_ID)).thenReturn(user)
+        Mockito.`when`(jwtTokenProvider.createRefreshToken(USER_ID)).thenReturn(NEW_REFRESH_TOKEN)
+        Mockito.`when`(jwtTokenProvider.hash(NEW_REFRESH_TOKEN)).thenReturn(NEW_TOKEN_HASH)
+        Mockito.`when`(jwtTokenProvider.createAccessToken(user)).thenReturn(ACCESS_TOKEN)
+
+        val tokenPair = refreshTokenService.rotate(REFRESH_TOKEN)
+
+        assertEquals(ACCESS_TOKEN, tokenPair.accessToken)
+        assertEquals(NEW_REFRESH_TOKEN, tokenPair.refreshToken)
+        Mockito.verify(userService).getAuthenticatableById(USER_ID)
+        Mockito.verify(userService, Mockito.never()).getById(USER_ID)
+    }
+
+    private fun refreshToken(): RefreshToken {
+        val now = LocalDateTime.now()
+
+        return RefreshToken(
+            id = REFRESH_TOKEN_ID,
+            userId = USER_ID,
+            deviceId = DEVICE_ID,
+            tokenHash = OLD_TOKEN_HASH,
+            expiresAt = now.plusDays(1),
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    private fun user(): User {
+        val now = LocalDateTime.now()
+
+        return User(
+            id = USER_ID,
+            nickname = "penguin",
+            profileImageId = null,
+            status = UserStatus.ACTIVE,
+            withdrawalRequestedAt = null,
+            withdrawalDueAt = null,
+            deletedAt = null,
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    private companion object {
+        const val REFRESH_TOKEN_ID = 1L
+        const val USER_ID = 10L
+        const val DEVICE_ID = "device-id"
+        const val REFRESH_TOKEN = "refresh-token"
+        const val NEW_REFRESH_TOKEN = "new-refresh-token"
+        const val OLD_TOKEN_HASH = "old-token-hash"
+        const val NEW_TOKEN_HASH = "new-token-hash"
+        const val ACCESS_TOKEN = "access-token"
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/repository/UserRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/repository/UserRepositoryTest.kt
@@ -70,7 +70,7 @@ class UserRepositoryTest {
         assertTrue(normalizedSql.startsWith("""update "users" set"""), normalizedSql)
         assertTrue(normalizedSql.contains("withdrawal_requested_at"), normalizedSql)
         assertTrue(normalizedSql.contains("withdrawal_due_at"), normalizedSql)
-        assertTrue(normalizedSql.contains(""""users"."withdrawal_due_at" > ?"""), normalizedSql)
+        assertTrue(normalizedSql.contains(""""users"."withdrawal_due_at" >"""), normalizedSql)
     }
 
     private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/repository/UserRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/repository/UserRepositoryTest.kt
@@ -41,6 +41,53 @@ class UserRepositoryTest {
         )
     }
 
+    @Test
+    fun `회원 탈퇴 요청은 활성 사용자만 탈퇴 요청 상태로 변경한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                UserRepository(dsl).requestWithdrawal(
+                    USER_ID,
+                    LocalDateTime.now(),
+                    LocalDateTime.now().plusDays(30),
+                )
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.startsWith("""update "users" set"""), normalizedSql)
+        assertTrue(normalizedSql.contains("withdrawal_requested_at"), normalizedSql)
+        assertTrue(normalizedSql.contains("withdrawal_due_at"), normalizedSql)
+        assertTrue(normalizedSql.contains(""""users"."status" = ?"""), normalizedSql)
+    }
+
+    @Test
+    fun `탈퇴 요청 취소는 유예 기간이 지나지 않은 사용자만 활성 상태로 변경한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                UserRepository(dsl).reactivateWithdrawalRequested(USER_ID, LocalDateTime.now())
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.startsWith("""update "users" set"""), normalizedSql)
+        assertTrue(normalizedSql.contains("withdrawal_requested_at"), normalizedSql)
+        assertTrue(normalizedSql.contains("withdrawal_due_at"), normalizedSql)
+        assertTrue(normalizedSql.contains(""""users"."withdrawal_due_at" > ?"""), normalizedSql)
+    }
+
+    private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {
+        var capturedSql = ""
+        lateinit var dsl: DSLContext
+        val connection =
+            MockConnection(
+                MockDataProvider { context ->
+                    capturedSql = context.sql()
+                    arrayOf(MockResult(1, userResult(dsl)))
+                },
+            )
+        dsl = DSL.using(connection, SQLDialect.POSTGRES)
+        repositoryCall(dsl)
+        return capturedSql
+    }
+
     private fun userResult(dsl: DSLContext) =
         dsl.newResult(*USER_FIELDS).apply {
             add(userRecord(dsl))
@@ -54,6 +101,8 @@ class UserRepositoryTest {
             set(UserTable.NICKNAME, USER_NICKNAME)
             set(UserTable.PROFILE_IMAGE_ID, null as Long?)
             set(UserTable.STATUS, UserStatus.ACTIVE.name)
+            set(UserTable.WITHDRAWAL_REQUESTED_AT, null as LocalDateTime?)
+            set(UserTable.WITHDRAWAL_DUE_AT, null as LocalDateTime?)
             set(UserTable.DELETED_AT, null as LocalDateTime?)
             set(UserTable.CREATED_AT, now)
             set(UserTable.UPDATED_AT, now)
@@ -69,6 +118,8 @@ class UserRepositoryTest {
                 UserTable.NICKNAME,
                 UserTable.PROFILE_IMAGE_ID,
                 UserTable.STATUS,
+                UserTable.WITHDRAWAL_REQUESTED_AT,
+                UserTable.WITHDRAWAL_DUE_AT,
                 UserTable.DELETED_AT,
                 UserTable.CREATED_AT,
                 UserTable.UPDATED_AT,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/OAuthUserServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/OAuthUserServiceTest.kt
@@ -121,6 +121,67 @@ class OAuthUserServiceTest {
         )
     }
 
+    @Test
+    fun `탈퇴 요청 사용자는 유예 기간 안에 같은 OAuth 로그인 시 활성 상태로 복구한다`() {
+        val withdrawalUser =
+            user(
+                status = UserStatus.WITHDRAWAL_REQUESTED,
+                withdrawalDueAt = LocalDateTime.now().plusDays(1),
+            )
+        val reactivatedUser =
+            withdrawalUser.copy(
+                status = UserStatus.ACTIVE,
+                withdrawalRequestedAt = null,
+                withdrawalDueAt = null,
+            )
+        Mockito
+            .`when`(oAuthAccountRepository.findActiveByProviderAndProviderId(Provider.KAKAO, PROVIDER_ID))
+            .thenReturn(oAuthAccount())
+        Mockito
+            .`when`(userRepository.reactivateWithdrawalRequested(eqValue(USER_ID), anyDateTime()))
+            .thenReturn(reactivatedUser)
+        Mockito
+            .`when`(
+                oAuthAccountRepository.updateLogin(
+                    eqValue(OAUTH_ACCOUNT_ID),
+                    eqValue(OAUTH_USER_PROFILE),
+                    anyDateTime(),
+                ),
+            ).thenReturn(oAuthAccount())
+
+        val result = oAuthUserService.updateOAuthLogin(withdrawalUser, OAUTH_USER_PROFILE)
+
+        assertEquals(reactivatedUser, result)
+        Mockito.verify(userRepository).reactivateWithdrawalRequested(eqValue(USER_ID), anyDateTime())
+    }
+
+    @Test
+    fun `탈퇴 요청 자동 취소에 실패하면 로그인 정보를 갱신하지 않는다`() {
+        val withdrawalUser =
+            user(
+                status = UserStatus.WITHDRAWAL_REQUESTED,
+                withdrawalDueAt = LocalDateTime.now().minusDays(1),
+            )
+        Mockito
+            .`when`(oAuthAccountRepository.findActiveByProviderAndProviderId(Provider.KAKAO, PROVIDER_ID))
+            .thenReturn(oAuthAccount())
+        Mockito
+            .`when`(userRepository.reactivateWithdrawalRequested(eqValue(USER_ID), anyDateTime()))
+            .thenReturn(null)
+
+        val exception =
+            assertFailsWith<CustomException> {
+                oAuthUserService.updateOAuthLogin(withdrawalUser, OAUTH_USER_PROFILE)
+            }
+
+        assertEquals(ErrorCode.AUTH_USER_DELETED, exception.errorCode)
+        Mockito.verify(oAuthAccountRepository, Mockito.never()).updateLogin(
+            anyLong(),
+            anyOAuthUserProfile(),
+            anyDateTime(),
+        )
+    }
+
     private fun anyLong(): Long {
         Mockito.anyLong()
         return 0L
@@ -143,6 +204,8 @@ class OAuthUserServiceTest {
 
     private fun user(
         status: UserStatus = UserStatus.ACTIVE,
+        withdrawalRequestedAt: LocalDateTime? = null,
+        withdrawalDueAt: LocalDateTime? = null,
         deletedAt: LocalDateTime? = null,
     ): User {
         val now = LocalDateTime.now()
@@ -152,6 +215,8 @@ class OAuthUserServiceTest {
             nickname = USER_NICKNAME,
             profileImageId = null,
             status = status,
+            withdrawalRequestedAt = withdrawalRequestedAt,
+            withdrawalDueAt = withdrawalDueAt,
             deletedAt = deletedAt,
             createdAt = now,
             updatedAt = now,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
@@ -61,6 +61,15 @@ class UserServiceTest {
     }
 
     @Test
+    fun `탈퇴 요청 상태 사용자는 인증 실패`() {
+        Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(user(status = UserStatus.WITHDRAWAL_REQUESTED))
+
+        val exception = assertFailsWith<CustomException> { userService.validateAuthenticatableUser(USER_ID) }
+
+        assertEquals(ErrorCode.AUTH_USER_DELETED, exception.errorCode)
+    }
+
+    @Test
     fun `활성 사용자는 인증 가능`() {
         Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(user())
 
@@ -119,8 +128,25 @@ class UserServiceTest {
         }
     }
 
+    @Test
+    fun `회원 탈퇴 요청 시 탈퇴 요청 상태와 유예 만료 시각을 저장한다`() {
+        Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(user())
+        Mockito
+            .`when`(userRepository.requestWithdrawal(Mockito.eq(USER_ID), anyDateTime(), anyDateTime()))
+            .thenReturn(1)
+
+        userService.requestWithdrawal(USER_ID)
+
+        Mockito.verify(userRepository).requestWithdrawal(Mockito.eq(USER_ID), anyDateTime(), anyDateTime())
+    }
+
     private fun nicknameDuplicateException(): DuplicateKeyException =
         DuplicateKeyException("duplicate key value violates unique constraint \"$USER_NICKNAME_UNIQUE_INDEX_NAME\"")
+
+    private fun anyDateTime(): LocalDateTime {
+        Mockito.any(LocalDateTime::class.java)
+        return LocalDateTime.MIN
+    }
 
     private fun user(
         status: UserStatus = UserStatus.ACTIVE,
@@ -133,6 +159,8 @@ class UserServiceTest {
             nickname = "penguin",
             profileImageId = null,
             status = status,
+            withdrawalRequestedAt = null,
+            withdrawalDueAt = null,
             deletedAt = deletedAt,
             createdAt = now,
             updatedAt = now,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
@@ -140,6 +140,21 @@ class UserServiceTest {
         Mockito.verify(userRepository).requestWithdrawal(Mockito.eq(USER_ID), anyDateTime(), anyDateTime())
     }
 
+    @Test
+    fun `회원 탈퇴 요청 상태 변경에 실패하면 예외가 발생한다`() {
+        Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(user())
+        Mockito
+            .`when`(userRepository.requestWithdrawal(Mockito.eq(USER_ID), anyDateTime(), anyDateTime()))
+            .thenReturn(0)
+
+        val exception =
+            assertFailsWith<CustomException> {
+                userService.requestWithdrawal(USER_ID)
+            }
+
+        assertEquals(ErrorCode.USER_WITHDRAWAL_REQUEST_FAILED, exception.errorCode)
+    }
+
     private fun nicknameDuplicateException(): DuplicateKeyException =
         DuplicateKeyException("duplicate key value violates unique constraint \"$USER_NICKNAME_UNIQUE_INDEX_NAME\"")
 

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/OAuthUserUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/OAuthUserUseCaseTest.kt
@@ -108,6 +108,8 @@ class OAuthUserUseCaseTest {
             nickname = nickname,
             profileImageId = null,
             status = UserStatus.ACTIVE,
+            withdrawalRequestedAt = null,
+            withdrawalDueAt = null,
             deletedAt = null,
             createdAt = now,
             updatedAt = now,

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.firstpenguin.app.domain.user.usecase
 
+import com.firstpenguin.app.domain.auth.service.RefreshTokenService
 import com.firstpenguin.app.domain.image.service.ImageService
 import com.firstpenguin.app.domain.user.dto.UpdateUserRequest
 import com.firstpenguin.app.domain.user.model.OAuthAccount
@@ -17,6 +18,7 @@ import kotlin.test.assertEquals
 class UserUseCaseTest {
     private lateinit var imageService: ImageService
     private lateinit var oAuthUserService: OAuthUserService
+    private lateinit var refreshTokenService: RefreshTokenService
     private lateinit var userService: UserService
     private lateinit var userUseCase: UserUseCase
 
@@ -24,8 +26,9 @@ class UserUseCaseTest {
     fun setUp() {
         imageService = Mockito.mock(ImageService::class.java)
         oAuthUserService = Mockito.mock(OAuthUserService::class.java)
+        refreshTokenService = Mockito.mock(RefreshTokenService::class.java)
         userService = Mockito.mock(UserService::class.java)
-        userUseCase = UserUseCase(imageService, oAuthUserService, userService)
+        userUseCase = UserUseCase(imageService, oAuthUserService, refreshTokenService, userService)
     }
 
     @Test
@@ -70,12 +73,22 @@ class UserUseCaseTest {
         Mockito.verify(userService).updateProfile(USER_ID, null, PROFILE_IMAGE_ID)
     }
 
+    @Test
+    fun `내 계정 탈퇴 요청 시 사용자 상태를 변경하고 모든 refresh token을 삭제한다`() {
+        userUseCase.withdrawMe(USER_ID)
+
+        Mockito.verify(userService).requestWithdrawal(USER_ID)
+        Mockito.verify(refreshTokenService).logoutAll(USER_ID)
+    }
+
     private fun user(): User =
         User(
             id = USER_ID,
             nickname = "penguin",
             profileImageId = null,
             status = UserStatus.ACTIVE,
+            withdrawalRequestedAt = null,
+            withdrawalDueAt = null,
             deletedAt = null,
             createdAt = CREATED_AT,
             updatedAt = CREATED_AT,


### PR DESCRIPTION
## 관련 이슈
- #179

## 변경 사항
- `DELETE /users/me` 회원 탈퇴 요청 API를 추가했습니다.
- 탈퇴 요청 시 `users.status`를 `WITHDRAWAL_REQUESTED`로 변경하고 `withdrawal_requested_at`, `withdrawal_due_at`을 저장합니다.
- 탈퇴 요청 시 해당 사용자의 모든 refresh token을 삭제하고 refresh token 쿠키를 만료합니다.
- 탈퇴 요청/차단/삭제 사용자는 access token 검증 및 refresh token 재발급 경로에서 인증되지 않도록 막았습니다.
- 30일 유예기간 안에 같은 OAuth 계정으로 로그인하면 탈퇴 요청을 자동 취소하고 ACTIVE 상태로 복구합니다.
- 탈퇴 요청 실패 경합 상황은 전용 `USER_WITHDRAWAL_REQUEST_FAILED` 에러로 처리합니다.

## 테스트
- `./gradlew lintKotlin`
- `./gradlew detekt`
- `./gradlew test --tests com.firstpenguin.app.domain.user.repository.UserRepositoryTest`
- pre-push hook `./gradlew test` 통과
- CodeRabbit review: 0 issues

## 참고
- 30일 이후 탈퇴 확정 스케줄러와 닉네임/provider 식별자 마스킹은 이번 PR 범위에 포함하지 않았습니다.
