### PR TITLE
feat: prod 서버 배포 구성 반영

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,6 +44,18 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Dev 배포 스크립트 동기화
+        if: github.ref_name == 'dev'
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          source: scripts/deploy-dev.sh
+          target: /opt/firstpenguin/scripts
+          strip_components: 1
+          overwrite: true
+
       - name: Prod Compose 파일 동기화
         if: github.ref_name == 'main'
         uses: appleboy/scp-action@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,6 +44,29 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Prod Compose 파일 동기화
+        if: github.ref_name == 'main'
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          source: docker-compose-prod.yml
+          target: /opt/firstpenguin/app
+          overwrite: true
+
+      - name: Prod 배포 스크립트 동기화
+        if: github.ref_name == 'main'
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          source: scripts/deploy-prod.sh
+          target: /opt/firstpenguin/scripts
+          strip_components: 1
+          overwrite: true
+
       - name: 서버 배포
         uses: appleboy/ssh-action@v1
         with:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
       interval: 5s
       timeout: 3s
       retries: 3

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - postgres-data-local:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
       interval: 5s
       timeout: 3s
       retries: 3

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -28,7 +28,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,39 @@
+name: firstpenguin-prod
+
+services:
+  app:
+    image: ghcr.io/depromeet/18th-team1-be/api:main
+    container_name: firstpenguin-prod-api
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      TZ: Asia/Seoul
+    env_file:
+      - .env
+    volumes:
+      - ./config:/app/config:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  db:
+    image: pgvector/pgvector:pg17
+    container_name: firstpenguin-prod-db
+    ports:
+      - "5432:5432"
+    env_file:
+      - .env
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  postgres-data:
+    name: firstpenguin-prod-postgres-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
       interval: 5s
       timeout: 3s
       retries: 3

--- a/infra/terraform/prod/.terraform.lock.hcl
+++ b/infra/terraform/prod/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -134,26 +134,6 @@ resource "google_compute_address" "api" {
 }
 
 # ============================================
