### PR TITLE
feat: 장르 기준 테이블 추가

### DIFF
--- a/app/src/main/resources/db/migration/V61__create_genres_and_add_books_genre_id.sql
+++ b/app/src/main/resources/db/migration/V61__create_genres_and_add_books_genre_id.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS genres (
+    id BIGINT PRIMARY KEY,
+    label VARCHAR(100) NOT NULL,
+    sort_order INT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS genres_label_uidx ON genres (label);
+
+CREATE UNIQUE INDEX IF NOT EXISTS genres_sort_order_uidx ON genres (sort_order);
+
+INSERT INTO genres (id, label, sort_order)
+VALUES
+    (1, '일반문학', 1),
+    (2, 'SF', 2),
+    (3, '추리･미스터리', 3),
+    (4, '공포･스릴러', 4),
+    (5, '판타지', 5),
+    (6, '로맨스', 6),
+    (7, '역사', 7),
+    (8, '무협', 8),
+    (9, '시･에세이', 9)
+ON CONFLICT (id) DO UPDATE
+SET label = EXCLUDED.label,
+    sort_order = EXCLUDED.sort_order;
+
+ALTER TABLE books
+    ADD COLUMN IF NOT EXISTS genre_id BIGINT;
+
+UPDATE books
+SET genre_id = genres.id
+FROM genres
+WHERE books.genre = genres.label
+  AND books.genre_id IS NULL;
+
+UPDATE books
+SET genre_id = 1
+WHERE genre_id IS NULL;
+
+ALTER TABLE books
+    ALTER COLUMN genre_id SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS books_genre_id_idx ON books (genre_id);


### PR DESCRIPTION
## 작업 내용

- `genres` 기준 테이블을 추가했습니다.
- 초기 장르 데이터를 seed로 추가했습니다.
- `books.genre_id` 컬럼을 추가하고 기존 `books.genre` 값을 기준으로 백필했습니다.
- `books.genre_id` 조회용 인덱스를 추가했습니다.
- 프로젝트 DB 규칙에 맞춰 FK는 추가하지 않았습니다.

## 배포 영향

- 기존 `books.genre` 컬럼은 유지합니다.
- 기존 발견 문장 API의 문자열 장르 필터 동작은 이 PR에서 변경하지 않습니다.
- 이후 PR에서 `GET /genres` API와 `genre_id` 기반 discovery 필터를 순차 적용합니다.

## 검증

- `./gradlew testClasses`

Refs #193
