### PR TITLE
feat: 장르 목록 조회 API 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/genre/controller/GenreController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/genre/controller/GenreController.kt
@@ -1,0 +1,23 @@
+package com.firstpenguin.app.domain.genre.controller
+
+import com.firstpenguin.app.domain.genre.dto.GenreResponse
+import com.firstpenguin.app.domain.genre.usecase.GenreUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/genres")
+@Tag(name = "장르", description = "장르 기준 데이터 API")
+class GenreController(
+    private val genreUseCase: GenreUseCase,
+) {
+    @Operation(
+        summary = "장르 목록 조회 API",
+        description = "서버에 저장된 장르 목록을 정렬 순서대로 반환한다.",
+    )
+    @GetMapping
+    fun getGenres(): List<GenreResponse> = genreUseCase.getGenres()
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/genre/dto/GenreResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/genre/dto/GenreResponse.kt
@@ -1,0 +1,21 @@
+package com.firstpenguin.app.domain.genre.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.firstpenguin.app.domain.genre.model.Genre
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class GenreResponse(
+    @get:JsonProperty("genre_id")
+    @field:Schema(description = "장르 ID", example = "1")
+    val genreId: Long,
+    @field:Schema(description = "장르 표시명", example = "일반문학")
+    val label: String,
+) {
+    companion object {
+        fun from(genre: Genre): GenreResponse =
+            GenreResponse(
+                genreId = genre.id,
+                label = genre.label,
+            )
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/genre/model/Genre.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/genre/model/Genre.kt
@@ -1,0 +1,7 @@
+package com.firstpenguin.app.domain.genre.model
+
+data class Genre(
+    val id: Long,
+    val label: String,
+    val sortOrder: Int,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/genre/repository/GenreRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/genre/repository/GenreRepository.kt
@@ -1,0 +1,26 @@
+package com.firstpenguin.app.domain.genre.repository
+
+import com.firstpenguin.app.domain.genre.model.Genre
+import com.firstpenguin.app.domain.genre.repository.table.GenreTable
+import org.jooq.DSLContext
+import org.jooq.Record
+import org.springframework.stereotype.Repository
+
+@Repository
+class GenreRepository(
+    private val dsl: DSLContext,
+) {
+    fun findAll(): List<Genre> =
+        dsl
+            .select(GenreTable.ID, GenreTable.LABEL, GenreTable.SORT_ORDER)
+            .from(GenreTable.GENRES)
+            .orderBy(GenreTable.SORT_ORDER.asc(), GenreTable.ID.asc())
+            .fetch(::toGenre)
+
+    private fun toGenre(record: Record): Genre =
+        Genre(
+            id = record[GenreTable.ID]!!,
+            label = record[GenreTable.LABEL]!!,
+            sortOrder = record[GenreTable.SORT_ORDER]!!,
+        )
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/genre/repository/table/GenreTable.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/genre/repository/table/GenreTable.kt
@@ -1,0 +1,10 @@
+package com.firstpenguin.app.domain.genre.repository.table
+
+import org.jooq.impl.DSL
+
+internal object GenreTable {
+    val GENRES = DSL.table(DSL.name("genres"))
+    val ID = DSL.field(DSL.name("genres", "id"), Long::class.java)
+    val LABEL = DSL.field(DSL.name("genres", "label"), String::class.java)
+    val SORT_ORDER = DSL.field(DSL.name("genres", "sort_order"), Int::class.java)
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/genre/service/GenreService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/genre/service/GenreService.kt
@@ -1,0 +1,12 @@
+package com.firstpenguin.app.domain.genre.service
+
+import com.firstpenguin.app.domain.genre.model.Genre
+import com.firstpenguin.app.domain.genre.repository.GenreRepository
+import org.springframework.stereotype.Service
+
+@Service
+class GenreService(
+    private val genreRepository: GenreRepository,
+) {
+    fun getGenres(): List<Genre> = genreRepository.findAll()
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/genre/usecase/GenreUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/genre/usecase/GenreUseCase.kt
@@ -1,0 +1,17 @@
+package com.firstpenguin.app.domain.genre.usecase
+
+import com.firstpenguin.app.domain.genre.dto.GenreResponse
+import com.firstpenguin.app.domain.genre.service.GenreService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GenreUseCase(
+    private val genreService: GenreService,
+) {
+    @Transactional(readOnly = true)
+    fun getGenres(): List<GenreResponse> =
+        genreService
+            .getGenres()
+            .map(GenreResponse::from)
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/repository/UserRepository.kt
@@ -66,7 +66,7 @@ class UserRepository(
             .set(withdrawalCancelValues(now))
             .where(UserTable.ID.eq(id))
             .and(UserTable.STATUS.eq(UserStatus.WITHDRAWAL_REQUESTED.name))
-            .and(UserTable.WITHDRAWAL_DUE_AT.gt(now))
+            .and(UserTable.WITHDRAWAL_DUE_AT.ge(now))
             .returningResult(USER_FIELDS)
             .fetchOne(::toUser)
 

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/genre/repository/GenreRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/genre/repository/GenreRepositoryTest.kt
@@ -1,0 +1,43 @@
+package com.firstpenguin.app.domain.genre.repository
+
+import com.firstpenguin.app.domain.genre.repository.table.GenreTable
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.jooq.tools.jdbc.MockConnection
+import org.jooq.tools.jdbc.MockDataProvider
+import org.jooq.tools.jdbc.MockResult
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class GenreRepositoryTest {
+    @Test
+    fun `장르 목록은 정렬 순서와 ID 기준으로 조회한다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                GenreRepository(dsl).findAll()
+            }
+        val normalizedSql = capturedSql.replace(Regex("\\s+"), " ")
+
+        assertTrue(normalizedSql.contains("from \"genres\""), normalizedSql)
+        assertTrue(
+            normalizedSql.contains("order by \"genres\".\"sort_order\" asc, \"genres\".\"id\" asc"),
+            normalizedSql,
+        )
+    }
+
+    private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {
+        var capturedSql = ""
+        lateinit var dsl: DSLContext
+        val connection =
+            MockConnection(
+                MockDataProvider { context ->
+                    capturedSql = context.sql()
+                    arrayOf(MockResult(0, dsl.newResult(GenreTable.ID, GenreTable.LABEL, GenreTable.SORT_ORDER)))
+                },
+            )
+        dsl = DSL.using(connection, SQLDialect.POSTGRES)
+        repositoryCall(dsl)
+        return capturedSql
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/genre/usecase/GenreUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/genre/usecase/GenreUseCaseTest.kt
@@ -1,0 +1,38 @@
+package com.firstpenguin.app.domain.genre.usecase
+
+import com.firstpenguin.app.domain.genre.model.Genre
+import com.firstpenguin.app.domain.genre.service.GenreService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import kotlin.test.assertEquals
+
+class GenreUseCaseTest {
+    private lateinit var genreService: GenreService
+    private lateinit var genreUseCase: GenreUseCase
+
+    @BeforeEach
+    fun setUp() {
+        genreService = Mockito.mock(GenreService::class.java)
+        genreUseCase = GenreUseCase(genreService)
+    }
+
+    @Test
+    fun `장르 목록을 응답 형식으로 변환한다`() {
+        Mockito
+            .`when`(genreService.getGenres())
+            .thenReturn(listOf(Genre(GENRE_ID, GENRE_LABEL, SORT_ORDER)))
+
+        val response = genreUseCase.getGenres()
+
+        assertEquals(1, response.size)
+        assertEquals(GENRE_ID, response.first().genreId)
+        assertEquals(GENRE_LABEL, response.first().label)
+    }
+
+    private companion object {
+        const val GENRE_ID = 1L
+        const val GENRE_LABEL = "일반문학"
+        const val SORT_ORDER = 1
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/repository/UserRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/repository/UserRepositoryTest.kt
@@ -60,7 +60,7 @@ class UserRepositoryTest {
     }
 
     @Test
-    fun `탈퇴 요청 취소는 유예 기간이 지나지 않은 사용자만 활성 상태로 변경한다`() {
+    fun `탈퇴 요청 취소는 유예 기간 이내 사용자만 활성 상태로 변경한다`() {
         val capturedSql =
             captureSql { dsl ->
                 UserRepository(dsl).reactivateWithdrawalRequested(USER_ID, LocalDateTime.now())
@@ -70,7 +70,7 @@ class UserRepositoryTest {
         assertTrue(normalizedSql.startsWith("""update "users" set"""), normalizedSql)
         assertTrue(normalizedSql.contains("withdrawal_requested_at"), normalizedSql)
         assertTrue(normalizedSql.contains("withdrawal_due_at"), normalizedSql)
-        assertTrue(normalizedSql.contains(""""users"."withdrawal_due_at" >"""), normalizedSql)
+        assertTrue(normalizedSql.contains(""""users"."withdrawal_due_at" >="""), normalizedSql)
     }
 
     private fun captureSql(repositoryCall: (DSLContext) -> Unit): String {


### PR DESCRIPTION
## 작업 내용

- `GET /genres` 장르 목록 조회 API를 추가했습니다.
- 장르 목록은 `genres.sort_order`, `genres.id` 기준으로 정렬해 반환합니다.
- 응답 필드는 프론트 연동 형식에 맞춰 `genre_id`, `label`로 직렬화합니다.
- 장르 controller/usecase/service/repository 계층과 단위 테스트를 추가했습니다.
- 기존 미커밋 user 작업도 함께 반영했습니다.
  - 탈퇴 요청 취소 조건을 `withdrawal_due_at > now`에서 `withdrawal_due_at >= now`로 변경했습니다.

## 배포 영향

- 기존 discovery API 동작은 변경하지 않습니다.
- 이번 PR은 장르 목록 조회 API 추가까지이며, discovery 검색/목록의 `genre_id` 필터 전환은 다음 PR에서 진행합니다.
- `GET /genres`는 현재 보안 설정상 기존 일반 API와 동일하게 인증이 필요합니다.

## 검증

- `./gradlew formatKotlin`
- `./gradlew test --tests 'com.firstpenguin.app.domain.genre.*' --tests 'com.firstpenguin.app.domain.user.repository.UserRepositoryTest'`
- `./gradlew testClasses lintKotlin detekt`

Refs #193
