### PR TITLE
fix: 월말결산 구매 링크 및 검색 정렬 파라미터 수정

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/controller/DiscoveryController.kt
@@ -72,7 +72,7 @@ class DiscoveryController(
         description =
             "추천 이력이 있는 문장을 문장 내용 기준으로 검색한다. " +
                 "검색어는 `quotes.content`에만 적용하고, 책 제목/저자/닉네임/감정 값은 검색하지 않는다. " +
-                "`sort`는 생략하면 최신순이며, `scrapCount`를 전달하면 스크랩 많은순으로 조회한다. " +
+                "`sort`는 생략하면 최신순이며, `scrap`을 전달하면 스크랩 많은순으로 조회한다. " +
                 "`genre`는 생략하거나 `전체`이면 전체 장르를 조회한다. " +
                 "다음 페이지는 직전 응답의 `nextCursor` 값을 그대로 전달한다.",
         security = [SecurityRequirement(name = "bearerAuth")],
@@ -86,7 +86,7 @@ class DiscoveryController(
         @Parameter(
             description = "검색 정렬. 생략하면 최신순이다.",
             example = "latest",
-            schema = Schema(allowableValues = ["latest", "scrapCount"]),
+            schema = Schema(allowableValues = ["latest", "scrap"]),
         )
         @RequestParam(required = false) sort: String?,
         @Parameter(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuoteSearchSort.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/discovery/model/DiscoveryQuoteSearchSort.kt
@@ -7,7 +7,7 @@ enum class DiscoveryQuoteSearchSort(
     val value: String,
 ) {
     LATEST("latest"),
-    SCRAP_COUNT("scrapCount"),
+    SCRAP_COUNT("scrap"),
     ;
 
     companion object {

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/dto/MonthlySettlementResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/dto/MonthlySettlementResponse.kt
@@ -87,6 +87,7 @@ data class MonthlySettlementMonthlyBookResponse(
     val author: String,
     val bookCoverImageUrl: String,
     val genre: String,
+    val bookPurchaseLink: String,
 ) {
     companion object {
         fun from(monthlyBook: MonthlySettlementSelectedBook): MonthlySettlementMonthlyBookResponse =
@@ -98,6 +99,7 @@ data class MonthlySettlementMonthlyBookResponse(
                 author = monthlyBook.author,
                 bookCoverImageUrl = monthlyBook.bookCoverImageUrl,
                 genre = monthlyBook.genre,
+                bookPurchaseLink = monthlyBook.bookPurchaseLink,
             )
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/model/MonthlySettlementSelectedBook.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/model/MonthlySettlementSelectedBook.kt
@@ -8,4 +8,5 @@ data class MonthlySettlementSelectedBook(
     val author: String,
     val bookCoverImageUrl: String,
     val genre: String,
+    val bookPurchaseLink: String,
 )

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementCommandRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementCommandRepository.kt
@@ -41,6 +41,7 @@ class MonthlySettlementCommandRepository(
             .set(MonthlySettlementTable.SELECTED_BOOK_AUTHOR, command.monthlyBook?.author)
             .set(MonthlySettlementTable.SELECTED_BOOK_COVER_IMAGE_URL, command.monthlyBook?.bookCoverImageUrl)
             .set(MonthlySettlementTable.SELECTED_BOOK_GENRE, command.monthlyBook?.genre)
+            .set(MonthlySettlementTable.SELECTED_BOOK_PURCHASE_LINK, command.monthlyBook?.bookPurchaseLink)
             .onConflict(
                 MonthlySettlementTable.USER_ID,
                 MonthlySettlementTable.SETTLEMENT_YEAR,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementEmotionAggregationRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementEmotionAggregationRepository.kt
@@ -114,6 +114,7 @@ class MonthlySettlementEmotionAggregationRepository(
             author = record[BookTable.AUTHOR]!!,
             bookCoverImageUrl = record[BookTable.COVER_IMAGE_URL]!!,
             genre = record[BookTable.GENRE]!!,
+            bookPurchaseLink = record[BookTable.ALADIN_LINK]!!,
         )
 
     private companion object {
@@ -127,6 +128,7 @@ class MonthlySettlementEmotionAggregationRepository(
                 BookTable.AUTHOR,
                 BookTable.COVER_IMAGE_URL,
                 BookTable.GENRE,
+                BookTable.ALADIN_LINK,
             )
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementRepository.kt
@@ -69,6 +69,7 @@ class MonthlySettlementRepository(
             author = record[MonthlySettlementTable.SELECTED_BOOK_AUTHOR],
             bookCoverImageUrl = record[MonthlySettlementTable.SELECTED_BOOK_COVER_IMAGE_URL],
             genre = record[MonthlySettlementTable.SELECTED_BOOK_GENRE],
+            bookPurchaseLink = record[MonthlySettlementTable.SELECTED_BOOK_PURCHASE_LINK],
         )
 
     private fun toMonthlySettlementEmotionTag(record: Record): MonthlySettlementEmotionTag =
@@ -108,6 +109,7 @@ class MonthlySettlementRepository(
                 MonthlySettlementTable.SELECTED_BOOK_AUTHOR,
                 MonthlySettlementTable.SELECTED_BOOK_COVER_IMAGE_URL,
                 MonthlySettlementTable.SELECTED_BOOK_GENRE,
+                MonthlySettlementTable.SELECTED_BOOK_PURCHASE_LINK,
                 MonthlySettlementTable.CREATED_AT,
             )
         val MONTHLY_SETTLEMENT_BOOK_FIELDS: List<Field<*>> =
@@ -137,9 +139,10 @@ private data class MonthlySelectedBookRow(
     val author: String?,
     val bookCoverImageUrl: String?,
     val genre: String?,
+    val bookPurchaseLink: String?,
 ) {
     fun toMonthlySelectedBook(): MonthlySettlementSelectedBook? {
-        val values = listOf(quoteId, bookId, quoteContent, title, author, bookCoverImageUrl, genre)
+        val values = listOf(quoteId, bookId, quoteContent, title, author, bookCoverImageUrl, genre, bookPurchaseLink)
 
         if (values.any { value -> value == null }) {
             return null
@@ -153,6 +156,7 @@ private data class MonthlySelectedBookRow(
             author = author!!,
             bookCoverImageUrl = bookCoverImageUrl!!,
             genre = genre!!,
+            bookPurchaseLink = bookPurchaseLink!!,
         )
     }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/table/MonthlySettlementTable.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/table/MonthlySettlementTable.kt
@@ -28,5 +28,7 @@ internal object MonthlySettlementTable {
         DSL.field(DSL.name("monthly_settlements", "selected_book_cover_image_url"), String::class.java)
     val SELECTED_BOOK_GENRE =
         DSL.field(DSL.name("monthly_settlements", "selected_book_genre"), String::class.java)
+    val SELECTED_BOOK_PURCHASE_LINK =
+        DSL.field(DSL.name("monthly_settlements", "selected_book_purchase_link"), String::class.java)
     val CREATED_AT = DSL.field(DSL.name("monthly_settlements", "created_at"), LocalDateTime::class.java)
 }

--- a/app/src/main/resources/db/migration/V60__add_monthly_settlement_selected_book_purchase_link.sql
+++ b/app/src/main/resources/db/migration/V60__add_monthly_settlement_selected_book_purchase_link.sql
@@ -1,0 +1,8 @@
+ALTER TABLE monthly_settlements
+    ADD COLUMN IF NOT EXISTS selected_book_purchase_link TEXT;
+
+UPDATE monthly_settlements
+SET selected_book_purchase_link = books.aladin_link
+FROM books
+WHERE monthly_settlements.selected_book_id = books.id
+  AND monthly_settlements.selected_book_purchase_link IS NULL;

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/discovery/usecase/DiscoveryUseCaseTest.kt
@@ -233,7 +233,7 @@ class DiscoveryUseCaseTest {
             discoveryUseCase.searchDiscoveryQuotes(
                 USER_ID,
                 SEARCH_QUERY,
-                sort = "scrapCount",
+                sort = "scrap",
                 cursor = EXPECTED_SCRAP_COUNT_CURSOR,
                 genre = GENRE,
             )
@@ -258,7 +258,7 @@ class DiscoveryUseCaseTest {
             discoveryUseCase.searchDiscoveryQuotes(
                 USER_ID,
                 SEARCH_QUERY,
-                sort = "scrapCount",
+                sort = "scrap",
                 cursor = null,
                 genre = null,
             )

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementRepositoryTest.kt
@@ -99,6 +99,7 @@ class MonthlySettlementRepositoryTest {
         val normalizedSql = capturedSql.normalized()
 
         assertTrue(normalizedSql.contains("recommendation_quotes"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"books\".\"aladin_link\""), normalizedSql)
         assertTrue(normalizedSql.contains("\"recommendations\".\"user_id\" = ?"), normalizedSql)
         assertTrue(
             normalizedSql.contains("\"recommendations\".\"recommendation_date\" >= cast(? as date)"),

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/usecase/MonthlySettlementUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/usecase/MonthlySettlementUseCaseTest.kt
@@ -48,6 +48,7 @@ class MonthlySettlementUseCaseTest {
         assertEquals(listOf(TAG_LABEL), response.emotionTags.map { emotionTag -> emotionTag.label })
         assertEquals(RECOMMENDATION_MESSAGE, response.recommendationMessage)
         assertEquals(SELECTED_QUOTE_ID, response.monthlyBook?.quoteId)
+        assertEquals(BOOK_PURCHASE_LINK, response.monthlyBook?.bookPurchaseLink)
         Mockito.verify(monthlySettlementService).findSnapshot(USER_ID, targetMonth)
         Mockito.verify(monthlySettlementService, Mockito.never()).createSnapshot(USER_ID, targetMonth)
     }
@@ -130,6 +131,7 @@ class MonthlySettlementUseCaseTest {
                             author = AUTHOR,
                             bookCoverImageUrl = BOOK_COVER_IMAGE_URL,
                             genre = GENRE,
+                            bookPurchaseLink = BOOK_PURCHASE_LINK,
                         ),
                     createdAt = CREATED_AT,
                 ),
@@ -169,6 +171,7 @@ class MonthlySettlementUseCaseTest {
         const val TITLE = "홍학의 자리"
         const val AUTHOR = "정해연"
         const val BOOK_COVER_IMAGE_URL = "https://cdn.example.com/book-cover-placeholder.png"
+        const val BOOK_PURCHASE_LINK = "https://www.aladin.co.kr/shop/wproduct.aspx?ItemId=1"
         const val QUOTE_CONTENT = "어떤 기억은 아물지 않습니다."
         const val RECOMMENDATION_MESSAGE = "무기력한 3월을 보내셨군요. 이 감정과 유사한 문장이 담긴 책을 추천해요."
         val CREATED_AT: LocalDateTime = LocalDateTime.of(2026, 4, 1, 0, 0)


### PR DESCRIPTION
## 작업 내용
- 월말결산 응답의 이달의 책에 `bookPurchaseLink`를 추가했습니다.
- 기존 월말결산 스냅샷도 구매 링크를 채우도록 마이그레이션을 추가했습니다.
- 발견탭 문장 검색의 스크랩순 정렬 파라미터를 `scrapCount`에서 `scrap`으로 변경했습니다.

## 변경 영향
- 클라이언트는 월말결산 이달의 책에서 구매 링크를 바로 사용할 수 있습니다.
- 발견탭 검색 API는 `sort=scrap`으로 스크랩 많은순 정렬을 요청합니다.

## 검증
- 별도 테스트는 요청에 따라 실행하지 않았습니다.
- 커밋 훅에서 기본 누수 검사와 Kotlin 컴파일 검증이 실행되었습니다.

Closes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 월간 정산 추천 도서에 구매 링크 정보를 추가했습니다.

* **Bug Fixes**
  * 검색 정렬 옵션 명칭을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->