### PR TITLE
fix: 월말 결산을 매 조회마다 조합하도록 변경

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/model/MonthlySettlementEmotionTag.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/model/MonthlySettlementEmotionTag.kt
@@ -2,6 +2,7 @@ package com.firstpenguin.app.domain.monthlysettlement.model
 
 data class MonthlySettlementEmotionTag(
     val tagId: Long,
+    val emotionRangeId: Long? = null,
     val label: String,
     val count: Int,
     val sortOrder: Int,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementEmotionAggregationRepository.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementEmotionAggregationRepository.kt
@@ -33,7 +33,7 @@ class MonthlySettlementEmotionAggregationRepository(
         if (limit <= 0) return emptyList()
 
         return dsl
-            .select(TagTable.ID, TagTable.LABEL, TAG_COUNT)
+            .select(TagTable.ID, TagTable.EMOTION_RANGE_ID, TagTable.LABEL, TAG_COUNT)
             .from(RecommendationTagTable.RECOMMENDATION_TAGS)
             .join(RecommendationTable.RECOMMENDATIONS)
             .on(RecommendationTable.ID.eq(RecommendationTagTable.RECOMMENDATION_ID))
@@ -41,7 +41,7 @@ class MonthlySettlementEmotionAggregationRepository(
             .on(TagTable.ID.eq(RecommendationTagTable.TAG_ID))
             .where(monthlyRecommendationCondition(userId, start, endExclusive))
             .and(TagTable.TYPE.eq(TagType.EMOTION.name))
-            .groupBy(TagTable.ID, TagTable.LABEL, TagTable.SORT_ORDER)
+            .groupBy(TagTable.ID, TagTable.EMOTION_RANGE_ID, TagTable.LABEL, TagTable.SORT_ORDER)
             .orderBy(TAG_COUNT.desc(), TagTable.SORT_ORDER.asc(), TagTable.ID.asc())
             .limit(limit)
             .fetch()
@@ -54,6 +54,32 @@ class MonthlySettlementEmotionAggregationRepository(
         endExclusive: LocalDate,
         tagId: Long,
     ): MonthlySettlementSelectedBook? =
+        findMonthlyBookCandidate(
+            userId = userId,
+            start = start,
+            endExclusive = endExclusive,
+            tagCondition = QuoteMetadataTagTable.TAG_ID.eq(tagId),
+        )
+
+    fun findMonthlyBookCandidateByEmotionRangeId(
+        userId: Long,
+        start: LocalDate,
+        endExclusive: LocalDate,
+        emotionRangeId: Long,
+    ): MonthlySettlementSelectedBook? =
+        findMonthlyBookCandidate(
+            userId = userId,
+            start = start,
+            endExclusive = endExclusive,
+            tagCondition = emotionRangeCondition(emotionRangeId),
+        )
+
+    private fun findMonthlyBookCandidate(
+        userId: Long,
+        start: LocalDate,
+        endExclusive: LocalDate,
+        tagCondition: Condition,
+    ): MonthlySettlementSelectedBook? =
         dsl
             .select(MONTHLY_SELECTED_BOOK_FIELDS)
             .from(RecommendationQuoteTable.RECOMMENDATION_QUOTES)
@@ -65,17 +91,25 @@ class MonthlySettlementEmotionAggregationRepository(
             .on(QuoteTable.ID.eq(QuoteMetadataTable.QUOTE_ID))
             .join(QuoteMetadataTagTable.QUOTE_METADATA_TAGS)
             .on(QuoteMetadataTable.ID.eq(QuoteMetadataTagTable.QUOTE_METADATA_ID))
+            .join(TagTable.TAGS)
+            .on(TagTable.ID.eq(QuoteMetadataTagTable.TAG_ID))
             .join(BookTable.BOOKS)
             .on(BookTable.ID.eq(QuoteTable.BOOK_ID))
             .join(GenreTable.GENRES)
             .on(GenreTable.ID.eq(BookTable.GENRE_ID))
             .where(monthlyRecommendationCondition(userId, start, endExclusive))
-            .and(QuoteMetadataTagTable.TAG_ID.eq(tagId))
+            .and(tagCondition)
             .and(activeQuoteAndBookCondition())
             .and(genreLabelExists())
+            .groupBy(MONTHLY_SELECTED_BOOK_FIELDS)
             .orderBy(DSL.rand())
             .limit(1)
             .fetchOne(::toMonthlySelectedBook)
+
+    private fun emotionRangeCondition(emotionRangeId: Long): Condition =
+        TagTable.TYPE
+            .eq(TagType.EMOTION.name)
+            .and(TagTable.EMOTION_RANGE_ID.eq(emotionRangeId))
 
     private fun monthlyRecommendationCondition(
         userId: Long,
@@ -103,6 +137,7 @@ class MonthlySettlementEmotionAggregationRepository(
     ): MonthlySettlementEmotionTag =
         MonthlySettlementEmotionTag(
             tagId = record[TagTable.ID]!!,
+            emotionRangeId = record[TagTable.EMOTION_RANGE_ID],
             label = record[TagTable.LABEL]!!,
             count = record[TAG_COUNT]!!,
             sortOrder = index + 1,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/service/MonthlySettlementService.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/service/MonthlySettlementService.kt
@@ -1,16 +1,19 @@
 package com.firstpenguin.app.domain.monthlysettlement.service
 
+import com.firstpenguin.app.domain.monthlysettlement.model.MonthlySettlement
 import com.firstpenguin.app.domain.monthlysettlement.model.MonthlySettlementBook
 import com.firstpenguin.app.domain.monthlysettlement.model.MonthlySettlementCreateCommand
 import com.firstpenguin.app.domain.monthlysettlement.model.MonthlySettlementEmotionTag
+import com.firstpenguin.app.domain.monthlysettlement.model.MonthlySettlementSelectedBook
 import com.firstpenguin.app.domain.monthlysettlement.model.MonthlySettlementSnapshot
-import com.firstpenguin.app.domain.monthlysettlement.repository.MonthlySettlementCommandRepository
 import com.firstpenguin.app.domain.monthlysettlement.repository.MonthlySettlementEmotionAggregationRepository
 import com.firstpenguin.app.domain.monthlysettlement.repository.MonthlySettlementQuoteAggregationRepository
 import com.firstpenguin.app.domain.monthlysettlement.repository.MonthlySettlementRepository
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
 import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 
 private const val MONTHLY_BOOK_COUNT = 3
@@ -19,7 +22,6 @@ private const val EMOTION_TAG_COUNT = 10
 @Service
 class MonthlySettlementService(
     private val monthlySettlementRepository: MonthlySettlementRepository,
-    private val monthlySettlementCommandRepository: MonthlySettlementCommandRepository,
     private val monthlySettlementQuoteAggregationRepository: MonthlySettlementQuoteAggregationRepository,
     private val monthlySettlementEmotionAggregationRepository: MonthlySettlementEmotionAggregationRepository,
 ) {
@@ -44,26 +46,7 @@ class MonthlySettlementService(
     fun createSnapshot(
         userId: Long,
         yearMonth: YearMonth,
-    ): MonthlySettlementSnapshot? {
-        val draft = createCommand(userId, yearMonth) ?: return null
-        val monthlySettlementId = monthlySettlementCommandRepository.insertMonthlySettlement(draft)
-
-        return findCreatedSnapshot(
-            userId = userId,
-            yearMonth = yearMonth,
-            monthlySettlementId = monthlySettlementId,
-        )
-    }
-
-    private fun findCreatedSnapshot(
-        userId: Long,
-        yearMonth: YearMonth,
-        monthlySettlementId: Long?,
-    ): MonthlySettlementSnapshot? {
-        if (monthlySettlementId == null) return findSnapshot(userId, yearMonth)
-
-        return checkNotNull(findSnapshot(userId, yearMonth))
-    }
+    ): MonthlySettlementSnapshot? = createCommand(userId, yearMonth)?.toSnapshot()
 
     private fun createCommand(
         userId: Long,
@@ -89,13 +72,7 @@ class MonthlySettlementService(
         val mostFrequentGenre =
             monthlySettlementQuoteAggregationRepository.findMostFrequentGenre(userId, start, endExclusive)
         val monthlyBooks = findMonthlyBooks(userId, yearMonth, mostFrequentGenre)
-        val monthlyBook =
-            monthlySettlementEmotionAggregationRepository.findMonthlyBookCandidateByEmotionTagId(
-                userId = userId,
-                start = start,
-                endExclusive = endExclusive,
-                tagId = topEmotionTag.tagId,
-            )
+        val monthlyBook = findMonthlyBook(userId, start, endExclusive, topEmotionTag)
 
         return MonthlySettlementCreateCommand(
             userId = userId,
@@ -110,6 +87,35 @@ class MonthlySettlementService(
             emotionTags = emotionTags,
         )
     }
+
+    private fun findMonthlyBook(
+        userId: Long,
+        start: LocalDate,
+        endExclusive: LocalDate,
+        topEmotionTag: MonthlySettlementEmotionTag,
+    ): MonthlySettlementSelectedBook? =
+        monthlySettlementEmotionAggregationRepository
+            .findMonthlyBookCandidateByEmotionTagId(
+                userId,
+                start,
+                endExclusive,
+                topEmotionTag.tagId,
+            ) ?: findMonthlyBookByEmotionRange(userId, start, endExclusive, topEmotionTag.emotionRangeId)
+
+    private fun findMonthlyBookByEmotionRange(
+        userId: Long,
+        start: LocalDate,
+        endExclusive: LocalDate,
+        emotionRangeId: Long?,
+    ): MonthlySettlementSelectedBook? =
+        emotionRangeId?.let {
+            monthlySettlementEmotionAggregationRepository.findMonthlyBookCandidateByEmotionRangeId(
+                userId,
+                start,
+                endExclusive,
+                it,
+            )
+        }
 
     private fun findMonthlyBooks(
         userId: Long,
@@ -153,4 +159,24 @@ class MonthlySettlementService(
         topEmotionTagLabel: String,
         yearMonth: YearMonth,
     ): String = "$topEmotionTagLabel ${yearMonth.monthValue}월을 보내셨군요. 이 감정과 유사한 문장이 담긴 책을 추천해요."
+
+    private fun MonthlySettlementCreateCommand.toSnapshot(): MonthlySettlementSnapshot =
+        MonthlySettlementSnapshot(
+            settlement =
+                MonthlySettlement(
+                    id = 0L,
+                    userId = userId,
+                    year = year,
+                    month = month,
+                    sharedQuoteCount = sharedQuoteCount,
+                    mostFrequentGenre = mostFrequentGenre,
+                    topEmotionTagId = topEmotionTag.tagId,
+                    topEmotionTagLabel = topEmotionTag.label,
+                    recommendationMessage = recommendationMessage,
+                    monthlyBook = monthlyBook,
+                    createdAt = LocalDateTime.now(),
+                ),
+            monthlyBooks = monthlyBooks,
+            emotionTags = emotionTags,
+        )
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/usecase/MonthlySettlementUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/monthlysettlement/usecase/MonthlySettlementUseCase.kt
@@ -13,7 +13,7 @@ import java.time.ZoneId
 class MonthlySettlementUseCase(
     private val monthlySettlementService: MonthlySettlementService,
 ) {
-    @Transactional
+    @Transactional(readOnly = true)
     fun getMonthlySettlement(
         userId: Long,
         year: Int,
@@ -21,8 +21,7 @@ class MonthlySettlementUseCase(
     ): MonthlySettlementResponse {
         val yearMonth = validateYearMonth(year, month)
         val snapshot =
-            monthlySettlementService.findSnapshot(userId, yearMonth)
-                ?: monthlySettlementService.createSnapshot(userId, yearMonth)
+            monthlySettlementService.createSnapshot(userId, yearMonth)
                 ?: return MonthlySettlementResponse.empty(
                     year = yearMonth.year,
                     month = yearMonth.monthValue,
@@ -40,7 +39,7 @@ class MonthlySettlementUseCase(
         }
 
         val requestedMonth = YearMonth.of(year, month)
-        if (requestedMonth.isBefore(currentMonth())) return requestedMonth
+        if (!requestedMonth.isAfter(currentMonth())) return requestedMonth
 
         throw CustomException(ErrorCode.MONTHLY_SETTLEMENT_NOT_AVAILABLE)
     }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementRepositoryTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/repository/MonthlySettlementRepositoryTest.kt
@@ -77,6 +77,7 @@ class MonthlySettlementRepositoryTest {
 
         assertTrue(normalizedSql.contains("recommendation_tags"), normalizedSql)
         assertTrue(normalizedSql.contains("\"tags\".\"type\" = ?"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"tags\".\"emotion_range_id\""), normalizedSql)
         assertTrue(
             normalizedSql.contains(
                 "order by \"tag_count\" desc, \"tags\".\"sort_order\" asc, \"tags\".\"id\" asc",
@@ -114,6 +115,28 @@ class MonthlySettlementRepositoryTest {
         assertTrue(normalizedSql.contains("quote_metadata_tags"), normalizedSql)
         assertTrue(normalizedSql.contains("quote_metadata"), normalizedSql)
         assertTrue(normalizedSql.contains("\"quote_metadata_tags\".\"tag_id\" = ?"), normalizedSql)
+        assertTrue(normalizedSql.contains("order by random()"), normalizedSql)
+    }
+
+    @Test
+    fun `이달의 책 후보는 정확한 태그가 없으면 같은 감정 범위의 quote metadata tag로 조회할 수 있다`() {
+        val capturedSql =
+            captureSql { dsl ->
+                MonthlySettlementEmotionAggregationRepository(dsl).findMonthlyBookCandidateByEmotionRangeId(
+                    userId = USER_ID,
+                    start = START,
+                    endExclusive = END_EXCLUSIVE,
+                    emotionRangeId = EMOTION_RANGE_ID,
+                )
+            }
+        val normalizedSql = capturedSql.normalized()
+
+        assertTrue(normalizedSql.contains("recommendation_quotes"), normalizedSql)
+        assertTrue(normalizedSql.contains("join \"tags\""), normalizedSql)
+        assertTrue(normalizedSql.contains("\"tags\".\"type\" = ?"), normalizedSql)
+        assertTrue(normalizedSql.contains("\"tags\".\"emotion_range_id\" = ?"), normalizedSql)
+        assertTrue(normalizedSql.contains("quote_metadata_tags"), normalizedSql)
+        assertTrue(normalizedSql.contains("group by"), normalizedSql)
         assertTrue(normalizedSql.contains("order by random()"), normalizedSql)
     }
 
@@ -185,6 +208,7 @@ class MonthlySettlementRepositoryTest {
         const val MONTH = 3
         const val SHARED_QUOTE_COUNT = 27
         const val TAG_ID = 10L
+        const val EMOTION_RANGE_ID = 1L
         const val TAG_LABEL = "무기력한"
         const val TAG_COUNT = 5
         const val EMOTION_TAG_LIMIT = 10

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/service/MonthlySettlementServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/service/MonthlySettlementServiceTest.kt
@@ -1,0 +1,148 @@
+package com.firstpenguin.app.domain.monthlysettlement.service
+
+import com.firstpenguin.app.domain.monthlysettlement.model.MonthlySettlementEmotionTag
+import com.firstpenguin.app.domain.monthlysettlement.model.MonthlySettlementSelectedBook
+import com.firstpenguin.app.domain.monthlysettlement.repository.MonthlySettlementEmotionAggregationRepository
+import com.firstpenguin.app.domain.monthlysettlement.repository.MonthlySettlementQuoteAggregationRepository
+import com.firstpenguin.app.domain.monthlysettlement.repository.MonthlySettlementRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.time.LocalDate
+import java.time.YearMonth
+import kotlin.test.assertEquals
+
+class MonthlySettlementServiceTest {
+    private lateinit var monthlySettlementRepository: MonthlySettlementRepository
+    private lateinit var monthlySettlementQuoteAggregationRepository:
+        MonthlySettlementQuoteAggregationRepository
+    private lateinit var monthlySettlementEmotionAggregationRepository:
+        MonthlySettlementEmotionAggregationRepository
+    private lateinit var monthlySettlementService: MonthlySettlementService
+
+    @BeforeEach
+    fun setUp() {
+        monthlySettlementRepository = Mockito.mock(MonthlySettlementRepository::class.java)
+        monthlySettlementQuoteAggregationRepository =
+            Mockito.mock(MonthlySettlementQuoteAggregationRepository::class.java)
+        monthlySettlementEmotionAggregationRepository =
+            Mockito.mock(MonthlySettlementEmotionAggregationRepository::class.java)
+        monthlySettlementService =
+            MonthlySettlementService(
+                monthlySettlementRepository,
+                monthlySettlementQuoteAggregationRepository,
+                monthlySettlementEmotionAggregationRepository,
+            )
+    }
+
+    @Test
+    fun `정확한 1위 감정 태그 후보가 없으면 같은 감정 범위 후보로 월말 책을 선택한다`() {
+        stubMonthlySettlementInputs()
+        Mockito
+            .`when`(
+                monthlySettlementEmotionAggregationRepository.findMonthlyBookCandidateByEmotionTagId(
+                    USER_ID,
+                    START,
+                    END_EXCLUSIVE,
+                    TAG_ID,
+                ),
+            ).thenReturn(null)
+        Mockito
+            .`when`(
+                monthlySettlementEmotionAggregationRepository.findMonthlyBookCandidateByEmotionRangeId(
+                    USER_ID,
+                    START,
+                    END_EXCLUSIVE,
+                    EMOTION_RANGE_ID,
+                ),
+            ).thenReturn(selectedBook())
+
+        val snapshot = monthlySettlementService.createSnapshot(USER_ID, YEAR_MONTH)
+
+        assertEquals(selectedBook(), snapshot?.settlement?.monthlyBook)
+        assertEquals(listOf(topEmotionTag()), snapshot?.emotionTags)
+    }
+
+    @Test
+    fun `정확한 1위 감정 태그 후보가 있으면 같은 감정 범위 후보를 조회하지 않는다`() {
+        stubMonthlySettlementInputs()
+        Mockito
+            .`when`(
+                monthlySettlementEmotionAggregationRepository.findMonthlyBookCandidateByEmotionTagId(
+                    USER_ID,
+                    START,
+                    END_EXCLUSIVE,
+                    TAG_ID,
+                ),
+            ).thenReturn(selectedBook())
+
+        val snapshot = monthlySettlementService.createSnapshot(USER_ID, YEAR_MONTH)
+
+        assertEquals(selectedBook(), snapshot?.settlement?.monthlyBook)
+        Mockito
+            .verify(monthlySettlementEmotionAggregationRepository, Mockito.never())
+            .findMonthlyBookCandidateByEmotionRangeId(USER_ID, START, END_EXCLUSIVE, EMOTION_RANGE_ID)
+    }
+
+    private fun stubMonthlySettlementInputs() {
+        Mockito
+            .`when`(monthlySettlementQuoteAggregationRepository.countRecommendedQuotes(USER_ID, START, END_EXCLUSIVE))
+            .thenReturn(SHARED_QUOTE_COUNT)
+        Mockito
+            .`when`(
+                monthlySettlementEmotionAggregationRepository.findEmotionTagCounts(
+                    USER_ID,
+                    START,
+                    END_EXCLUSIVE,
+                    EMOTION_TAG_LIMIT,
+                ),
+            ).thenReturn(listOf(topEmotionTag()))
+        Mockito
+            .`when`(monthlySettlementQuoteAggregationRepository.findMostFrequentGenre(USER_ID, START, END_EXCLUSIVE))
+            .thenReturn(null)
+    }
+
+    private fun topEmotionTag(): MonthlySettlementEmotionTag =
+        MonthlySettlementEmotionTag(
+            tagId = TAG_ID,
+            emotionRangeId = EMOTION_RANGE_ID,
+            label = TAG_LABEL,
+            count = TAG_COUNT,
+            sortOrder = 1,
+        )
+
+    private fun selectedBook(): MonthlySettlementSelectedBook =
+        MonthlySettlementSelectedBook(
+            quoteId = SELECTED_QUOTE_ID,
+            bookId = BOOK_ID,
+            quoteContent = QUOTE_CONTENT,
+            title = TITLE,
+            author = AUTHOR,
+            bookCoverImageUrl = BOOK_COVER_IMAGE_URL,
+            genre = GENRE,
+            bookPurchaseLink = BOOK_PURCHASE_LINK,
+        )
+
+    private companion object {
+        const val USER_ID = 1L
+        const val YEAR = 2026
+        const val MONTH = 3
+        const val SHARED_QUOTE_COUNT = 27
+        const val TAG_ID = 10L
+        const val EMOTION_RANGE_ID = 1L
+        const val TAG_LABEL = "무기력한"
+        const val TAG_COUNT = 5
+        const val EMOTION_TAG_LIMIT = 10
+        const val SELECTED_QUOTE_ID = 20L
+        const val BOOK_ID = 30L
+        const val QUOTE_CONTENT = "어떤 기억은 아물지 않습니다."
+        const val TITLE = "홍학의 자리"
+        const val AUTHOR = "정해연"
+        const val BOOK_COVER_IMAGE_URL = "https://cdn.example.com/book-cover-placeholder.png"
+        const val GENRE = "추리/미스터리 소설"
+        const val BOOK_PURCHASE_LINK = "https://www.aladin.co.kr/shop/wproduct.aspx?ItemId=1"
+        val YEAR_MONTH: YearMonth = YearMonth.of(YEAR, MONTH)
+        val START: LocalDate = YEAR_MONTH.atDay(1)
+        val END_EXCLUSIVE: LocalDate = YEAR_MONTH.plusMonths(1).atDay(1)
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/usecase/MonthlySettlementUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/monthlysettlement/usecase/MonthlySettlementUseCaseTest.kt
@@ -29,11 +29,11 @@ class MonthlySettlementUseCaseTest {
     }
 
     @Test
-    fun `저장된 월말 결산이 있으면 그대로 응답한다`() {
+    fun `월말 결산은 저장본 조회 없이 조합 결과로 응답한다`() {
         val targetMonth = YearMonth.now(SEOUL_ZONE).minusMonths(1)
         val snapshot = snapshot(targetMonth)
         Mockito
-            .`when`(monthlySettlementService.findSnapshot(USER_ID, targetMonth))
+            .`when`(monthlySettlementService.createSnapshot(USER_ID, targetMonth))
             .thenReturn(snapshot)
 
         val response =
@@ -49,16 +49,13 @@ class MonthlySettlementUseCaseTest {
         assertEquals(RECOMMENDATION_MESSAGE, response.recommendationMessage)
         assertEquals(SELECTED_QUOTE_ID, response.monthlyBook?.quoteId)
         assertEquals(BOOK_PURCHASE_LINK, response.monthlyBook?.bookPurchaseLink)
-        Mockito.verify(monthlySettlementService).findSnapshot(USER_ID, targetMonth)
-        Mockito.verify(monthlySettlementService, Mockito.never()).createSnapshot(USER_ID, targetMonth)
+        Mockito.verify(monthlySettlementService).createSnapshot(USER_ID, targetMonth)
+        Mockito.verify(monthlySettlementService, Mockito.never()).findSnapshot(USER_ID, targetMonth)
     }
 
     @Test
-    fun `저장된 결산도 생성 가능한 결산도 없으면 빈 응답을 반환한다`() {
+    fun `조합 가능한 결산이 없으면 빈 응답을 반환한다`() {
         val targetMonth = YearMonth.now(SEOUL_ZONE).minusMonths(1)
-        Mockito
-            .`when`(monthlySettlementService.findSnapshot(USER_ID, targetMonth))
-            .thenReturn(null)
         Mockito
             .`when`(monthlySettlementService.createSnapshot(USER_ID, targetMonth))
             .thenReturn(null)
@@ -78,15 +75,34 @@ class MonthlySettlementUseCaseTest {
     }
 
     @Test
-    fun `현재 월은 월말 결산 조회를 차단한다`() {
+    fun `현재 월도 월말 결산 조회를 허용한다`() {
         val currentMonth = YearMonth.now(SEOUL_ZONE)
+        val snapshot = snapshot(currentMonth)
+        Mockito
+            .`when`(monthlySettlementService.createSnapshot(USER_ID, currentMonth))
+            .thenReturn(snapshot)
+
+        val response =
+            monthlySettlementUseCase.getMonthlySettlement(
+                userId = USER_ID,
+                year = currentMonth.year,
+                month = currentMonth.monthValue,
+            )
+
+        assertEquals(SHARED_QUOTE_COUNT, response.sharedQuoteCount)
+        Mockito.verify(monthlySettlementService).createSnapshot(USER_ID, currentMonth)
+    }
+
+    @Test
+    fun `미래 월은 월말 결산 조회를 차단한다`() {
+        val futureMonth = YearMonth.now(SEOUL_ZONE).plusMonths(1)
 
         val exception =
             assertFailsWith<CustomException> {
                 monthlySettlementUseCase.getMonthlySettlement(
                     userId = USER_ID,
-                    year = currentMonth.year,
-                    month = currentMonth.monthValue,
+                    year = futureMonth.year,
+                    month = futureMonth.monthValue,
                 )
             }
 


### PR DESCRIPTION
## 작업 내용
- 월말 결산 조회에서 저장 snapshot 우선 조회를 제거하고 매 요청마다 추천 이력 기준으로 조합하도록 변경했습니다.
- 현재 월 조회를 허용하고 미래 월만 차단하도록 조회 가능 조건을 조정했습니다.
- 1위 감정 태그로 이달의 책 후보를 찾지 못하면 같은 emotionRange의 문장 감정 태그로 fallback 조회합니다.
- 동작 변경에 맞춰 usecase/service/repository 테스트를 추가 및 갱신했습니다.

## 검증
- `./gradlew formatKotlin test --tests 'com.firstpenguin.app.domain.monthlysettlement.*'`\n- `./gradlew formatKotlin test lintKotlin detekt`\n- push 전 hook 테스트 통과\n\nCloses #207