-# Persistent Disk
-# ============================================
-resource "google_compute_disk" "postgres_data" {
-  name = "${var.env}-${var.service_name}-disk-postgres-data"
-  type = var.postgres_disk_type
-  zone = var.zone
-  size = var.postgres_disk_size_gb
-
-  lifecycle {
-    prevent_destroy = true
-  }
-
-  labels = {
-    env     = var.env
-    service = var.service_name
-    role    = "postgres-data"
-  }
-}
-
-# ============================================
 # VM Instance
 # ============================================
 resource "google_compute_instance" "api" {
@@ -179,12 +159,6 @@ resource "google_compute_instance" "api" {
       size  = var.boot_disk_size_gb
       type  = var.boot_disk_type
     }
-  }
-
-  attached_disk {
-    source      = google_compute_disk.postgres_data.id
-    device_name = "postgres-data"
-    mode        = "READ_WRITE"
   }
 
   network_interface {

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -1,2 +1,241 @@
-# prod 환경은 추후 구성
-# dev/main.tf를 참고하여 prod 값으로 설정
+terraform {
+  required_version = ">= 1.0"
+
+  backend "gcs" {
+    bucket = "firstpenguin-tf-state"
+    prefix = "terraform/prod"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+locals {
+  instance_ssh_keys = [
+    for ssh_key in var.ssh_public_keys : "${ssh_key.user}:${ssh_key.key}"
+  ]
+}
+
+# ============================================
+# VPC
+# ============================================
+resource "google_compute_network" "vpc" {
+  name                    = "${var.env}-${var.service_name}-vpc"
+  auto_create_subnetworks = false
+}
+
+# ============================================
+# Subnets
+# ============================================
+resource "google_compute_subnetwork" "public" {
+  name          = "${var.env}-${var.service_name}-subnet-public"
+  ip_cidr_range = var.public_subnet_cidr
+  region        = var.region
+  network       = google_compute_network.vpc.id
+}
+
+resource "google_compute_subnetwork" "private" {
+  name          = "${var.env}-${var.service_name}-subnet-private"
+  ip_cidr_range = var.private_subnet_cidr
+  region        = var.region
+  network       = google_compute_network.vpc.id
+}
+
+# ============================================
+# Firewall Rules
+# ============================================
+resource "google_compute_firewall" "allow_ssh" {
+  name    = "${var.env}-${var.service_name}-fw-allow-ssh"
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  target_tags   = ["api-server"]
+  source_ranges = var.ssh_source_ranges
+}
+
+resource "google_compute_firewall" "allow_app" {
+  name    = "${var.env}-${var.service_name}-fw-allow-app"
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8080"]
+  }
+
+  target_tags   = ["api-server"]
+  source_ranges = var.app_source_ranges
+}
+
+resource "google_compute_firewall" "allow_icmp" {
+  name    = "${var.env}-${var.service_name}-fw-allow-icmp"
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "icmp"
+  }
+
+  target_tags   = ["api-server"]
+  source_ranges = var.icmp_source_ranges
+}
+
+resource "google_compute_firewall" "allow_internal" {
+  name    = "${var.env}-${var.service_name}-fw-allow-internal"
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["0-65535"]
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = var.internal_source_ranges
+}
+
+# ============================================
+# Static IP
+# ============================================
+resource "google_compute_address" "api" {
+  name   = "${var.env}-${var.service_name}-ip-api"
+  region = var.region
+}
+
+# ============================================
+# Persistent Disk
+# ============================================
+resource "google_compute_disk" "postgres_data" {
+  name = "${var.env}-${var.service_name}-disk-postgres-data"
+  type = var.postgres_disk_type
+  zone = var.zone
+  size = var.postgres_disk_size_gb
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  labels = {
+    env     = var.env
+    service = var.service_name
+    role    = "postgres-data"
+  }
+}
+
+# ============================================
+# VM Instance
+# ============================================
+resource "google_compute_instance" "api" {
+  name         = "${var.env}-${var.service_name}-vm-api"
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  allow_stopping_for_update = true
+  deletion_protection       = var.vm_deletion_protection
+
+  metadata = merge(
+    {
+      block-project-ssh-keys = "true"
+    },
+    length(local.instance_ssh_keys) > 0 ? {
+      ssh-keys = join("\n", local.instance_ssh_keys)
+    } : {}
+  )
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
+      size  = var.boot_disk_size_gb
+      type  = var.boot_disk_type
+    }
+  }
+
+  attached_disk {
+    source      = google_compute_disk.postgres_data.id
+    device_name = "postgres-data"
+    mode        = "READ_WRITE"
+  }
+
+  network_interface {
+    network    = google_compute_network.vpc.id
+    subnetwork = google_compute_subnetwork.public.id
+
+    access_config {
+      nat_ip = google_compute_address.api.address
+    }
+  }
+
+  service_account {
+    email  = google_service_account.api.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags = ["api-server", "db-server"]
+
+  labels = {
+    env     = var.env
+    service = var.service_name
+  }
+}
+
+# ============================================
+# Service Account (이미지 버킷용)
+# ============================================
+resource "google_service_account" "api" {
+  account_id   = "${var.env}-${var.service_name}-api-sa"
+  display_name = "${var.env} API Server Service Account"
+}
+
+resource "google_service_account_iam_member" "api_sa_token_creator" {
+  service_account_id = google_service_account.api.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.api.email}"
+}
+
+# ============================================
+# GCS Image Bucket
+# ============================================
+resource "google_storage_bucket" "images" {
+  name          = "${var.env}-${var.service_name}-images"
+  location      = var.region
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+
+  cors {
+    origin          = var.gcs_cors_origins
+    method          = ["GET", "PUT"]
+    response_header = ["Content-Type", "Access-Control-Allow-Origin"]
+    max_age_seconds = 3600
+  }
+}
+
+resource "google_storage_bucket_iam_member" "images_public_read" {
+  bucket = google_storage_bucket.images.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+resource "google_storage_bucket_iam_member" "images_api_sa_admin" {
+  bucket = google_storage_bucket.images.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.api.email}"
+}

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -79,6 +79,19 @@ resource "google_compute_firewall" "allow_app" {
   source_ranges = var.app_source_ranges
 }
 
