### PR TITLE
Feat/#153/recommendation response time optimization

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationFinalScoreWeights.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/model/RecommendationFinalScoreWeights.kt
@@ -5,8 +5,8 @@ data class RecommendationFinalScoreWeights(
     val semantic: Double,
 ) {
     companion object {
-        val DEFAULT = RecommendationFinalScoreWeights(metadata = 0.45, semantic = 0.55)
-        val SEMANTIC_LEANING = RecommendationFinalScoreWeights(metadata = 0.35, semantic = 0.65)
-        val SEMANTIC_FOCUSED = RecommendationFinalScoreWeights(metadata = 0.30, semantic = 0.70)
+        val DEFAULT = RecommendationFinalScoreWeights(metadata = 0.60, semantic = 0.40)
+        val SEMANTIC_LEANING = RecommendationFinalScoreWeights(metadata = 0.45, semantic = 0.55)
+        val SEMANTIC_FOCUSED = RecommendationFinalScoreWeights(metadata = 0.35, semantic = 0.65)
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/policy/RecommendationSemanticExpansionPolicy.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/policy/RecommendationSemanticExpansionPolicy.kt
@@ -1,0 +1,47 @@
+package com.firstpenguin.app.domain.recommendation.policy
+
+import com.firstpenguin.app.domain.recommendation.model.EffectiveTag
+import com.firstpenguin.app.domain.recommendation.model.RecommendationInput
+import com.firstpenguin.app.domain.recommendation.model.UserSemanticEmbedding
+import com.firstpenguin.app.global.enums.TagType
+
+object RecommendationSemanticExpansionPolicy {
+    fun shouldExpand(
+        input: RecommendationInput,
+        effectiveTags: Collection<EffectiveTag>,
+        userEmbedding: UserSemanticEmbedding?,
+    ): Boolean =
+        when {
+            userEmbedding == null || !input.hasAnalysisText() -> false
+            effectiveTags.hasSpecificSemanticTag() -> true
+            input.diaryText.hasValue() -> true
+            input.isSadEmotionRange() -> true
+            input.isHappyEmotionRange() -> false
+            else -> input.analysisTextLength() >= SEMANTIC_EXPANSION_MIN_TEXT_LENGTH
+        }
+
+    private fun Collection<EffectiveTag>.hasSpecificSemanticTag(): Boolean = any(::isSpecificSemanticTag)
+
+    private fun isSpecificSemanticTag(tag: EffectiveTag): Boolean = tag.type in SPECIFIC_SEMANTIC_TAG_TYPES
+
+    private fun RecommendationInput.hasAnalysisText(): Boolean = feelingText.hasValue() || diaryText.hasValue()
+
+    private fun RecommendationInput.analysisTextLength(): Int = analysisTexts().sumOf(String::length)
+
+    private fun RecommendationInput.analysisTexts(): List<String> = listOfNotNull(feelingText, diaryText)
+
+    private fun RecommendationInput.isSadEmotionRange(): Boolean = emotionValue in SAD_EMOTION_VALUE_RANGE
+
+    private fun RecommendationInput.isHappyEmotionRange(): Boolean = emotionValue in HAPPY_EMOTION_VALUE_RANGE
+
+    private fun String?.hasValue(): Boolean = !isNullOrBlank()
+
+    private val SPECIFIC_SEMANTIC_TAG_TYPES = setOf(TagType.CONTEXT, TagType.SITUATION)
+    private val SAD_EMOTION_VALUE_RANGE = SAD_EMOTION_VALUE_MIN..SAD_EMOTION_VALUE_MAX
+    private val HAPPY_EMOTION_VALUE_RANGE = HAPPY_EMOTION_VALUE_MIN..HAPPY_EMOTION_VALUE_MAX
+    private const val SAD_EMOTION_VALUE_MIN = 1
+    private const val SAD_EMOTION_VALUE_MAX = 3
+    private const val HAPPY_EMOTION_VALUE_MIN = 7
+    private const val HAPPY_EMOTION_VALUE_MAX = 9
+    private const val SEMANTIC_EXPANSION_MIN_TEXT_LENGTH = 20
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposer.kt
@@ -11,6 +11,7 @@ import com.firstpenguin.app.domain.recommendation.model.RecommendationResult
 import com.firstpenguin.app.domain.recommendation.model.SourcedRecommendationCandidate
 import com.firstpenguin.app.domain.recommendation.model.UserSemanticEmbedding
 import com.firstpenguin.app.domain.recommendation.policy.RecommendationFinalScoreWeightPolicy
+import com.firstpenguin.app.domain.recommendation.policy.RecommendationSemanticExpansionPolicy
 import org.springframework.stereotype.Component
 
 private const val FIRST_RANK = 1
@@ -20,7 +21,8 @@ private const val MAX_SAME_ROLE_TAG_COUNT = 3
 private const val NO_ROLE_TAG_COUNT = 0
 private const val DEFAULT_SEMANTIC_SCORE = 0.0
 private const val SEMANTIC_SEED_CANDIDATE_LIMIT = 30
-private const val STRONG_SEMANTIC_SCORE = 0.45
+private const val STRONG_SEMANTIC_SCORE = 0.55
+private const val HAPPY_STRONG_SEMANTIC_METADATA_SCORE = 0.25
 
 private typealias RankedQuotes = List<RankedRecommendationQuote>
 
@@ -74,8 +76,8 @@ class RecommendationResultComposer(
         val rankedQuotes =
             rank(input, effectiveTags, supplementedCandidates, moodTagIdByCode, tagRarityWeights, userEmbedding)
                 .diversifyRoleTags()
-                .preferEmotionMatches()
-                .preferEmotionSources()
+                .preferEmotionMatches(input)
+                .preferEmotionSources(input)
                 .take(RECOMMENDATION_RESULT_COUNT)
                 .rerank()
         if (rankedQuotes.isEmpty()) return null
@@ -94,7 +96,7 @@ class RecommendationResultComposer(
         initialRankedQuotes: List<RankedRecommendationQuote>,
         userEmbedding: UserSemanticEmbedding?,
     ): List<SourcedRecommendationCandidate> =
-        semanticSeedCandidates(input, userEmbedding, candidates)
+        semanticSeedCandidates(input, effectiveTags, userEmbedding, candidates)
             .let { semanticSeeds ->
                 val existingCandidates =
                     sourceCandidates(
@@ -112,16 +114,17 @@ class RecommendationResultComposer(
                             excludedQuoteIds = existingCandidates.map { candidate -> candidate.quoteId },
                         )
                     },
-                    prioritizeSemanticFallback = input.shouldExpandSemanticCandidates(userEmbedding),
+                    prioritizeSemanticFallback = input.shouldExpandSemanticCandidates(effectiveTags, userEmbedding),
                 )
             }
 
     private fun semanticSeedCandidates(
         input: RecommendationInput,
+        effectiveTags: List<EffectiveTag>,
         userEmbedding: UserSemanticEmbedding?,
         candidates: List<RecommendationCandidate>,
     ): List<SourcedRecommendationCandidate> {
-        if (!input.shouldExpandSemanticCandidates(userEmbedding)) return emptyList()
+        if (!input.shouldExpandSemanticCandidates(effectiveTags, userEmbedding)) return emptyList()
 
         return semanticProvider
             .findSimilarCandidates(
@@ -257,27 +260,37 @@ private fun RecommendationInput.fallbackAnalysisLog(userEmbedding: UserSemanticE
 
 private fun RecommendationInput.hasAnalysisText(): Boolean = feelingText.hasValue() || diaryText.hasValue()
 
-private fun RankedQuotes.preferEmotionMatches(): RankedQuotes =
-    filterNot { quote -> quote.shouldDeferForMissingEmotion() }
-        .plus(filter { quote -> quote.shouldDeferForMissingEmotion() })
+private fun RankedQuotes.preferEmotionMatches(input: RecommendationInput): RankedQuotes =
+    filterNot { quote -> quote.shouldDeferForMissingEmotion(input) }
+        .plus(filter { quote -> quote.shouldDeferForMissingEmotion(input) })
         .distinctBy { quote -> quote.quoteId }
 
-private fun RankedQuotes.preferEmotionSources(): RankedQuotes =
-    filter { quote -> quote.source.isEmotionSource() || quote.isStrongSemanticMatch() }
-        .plus(filterNot { quote -> quote.source.isEmotionSource() || quote.isStrongSemanticMatch() })
+private fun RankedQuotes.preferEmotionSources(input: RecommendationInput): RankedQuotes =
+    filter { quote -> quote.source.isEmotionSource() || quote.isStrongSemanticMatch(input) }
+        .plus(filterNot { quote -> quote.source.isEmotionSource() || quote.isStrongSemanticMatch(input) })
         .distinctBy { quote -> quote.quoteId }
 
-private fun RankedRecommendationQuote.shouldDeferForMissingEmotion(): Boolean =
-    score.emotionScore <= NO_EMOTION_SCORE && !isStrongSemanticMatch()
+private fun RankedRecommendationQuote.shouldDeferForMissingEmotion(input: RecommendationInput): Boolean =
+    score.emotionScore <= NO_EMOTION_SCORE && !isStrongSemanticMatch(input)
 
-private fun RankedRecommendationQuote.isStrongSemanticMatch(): Boolean = score.semanticScore >= STRONG_SEMANTIC_SCORE
+private fun RankedRecommendationQuote.isStrongSemanticMatch(input: RecommendationInput): Boolean =
+    score.semanticScore >= STRONG_SEMANTIC_SCORE &&
+        (
+            input.emotionValue !in HAPPY_EMOTION_VALUE_RANGE ||
+                score.metadataScore >= HAPPY_STRONG_SEMANTIC_METADATA_SCORE
+        )
 
 private fun RecommendationCandidateSource.isEmotionSource(): Boolean =
     this == RecommendationCandidateSource.PRIMARY || this == RecommendationCandidateSource.FALLBACK_EMOTION
 
-private fun RecommendationInput.shouldExpandSemanticCandidates(userEmbedding: UserSemanticEmbedding?): Boolean =
-    userEmbedding != null && hasAnalysisText()
+private fun RecommendationInput.shouldExpandSemanticCandidates(
+    effectiveTags: Collection<EffectiveTag>,
+    userEmbedding: UserSemanticEmbedding?,
+): Boolean = RecommendationSemanticExpansionPolicy.shouldExpand(this, effectiveTags, userEmbedding)
 
 private fun String?.hasValue(): Boolean = !isNullOrBlank()
 
 private const val NO_EMOTION_SCORE = 0.0
+private val HAPPY_EMOTION_VALUE_RANGE = HAPPY_EMOTION_VALUE_MIN..HAPPY_EMOTION_VALUE_MAX
+private const val HAPPY_EMOTION_VALUE_MIN = 7
+private const val HAPPY_EMOTION_VALUE_MAX = 9

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationRankerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationRankerTest.kt
@@ -82,8 +82,8 @@ class RecommendationRankerTest {
         const val BOOK_ID = 100L
         const val METADATA_SCORE = 0.8
         const val SEMANTIC_SCORE = 0.6
-        const val EXPECTED_FINAL_SCORE = 0.69
-        const val EXPECTED_SEMANTIC_FOCUSED_SCORE = 0.66
+        const val EXPECTED_FINAL_SCORE = 0.72
+        const val EXPECTED_SEMANTIC_FOCUSED_SCORE = 0.67
         const val DELTA = 0.000001
 
         fun candidate(quoteId: Long): RecommendationCandidate =

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/recommendation/service/RecommendationResultComposerTest.kt
@@ -105,7 +105,7 @@ class RecommendationResultComposerTest {
         val semanticProvider =
             FakeRecommendationSemanticProvider(
                 userEmbedding = UserSemanticEmbedding("좋아하는 사람을 떠올리며 설레는 마음을 오래 느끼고 싶다", listOf(0.1)),
-                semanticScores = mapOf(1L to 0.5, 2L to 0.6),
+                semanticScores = mapOf(1L to 0.2, 2L to 0.8),
             )
         val composer = composer(semanticProvider = semanticProvider)
         val situationEffectiveTags =
@@ -199,6 +199,108 @@ class RecommendationResultComposerTest {
         val quoteIds = requireNotNull(result).quotes.map { quote -> quote.quoteId }
 
         assertEquals(MISSING_EMOTION_QUOTE_ID, quoteIds.first())
+    }
+
+    @Test
+    fun `행복한 짧은 입력은 구체 태그가 없으면 semantic 후보를 섞지 않는다`() {
+        val semanticCandidate =
+            candidate(
+                quoteId = HIGH_SEMANTIC_FALLBACK_QUOTE_ID,
+                roleTagId = HIGH_SEMANTIC_FALLBACK_QUOTE_ID,
+                tagIdsByType = emptyMap(),
+            )
+        val semanticProvider =
+            FakeRecommendationSemanticProvider(
+                userEmbedding = UserSemanticEmbedding("현재 기쁜 마음을 이어가고 싶다", listOf(0.1)),
+                semanticScores = mapOf(HIGH_SEMANTIC_FALLBACK_QUOTE_ID to HIGH_SEMANTIC_SCORE),
+                similarCandidates = listOf(semanticCandidate),
+            )
+        val composer = composer(semanticProvider = semanticProvider)
+        val input =
+            recommendationInput(
+                canonicalIntent = "현재 기쁜 마음을 이어가고 싶다",
+                feelingText = "행복해서!",
+                emotionValue = HAPPY_EMOTION_VALUE,
+            )
+
+        val result =
+            composer.compose(
+                input = input,
+                effectiveTags = effectiveTags,
+                candidates = (1L..10L).map { quoteId -> candidate(quoteId, roleTagId = quoteId) },
+                moodTagIdByCode = emptyMap(),
+            )
+
+        assertEquals(1L, result?.mainQuote?.quoteId)
+        assertTrue(semanticProvider.similarCandidateLimits.isEmpty())
+    }
+
+    @Test
+    fun `행복한 입력도 situation 태그가 있으면 semantic 후보를 섞는다`() {
+        val semanticCandidate =
+            candidate(
+                quoteId = HIGH_SEMANTIC_FALLBACK_QUOTE_ID,
+                roleTagId = HIGH_SEMANTIC_FALLBACK_QUOTE_ID,
+                tagIdsByType = mapOf(TagType.SITUATION to setOf(SITUATION_TAG_ID)),
+            )
+        val semanticProvider =
+            FakeRecommendationSemanticProvider(
+                userEmbedding = UserSemanticEmbedding("좋아하는 사람을 떠올리며 설레는 마음을 오래 느끼고 싶다", listOf(0.1)),
+                similarCandidates = listOf(semanticCandidate),
+            )
+        val composer = composer(semanticProvider = semanticProvider)
+        val input =
+            recommendationInput(
+                canonicalIntent = "좋아하는 사람을 떠올리며 설레는 마음을 오래 느끼고 싶다",
+                feelingText = "좋아하는 사람이 생각나서 설레고 행복해",
+                emotionValue = HAPPY_EMOTION_VALUE,
+            )
+        val situationEffectiveTags =
+            effectiveTags +
+                EffectiveTag(
+                    tagId = SITUATION_TAG_ID,
+                    code = "SITUATION_ROMANCE",
+                    type = TagType.SITUATION,
+                )
+
+        composer.compose(
+            input = input,
+            effectiveTags = situationEffectiveTags,
+            candidates = (1L..10L).map { quoteId -> candidate(quoteId, roleTagId = quoteId) },
+            moodTagIdByCode = emptyMap(),
+        )
+
+        assertEquals(listOf(SEMANTIC_SEED_CANDIDATE_LIMIT), semanticProvider.similarCandidateLimits)
+    }
+
+    @Test
+    fun `행복한 입력에서는 metadata가 낮은 semantic 후보를 감정 후보 뒤로 미룬다`() {
+        val candidates =
+            listOf(candidate(MISSING_EMOTION_QUOTE_ID, roleTagId = 1L, tagIdsByType = emptyMap())) +
+                (2L..10L).map { quoteId -> candidate(quoteId, roleTagId = quoteId) }
+        val semanticProvider =
+            FakeRecommendationSemanticProvider(
+                userEmbedding = UserSemanticEmbedding("현재 기쁜 마음을 이어가고 싶다", listOf(0.1)),
+                semanticScores = mapOf(MISSING_EMOTION_QUOTE_ID to HIGH_SEMANTIC_SCORE),
+            )
+        val composer = composer(semanticProvider = semanticProvider)
+        val input =
+            recommendationInput(
+                canonicalIntent = "현재 기쁜 마음을 이어가고 싶다",
+                feelingText = "행복해서!",
+                emotionValue = HAPPY_EMOTION_VALUE,
+            )
+
+        val result =
+            composer.compose(
+                input = input,
+                effectiveTags = effectiveTags,
+                candidates = candidates,
+                moodTagIdByCode = emptyMap(),
+            )
+        val quoteIds = requireNotNull(result).quotes.map { quote -> quote.quoteId }
+
+        assertEquals(MISSING_EMOTION_QUOTE_ID, quoteIds.last())
     }
 
     @Test
@@ -398,6 +500,7 @@ class RecommendationResultComposerTest {
         const val HIGH_SEMANTIC_FALLBACK_QUOTE_ID = 101L
         const val HIGH_SEMANTIC_SCORE = 1.0
         const val LOW_SEMANTIC_SCORE = 0.1
+        const val HAPPY_EMOTION_VALUE = 8
         const val SEMANTIC_SEED_CANDIDATE_LIMIT = 30
         const val EMBEDDING_ELAPSED_MS = 123L
         const val FALLBACK_EMBEDDING_INPUT = "diaryText: 행복해서!"
@@ -431,10 +534,11 @@ class RecommendationResultComposerTest {
         fun recommendationInput(
             canonicalIntent: String? = null,
             feelingText: String? = null,
+            emotionValue: Int = EMOTION_VALUE,
         ): RecommendationInput =
             RecommendationInput(
                 userId = USER_ID,
-                emotionValue = EMOTION_VALUE,
+                emotionValue = emotionValue,
                 emotionRangeId = EMOTION_RANGE_ID,
                 emotionTags = listOf(tag(EMOTION_TAG_ID, TagType.EMOTION, "EMOTION_ANXIOUS")),
                 needTag = tag(NEED_TAG_ID, TagType.NEED, "NEED_COMFORT"),


### PR DESCRIPTION
- semantic 후보 seed 조건 분리, HAPPY에서는 metadata가 낮은 semantic 후보가 감정 후보를 밀어내지 못하게 막음
- final score 점수 비율 조정