### PR TITLE
feat: prod 서버 인프라 및 도메인 설정 구성

### DIFF
--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -215,7 +215,7 @@ resource "google_storage_bucket" "images" {
   uniform_bucket_level_access = true
 
   cors {
-    origin          = ["https://dev.senti.today", "http://localhost:3000"]
+    origin          = ["https://dev.senti.today", "https://senti.today", "http://localhost:3000"]
     method          = ["GET", "PUT"]
     response_header = ["Content-Type", "Access-Control-Allow-Origin"]
     max_age_seconds = 3600


### PR DESCRIPTION
## 작업 배경

Closes #209

운영 도메인 `senti.today` 전환과 함께 dev/prod 서버 및 DB를 분리하기 위해 prod 전용 GCP 인프라를 구성합니다.

## 변경 사항

- dev GCS 이미지 버킷 CORS에 `https://senti.today` 추가
- prod Terraform state를 `terraform/prod` prefix로 분리
- prod 전용 VPC와 public/private subnet 구성
- prod 전용 VM과 static IP 구성
- VM boot disk 50GB, PostgreSQL persistent disk 100GB 구성
- PostgreSQL 데이터 디스크 삭제 방지 설정
- prod 환경에서 5432 외부 방화벽 미개방
- prod 전용 API 서비스 계정 및 GCS 이미지 버킷 구성
- private config 저장소의 prod 설정 반영 후 submodule pointer 갱신

공개 PR에는 private config의 실제 값이나 민감정보를 포함하지 않습니다.

## 검증

- `terraform -chdir=infra/terraform/prod fmt -check -recursive`
- `terraform -chdir=infra/terraform/prod validate`
- prod plan: `15 to add, 0 to change, 0 to destroy`
- gitleaks 통과
- Gradle test 통과

## 후속 작업

- prod Terraform apply
- PostgreSQL 데이터 디스크 mount 및 prod Docker Compose 구성
- dev DB dump 후 prod DB restore
- GitHub prod Environment secret 설정
- OAuth redirect URI 및 DNS/proxy 설정