+resource "google_compute_firewall" "allow_postgres" {
+  name    = "${var.env}-${var.service_name}-fw-allow-postgres"
+  network = google_compute_network.vpc.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["5432"]
+  }
+
+  target_tags   = ["db-server"]
+  source_ranges = var.postgres_source_ranges
+}
+
 resource "google_compute_firewall" "allow_icmp" {
   name    = "${var.env}-${var.service_name}-fw-allow-icmp"
   network = google_compute_network.vpc.id

--- a/infra/terraform/prod/outputs.tf
+++ b/infra/terraform/prod/outputs.tf
@@ -1,0 +1,29 @@
+output "vm_external_ip" {
+  description = "VM 외부 IP"
+  value       = google_compute_address.api.address
+}
+
+output "vm_name" {
+  description = "VM 인스턴스 이름"
+  value       = google_compute_instance.api.name
+}
+
+output "vpc_name" {
+  description = "VPC 이름"
+  value       = google_compute_network.vpc.name
+}
+
+output "image_bucket_name" {
+  description = "GCS 이미지 버킷 이름"
+  value       = google_storage_bucket.images.name
+}
+
+output "service_account_email" {
+  description = "API 서버 서비스 계정 이메일"
+  value       = google_service_account.api.email
+}
+
+output "postgres_data_disk_name" {
+  description = "PostgreSQL 데이터 디스크 이름"
+  value       = google_compute_disk.postgres_data.name
+}

--- a/infra/terraform/prod/outputs.tf
+++ b/infra/terraform/prod/outputs.tf
@@ -22,8 +22,3 @@ output "service_account_email" {
   description = "API 서버 서비스 계정 이메일"
   value       = google_service_account.api.email
 }
-
-output "postgres_data_disk_name" {
-  description = "PostgreSQL 데이터 디스크 이름"
-  value       = google_compute_disk.postgres_data.name
-}

--- a/infra/terraform/prod/terraform.tfvars
+++ b/infra/terraform/prod/terraform.tfvars
@@ -1,0 +1,38 @@
+project_id   = "project-10e57bb0-e960-4b16-9fa"
+region       = "asia-northeast3"
+zone         = "asia-northeast3-a"
+env          = "prod"
+service_name = "firstpenguin"
+machine_type = "e2-medium"
+
+boot_disk_size_gb     = 50
+boot_disk_type        = "pd-ssd"
+postgres_disk_size_gb = 100
+postgres_disk_type    = "pd-ssd"
+
+public_subnet_cidr     = "10.1.1.0/24"
+private_subnet_cidr    = "10.1.10.0/24"
+internal_source_ranges = ["10.1.0.0/16"]
+
+ssh_source_ranges  = ["0.0.0.0/0"]
+app_source_ranges  = ["0.0.0.0/0"]
+icmp_source_ranges = ["0.0.0.0/0"]
+
+gcs_cors_origins = [
+  "https://senti.today",
+]
+
+ssh_public_keys = [
+  {
+    user = "ubuntu"
+    key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCqxGaKI8EFWkYt5MUmVkilFEbVA6a8iheAzU6hSA/e5FcdOXOabkZF135eE5pWAqIhwRnFZqsv33/xSnjXoa4uqcV2yPjTdr6iV4ed5dTerBfVwru8MNySPsy2J3gDlTJgyXSdpqwsSfmDvKF3taJw3+kHm/aH95uJ5ROQBKsDRcXDxdUeHFJOEwdWI/Z1nEpCfCWk6r53e0T1cZnXlmFc28TRLcP0q+fHxwgZQsxBXSqlUuJ069EYTpXlN3eAUVr5HIT3P0nHx0iUx6+OiZIxbcgH6uSB5LTHvvTIlUoN/icYdRjhPKEqpbm4CR3vco4C6/SzGD1Qci7oHqBG38iT8+Im1SFQTlDmLPFAF5uvgudf3Ih4uu8kX7mvPXQmCMI8k8BhXkrfPv+UN7cTecokW9j0o5vkw7HgG51qovGJ3gjhB4+yeQyyCcU9xhs876frH+Hs86udX1eNaV2j3XK/VvSFjjWXvZbbXzgdcgiM9uFqksJTHSTKkb5nMALU8E0= kimsj@MacBook-Pro-4.local"
+  },
+  {
+    user = "ubuntu"
+    key  = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFlgZGizA/SJSCulz3GkHD4EIX0OggijIPTcYLX+SKwd"
+  },
+  {
+    user = "ubuntu"
+    key  = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJmEd2Y1//SM9jRchQF4UT4nhBGCr+eVTEQlNhj1oxC2"
+  },
+]

--- a/infra/terraform/prod/terraform.tfvars
+++ b/infra/terraform/prod/terraform.tfvars
@@ -3,7 +3,7 @@ region       = "asia-northeast3"
 zone         = "asia-northeast3-a"
 env          = "prod"
 service_name = "firstpenguin"
-machine_type = "e2-medium"
+machine_type = "e2-standard-2"
 
 boot_disk_size_gb     = 50
 boot_disk_type        = "pd-ssd"
@@ -14,9 +14,10 @@ public_subnet_cidr     = "10.1.1.0/24"
 private_subnet_cidr    = "10.1.10.0/24"
 internal_source_ranges = ["10.1.0.0/16"]
 
-ssh_source_ranges  = ["0.0.0.0/0"]
-app_source_ranges  = ["0.0.0.0/0"]
-icmp_source_ranges = ["0.0.0.0/0"]
+ssh_source_ranges      = ["0.0.0.0/0"]
+app_source_ranges      = ["0.0.0.0/0"]
+postgres_source_ranges = ["0.0.0.0/0"]
+icmp_source_ranges     = ["0.0.0.0/0"]
 
 gcs_cors_origins = [
   "https://senti.today",

--- a/infra/terraform/prod/terraform.tfvars
+++ b/infra/terraform/prod/terraform.tfvars
@@ -5,10 +5,8 @@ env          = "prod"
 service_name = "firstpenguin"
 machine_type = "e2-standard-2"
 
-boot_disk_size_gb     = 50
-boot_disk_type        = "pd-ssd"
-postgres_disk_size_gb = 100
-postgres_disk_type    = "pd-ssd"
+boot_disk_size_gb = 100
+boot_disk_type    = "pd-ssd"
 
 public_subnet_cidr     = "10.1.1.0/24"
 private_subnet_cidr    = "10.1.10.0/24"

--- a/infra/terraform/prod/variables.tf
+++ b/infra/terraform/prod/variables.tf
@@ -30,7 +30,7 @@ variable "service_name" {
 variable "machine_type" {
   description = "VM 머신 타입"
   type        = string
-  default     = "e2-medium"
+  default     = "e2-standard-2"
 }
 
 variable "boot_disk_size_gb" {
@@ -83,6 +83,12 @@ variable "ssh_source_ranges" {
 
 variable "app_source_ranges" {
   description = "8080 애플리케이션 접근 허용 CIDR 목록"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "postgres_source_ranges" {
+  description = "5432 PostgreSQL 접근 허용 CIDR 목록"
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }

--- a/infra/terraform/prod/variables.tf
+++ b/infra/terraform/prod/variables.tf
@@ -36,23 +36,11 @@ variable "machine_type" {
 variable "boot_disk_size_gb" {
   description = "VM boot disk 크기(GB)"
   type        = number
-  default     = 50
+  default     = 100
 }
 
 variable "boot_disk_type" {
   description = "VM boot disk 타입"
-  type        = string
-  default     = "pd-ssd"
-}
-
-variable "postgres_disk_size_gb" {
-  description = "PostgreSQL 데이터 디스크 크기(GB)"
-  type        = number
-  default     = 100
-}
-
-variable "postgres_disk_type" {
-  description = "PostgreSQL 데이터 디스크 타입"
   type        = string
   default     = "pd-ssd"
 }

--- a/infra/terraform/prod/variables.tf
+++ b/infra/terraform/prod/variables.tf
@@ -1,0 +1,115 @@
+variable "project_id" {
+  description = "GCP 프로젝트 ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP 리전"
+  type        = string
+  default     = "asia-northeast3"
+}
+
+variable "zone" {
+  description = "GCP 존"
+  type        = string
+  default     = "asia-northeast3-a"
+}
+
+variable "env" {
+  description = "환경 (dev, prod)"
+  type        = string
+  default     = "prod"
+}
+
+variable "service_name" {
+  description = "서비스 이름"
+  type        = string
+  default     = "firstpenguin"
+}
+
+variable "machine_type" {
+  description = "VM 머신 타입"
+  type        = string
+  default     = "e2-medium"
+}
+
+variable "boot_disk_size_gb" {
+  description = "VM boot disk 크기(GB)"
+  type        = number
+  default     = 50
+}
+
+variable "boot_disk_type" {
+  description = "VM boot disk 타입"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "postgres_disk_size_gb" {
+  description = "PostgreSQL 데이터 디스크 크기(GB)"
+  type        = number
+  default     = 100
+}
+
+variable "postgres_disk_type" {
+  description = "PostgreSQL 데이터 디스크 타입"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "vm_deletion_protection" {
+  description = "VM 삭제 보호 활성화 여부"
+  type        = bool
+  default     = true
+}
+
+variable "public_subnet_cidr" {
+  description = "public subnet CIDR"
+  type        = string
+  default     = "10.1.1.0/24"
+}
+
+variable "private_subnet_cidr" {
+  description = "private subnet CIDR"
+  type        = string
+  default     = "10.1.10.0/24"
+}
+
+variable "ssh_source_ranges" {
+  description = "SSH 접근 허용 CIDR 목록"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "app_source_ranges" {
+  description = "8080 애플리케이션 접근 허용 CIDR 목록"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "icmp_source_ranges" {
+  description = "ICMP 접근 허용 CIDR 목록"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "internal_source_ranges" {
+  description = "VPC 내부 통신 허용 CIDR 목록"
+  type        = list(string)
+  default     = ["10.1.0.0/16"]
+}
+
+variable "ssh_public_keys" {
+  description = "VM 인스턴스에 등록할 SSH 공개키 목록"
+  type = list(object({
+    user = string
+    key  = string
+  }))
+  default = []
+}
+
+variable "gcs_cors_origins" {
+  description = "GCS 이미지 버킷 CORS origin 목록"
+  type        = list(string)
+  default     = ["https://senti.today"]
+}

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-set -e
+set -Eeuo pipefail
 
 IMAGE="ghcr.io/depromeet/18th-team1-be/api"
 APP_DIR="/opt/firstpenguin/app"
 CONFIG_DIR="/opt/firstpenguin/app/config"
+HEALTHCHECK_MAX_ATTEMPTS=24
+HEALTHCHECK_INTERVAL_SECONDS=5
 
 echo "=== 설정 파일 업데이트 ==="
 cd "$CONFIG_DIR"
@@ -17,13 +19,26 @@ cd "$APP_DIR"
 docker compose -f docker-compose-dev.yml up -d --force-recreate app
 
 echo "=== 헬스체크 ==="
-for i in $(seq 1 6); do
-  curl -sSf --connect-timeout 2 --max-time 3 \
-    http://localhost:8080/api/actuator/health && break
-  echo "대기 중... ($i/6)"
-  sleep 5
-  [ "$i" -eq 6 ] && echo "헬스체크 실패: 앱이 30초 내에 뜨지 않았습니다." && exit 1
+healthcheck_succeeded=false
+for attempt in $(seq 1 "$HEALTHCHECK_MAX_ATTEMPTS"); do
+  if curl -sSf --connect-timeout 2 --max-time 3 \
+    http://localhost:8080/api/actuator/health >/dev/null; then
+    echo "헬스체크 성공"
+    healthcheck_succeeded=true
+    break
+  fi
+
+  echo "대기 중... ($attempt/$HEALTHCHECK_MAX_ATTEMPTS)"
+  if [ "$attempt" -lt "$HEALTHCHECK_MAX_ATTEMPTS" ]; then
+    sleep "$HEALTHCHECK_INTERVAL_SECONDS"
+  fi
 done
+
+if [ "$healthcheck_succeeded" != true ]; then
+  echo "헬스체크 실패: 제한 시간 내에 앱이 준비되지 않았습니다."
+  docker compose -f docker-compose-dev.yml logs --tail=100 app
+  exit 1
+fi
 
 echo "=== 이전 이미지 정리 ==="
 docker image prune -f

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -4,6 +4,8 @@ set -Eeuo pipefail
 APP_DIR="/opt/firstpenguin/app"
 CONFIG_DIR="$APP_DIR/config"
 COMPOSE_FILE="$APP_DIR/docker-compose-prod.yml"
+HEALTHCHECK_MAX_ATTEMPTS=24
+HEALTHCHECK_INTERVAL_SECONDS=5
 
 for required_file in "$APP_DIR/.env" "$COMPOSE_FILE" "$CONFIG_DIR/application-prod.yml"; do
   if [ ! -f "$required_file" ]; then
@@ -30,7 +32,7 @@ echo "=== 앱 재시작 ==="
 docker compose -f "$COMPOSE_FILE" up -d --no-deps --force-recreate app
 
 echo "=== 헬스체크 ==="
-for attempt in $(seq 1 12); do
+for attempt in $(seq 1 "$HEALTHCHECK_MAX_ATTEMPTS"); do
   if curl -sSf --connect-timeout 2 --max-time 3 \
     http://localhost:8080/api/actuator/health >/dev/null; then
     echo "헬스체크 성공"
@@ -39,10 +41,12 @@ for attempt in $(seq 1 12); do
     exit 0
   fi
 
-  echo "대기 중... ($attempt/12)"
-  sleep 5
+  echo "대기 중... ($attempt/$HEALTHCHECK_MAX_ATTEMPTS)"
+  if [ "$attempt" -lt "$HEALTHCHECK_MAX_ATTEMPTS" ]; then
+    sleep "$HEALTHCHECK_INTERVAL_SECONDS"
+  fi
 done
 
-echo "헬스체크 실패: 앱이 60초 내에 준비되지 않았습니다."
+echo "헬스체크 실패: 제한 시간 내에 앱이 준비되지 않았습니다."
 docker compose -f "$COMPOSE_FILE" logs --tail=100 app
 exit 1

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+APP_DIR="/opt/firstpenguin/app"
+CONFIG_DIR="$APP_DIR/config"
+COMPOSE_FILE="$APP_DIR/docker-compose-prod.yml"
+
+for required_file in "$APP_DIR/.env" "$COMPOSE_FILE" "$CONFIG_DIR/application-prod.yml"; do
+  if [ ! -f "$required_file" ]; then
+    echo "필수 파일이 없습니다: $required_file"
+    exit 1
+  fi
+done
+
+echo "=== 설정 파일 업데이트 ==="
+git -C "$CONFIG_DIR" pull --ff-only origin main
+
+cd "$APP_DIR"
+
+echo "=== Compose 설정 검증 ==="
+docker compose -f "$COMPOSE_FILE" config --quiet
+
+echo "=== 최신 이미지 pull ==="
+docker compose -f "$COMPOSE_FILE" pull app
+
+echo "=== DB 실행 ==="
+docker compose -f "$COMPOSE_FILE" up -d db
+
+echo "=== 앱 재시작 ==="
+docker compose -f "$COMPOSE_FILE" up -d --no-deps --force-recreate app
+
+echo "=== 헬스체크 ==="
+for attempt in $(seq 1 12); do
+  if curl -sSf --connect-timeout 2 --max-time 3 \
+    http://localhost:8080/api/actuator/health >/dev/null; then
+    echo "헬스체크 성공"
+    docker image prune -f
+    docker ps --filter "name=firstpenguin-prod"
+    exit 0
+  fi
+
+  echo "대기 중... ($attempt/12)"
+  sleep 5
+done
+
+echo "헬스체크 실패: 앱이 60초 내에 준비되지 않았습니다."
+docker compose -f "$COMPOSE_FILE" logs --tail=100 app
+exit 1


### PR DESCRIPTION
## 📢 요약

- Prod 전용 Terraform, Docker Compose, 배포 스크립트를 `main`에 반영합니다.
- Prod VM은 `e2-standard-2`, 단일 `100GB pd-ssd` boot disk로 구성합니다.
- `main` 머지 시 Prod 이미지 빌드, Compose/스크립트 SCP, 서버 배포가 실행됩니다.
- PostgreSQL healthcheck와 애플리케이션 배포 대기 시간을 보완합니다.

🔗 연관 이슈: #209

## ✅ 체크리스트

- [x] 커밋 컨벤션 준수
- [x] Gradle 전체 테스트 완료
- [x] Terraform fmt/validate/plan/apply 확인
- [x] Docker Compose 및 배포 스크립트 검증

## 📸 스크린샷 / 테스트 결과

- Prod Terraform apply: `15 added, 0 changed, 0 destroyed`
- Apply 후 Terraform plan: `No changes`
- Prod VM boot disk: `100GB pd-ssd` 1개
- PR #211 CI 및 CodeRabbit 검사 통과

## 📜 기타

- 이 PR을 머지하면 `main` push로 Prod CD가 실행됩니다.
- Prod Environment의 서버 SSH 설정과 private config Deploy Key 구성을 완료했습니다.
- 배포 확인 후 Dev DB dump를 Prod DB에 restore합니다.