### PR TITLE
feat: 사용자 가입일 공개 조회 API 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
@@ -117,6 +117,7 @@ class SecurityConfig(
                 "/oauth2/**",
                 "/login/oauth2/**",
                 "/monthly-settlements/shared",
+                "/users/*/signup-date",
                 "/swagger-ui/**",
                 "/swagger-ui.html",
                 "/v3/api-docs/**",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/controller/UserController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/controller/UserController.kt
@@ -4,6 +4,7 @@ import com.firstpenguin.app.domain.auth.model.AuthenticatedUser
 import com.firstpenguin.app.domain.auth.token.RefreshTokenCookieManager
 import com.firstpenguin.app.domain.user.dto.UpdateUserRequest
 import com.firstpenguin.app.domain.user.dto.UserResponse
+import com.firstpenguin.app.domain.user.dto.UserSignupDateResponse
 import com.firstpenguin.app.domain.user.usecase.UserUseCase
 import com.firstpenguin.app.global.response.ErrorResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -21,17 +22,52 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/users")
-@Tag(name = "사용자", description = "로그인한 사용자 정보 API")
+@Tag(name = "사용자", description = "사용자 정보 API")
 class UserController(
     private val refreshTokenCookieManager: RefreshTokenCookieManager,
     private val userUseCase: UserUseCase,
 ) {
+    @GetMapping("/{userId}/signup-date")
+    @Operation(
+        summary = "사용자 가입일 조회",
+        description = "인증 없이 사용자 ID로 가입일을 조회합니다. signupDate는 yyyy-MM-dd 형식입니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "사용자 가입일 조회 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = UserSignupDateResponse::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없습니다.",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ErrorResponse::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getSignupDate(
+        @Parameter(description = "사용자 ID", example = "1")
+        @PathVariable userId: Long,
+    ): UserSignupDateResponse = userUseCase.getSignupDate(userId)
+
     @GetMapping("/me")
     @Operation(
         summary = "내 정보 조회",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/dto/UserSignupDateResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/dto/UserSignupDateResponse.kt
@@ -1,0 +1,15 @@
+package com.firstpenguin.app.domain.user.dto
+
+import com.firstpenguin.app.domain.user.model.User
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "사용자 가입일 응답")
+data class UserSignupDateResponse(
+    @field:Schema(description = "가입한 날짜", example = "2026-06-13")
+    val signupDate: LocalDate,
+) {
+    companion object {
+        fun from(user: User): UserSignupDateResponse = UserSignupDateResponse(signupDate = user.createdAt.toLocalDate())
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCase.kt
@@ -4,6 +4,7 @@ import com.firstpenguin.app.domain.auth.service.RefreshTokenService
 import com.firstpenguin.app.domain.image.service.ImageService
 import com.firstpenguin.app.domain.user.dto.UpdateUserRequest
 import com.firstpenguin.app.domain.user.dto.UserResponse
+import com.firstpenguin.app.domain.user.dto.UserSignupDateResponse
 import com.firstpenguin.app.domain.user.service.OAuthUserService
 import com.firstpenguin.app.domain.user.service.UserService
 import com.firstpenguin.app.global.exception.CustomException
@@ -18,6 +19,9 @@ class UserUseCase(
     private val refreshTokenService: RefreshTokenService,
     private val userService: UserService,
 ) {
+    @Transactional(readOnly = true)
+    fun getSignupDate(userId: Long): UserSignupDateResponse = UserSignupDateResponse.from(userService.getById(userId))
+
     @Transactional(readOnly = true)
     fun getMe(userId: Long): UserResponse {
         val user = userService.getById(userId)

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfigTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfigTest.kt
@@ -29,6 +29,11 @@ class SecurityConfigTest {
         assertTrue(permitAllPatterns().contains("/monthly-settlements/shared"))
     }
 
+    @Test
+    fun `사용자 가입일 조회 API는 인증 없이 접근할 수 있다`() {
+        assertTrue(permitAllPatterns().contains("/users/*/signup-date"))
+    }
+
     private fun permitAllPatterns(): List<String> {
         val field = SecurityConfig::class.java.getDeclaredField("PERMIT_ALL_PATTERNS")
         field.isAccessible = true

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/controller/UserControllerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/controller/UserControllerTest.kt
@@ -1,0 +1,41 @@
+package com.firstpenguin.app.domain.user.controller
+
+import com.firstpenguin.app.domain.auth.token.RefreshTokenCookieManager
+import com.firstpenguin.app.domain.user.dto.UserSignupDateResponse
+import com.firstpenguin.app.domain.user.usecase.UserUseCase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.time.LocalDate
+import kotlin.test.assertEquals
+
+class UserControllerTest {
+    private lateinit var userUseCase: UserUseCase
+    private lateinit var userController: UserController
+
+    @BeforeEach
+    fun setUp() {
+        userUseCase = Mockito.mock(UserUseCase::class.java)
+        userController =
+            UserController(
+                refreshTokenCookieManager = Mockito.mock(RefreshTokenCookieManager::class.java),
+                userUseCase = userUseCase,
+            )
+    }
+
+    @Test
+    fun `사용자 ID로 가입일을 조회한다`() {
+        val response = UserSignupDateResponse(SIGNUP_DATE)
+        Mockito.`when`(userUseCase.getSignupDate(USER_ID)).thenReturn(response)
+
+        val result = userController.getSignupDate(USER_ID)
+
+        assertEquals(response, result)
+        Mockito.verify(userUseCase).getSignupDate(USER_ID)
+    }
+
+    private companion object {
+        const val USER_ID = 1L
+        val SIGNUP_DATE: LocalDate = LocalDate.of(2026, 6, 13)
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/service/UserServiceTest.kt
@@ -24,6 +24,15 @@ class UserServiceTest {
     }
 
     @Test
+    fun `존재하지 않는 사용자 조회 시 실패한다`() {
+        Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(null)
+
+        val exception = assertFailsWith<CustomException> { userService.getById(USER_ID) }
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
     fun `인증 사용자가 존재하지 않으면 인증 실패`() {
         Mockito.`when`(userRepository.findById(USER_ID)).thenReturn(null)
 

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/user/usecase/UserUseCaseTest.kt
@@ -32,6 +32,17 @@ class UserUseCaseTest {
     }
 
     @Test
+    fun `사용자 ID로 가입일을 조회한다`() {
+        val user = user()
+        Mockito.`when`(userService.getById(USER_ID)).thenReturn(user)
+
+        val response = userUseCase.getSignupDate(USER_ID)
+
+        assertEquals(user.createdAt.toLocalDate(), response.signupDate)
+        Mockito.verify(userService).getById(USER_ID)
+    }
+
+    @Test
     fun `내 정보 조회 응답에 OAuth provider와 가입한 날짜를 포함한다`() {
         val user = user()
         val oAuthAccount = oAuthAccount()


### PR DESCRIPTION
## 📢 요약
- 인증 없이 사용자 ID로 가입일을 조회하는 `GET /users/{userId}/signup-date` API를 추가했습니다.
- 가입일만 노출하는 응답 DTO와 사용자 조회 usecase를 추가했습니다.
- 해당 경로를 Spring Security 공개 경로로 등록했습니다.
- controller, usecase, service, 보안 설정 테스트를 추가했습니다.

🔗 연관 이슈: Resolves #214

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 테스트 완료
- [x] API 문서 업데이트

## 📸 스크린샷 / 테스트 결과
pre-push 훅의 전체 테스트가 통과했습니다.

응답 예시:

```json
{
  "signupDate": "2026-06-13"
}
```

## 📜 기타
- 존재하지 않는 사용자 ID는 기존 `USER_NOT_FOUND` 오류로 404를 반환합니다.
- DB 스키마 변경은 없습니다.
