### PR TITLE
[Feature] 비로그인 월말 결산 공유 조회 API 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Flyway 마이그레이션 버전 중복 검사
+        working-directory: .
+        run: |
+          duplicates=$(find app/src/main/resources/db/migration -maxdepth 1 -name 'V*.sql' \
+            -exec basename {} \; \
+            | sed -E 's/^V([0-9]+)__.*/\1/' \
+            | sort \
+            | uniq -d)
+
+          if [ -n "$duplicates" ]; then
+            echo "Flyway 마이그레이션 버전 중복:"
+            echo "$duplicates"
+            exit 1
+          fi
+
       - uses: actions/setup-java@v4
         with:
           distribution: temurin

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
@@ -116,6 +116,7 @@ class SecurityConfig(
                 "/auth/dev-token",
                 "/oauth2/**",
                 "/login/oauth2/**",
+                "/monthly-settlements/shared",
                 "/swagger-ui/**",
                 "/swagger-ui.html",
                 "/v3/api-docs/**",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/controller/MonthlySettlementController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/controller/MonthlySettlementController.kt
@@ -38,4 +38,22 @@ class MonthlySettlementController(
                 month = month,
             ),
         )
+
+    @Operation(
+        summary = "월말 결산 공유 조회 API",
+        description = "공유 URL에서 토큰 없이 사용자 ID와 조회 월로 월말 결산을 조회한다.",
+    )
+    @GetMapping("/shared")
+    fun getSharedMonthlySettlement(
+        @Parameter(description = "조회 대상 사용자 ID", example = "1") @RequestParam userId: Long,
+        @Parameter(description = "조회 연도", example = "2026") @RequestParam year: Int,
+        @Parameter(description = "조회 월", example = "3") @RequestParam month: Int,
+    ): ResponseEntity<MonthlySettlementResponse> =
+        ResponseEntity.ok(
+            monthlySettlementUseCase.getMonthlySettlement(
+                userId = userId,
+                year = year,
+                month = month,
+            ),
+        )
 }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfigTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfigTest.kt
@@ -24,6 +24,18 @@ class SecurityConfigTest {
         assertTrue(config.allowedMethods.orEmpty().contains(HttpMethod.PATCH.name()))
     }
 
+    @Test
+    fun `월말 결산 공유 조회 API는 인증 없이 접근할 수 있다`() {
+        assertTrue(permitAllPatterns().contains("/monthly-settlements/shared"))
+    }
+
+    private fun permitAllPatterns(): List<String> {
+        val field = SecurityConfig::class.java.getDeclaredField("PERMIT_ALL_PATTERNS")
+        field.isAccessible = true
+
+        return (field.get(null) as Array<*>).filterIsInstance<String>()
+    }
+
     private fun securityConfig(): SecurityConfig =
         SecurityConfig(
             jwtAuthenticationFilter = Mockito.mock(JwtAuthenticationFilter::class.java),

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/controller/MonthlySettlementControllerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/controller/MonthlySettlementControllerTest.kt
@@ -1,0 +1,75 @@
+package com.firstpenguin.app.domain.monthlysettlement.controller
+
+import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
+import com.firstpenguin.app.domain.monthlysettlement.dto.MonthlySettlementResponse
+import com.firstpenguin.app.domain.monthlysettlement.usecase.MonthlySettlementUseCase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import kotlin.test.assertEquals
+
+class MonthlySettlementControllerTest {
+    private lateinit var monthlySettlementUseCase: MonthlySettlementUseCase
+    private lateinit var monthlySettlementController: MonthlySettlementController
+
+    @BeforeEach
+    fun setUp() {
+        monthlySettlementUseCase = Mockito.mock(MonthlySettlementUseCase::class.java)
+        monthlySettlementController = MonthlySettlementController(monthlySettlementUseCase)
+    }
+
+    @Test
+    fun `인증 사용자 월말 결산을 조회한다`() {
+        val response = response(USER_ID)
+        Mockito
+            .`when`(monthlySettlementUseCase.getMonthlySettlement(USER_ID, YEAR, MONTH))
+            .thenReturn(response)
+
+        val result =
+            monthlySettlementController.getMonthlySettlement(
+                authenticatedUser = AuthenticatedUser(USER_ID),
+                year = YEAR,
+                month = MONTH,
+            )
+
+        assertEquals(response, result.body)
+        Mockito.verify(monthlySettlementUseCase).getMonthlySettlement(USER_ID, YEAR, MONTH)
+    }
+
+    @Test
+    fun `토큰 없이 사용자 ID로 공유 월말 결산을 조회한다`() {
+        val response = response(SHARED_USER_ID)
+        Mockito
+            .`when`(monthlySettlementUseCase.getMonthlySettlement(SHARED_USER_ID, YEAR, MONTH))
+            .thenReturn(response)
+
+        val result =
+            monthlySettlementController.getSharedMonthlySettlement(
+                userId = SHARED_USER_ID,
+                year = YEAR,
+                month = MONTH,
+            )
+
+        assertEquals(response, result.body)
+        Mockito.verify(monthlySettlementUseCase).getMonthlySettlement(SHARED_USER_ID, YEAR, MONTH)
+    }
+
+    private fun response(userId: Long): MonthlySettlementResponse =
+        MonthlySettlementResponse(
+            year = YEAR,
+            month = MONTH,
+            sharedQuoteCount = userId.toInt(),
+            mostFrequentGenre = null,
+            monthlyBooks = emptyList(),
+            emotionTags = emptyList(),
+            recommendationMessage = null,
+            monthlyBook = null,
+        )
+
+    private companion object {
+        const val USER_ID = 10L
+        const val SHARED_USER_ID = 20L
+        const val YEAR = 2026
+        const val MONTH = 3
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 토큰 없이 `userId`, `year`, `month`로 월말 결산을 조회하는 공유 API를 추가했습니다.
- `GET /monthly-settlements/shared` 경로를 인증 없이 접근할 수 있도록 허용했습니다.
- 기존 월말 결산 응답과 조회 usecase를 재사용해 로그인 조회 API와 동일한 조회 정책을 유지했습니다.
- 컨트롤러 호출 테스트와 공개 경로 설정 테스트를 추가했습니다.

## 영향 범위

- 월말 결산 API
- Spring Security 공개 경로 설정
- 월말 결산 컨트롤러 및 보안 설정 테스트

## 검증

- `./gradlew testClasses lintKotlin test detekt`
- push 전 hook에서 `./gradlew test`

## 관련 이슈

- #202
