### PR TITLE
feat: 실행 환경 확인 API 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
@@ -122,6 +122,7 @@ class SecurityConfig(
                 "/swagger-ui.html",
                 "/v3/api-docs/**",
                 "/error",
+                "/system/environment",
                 "/actuator/health",
             )
     }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/system/controller/SystemController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/system/controller/SystemController.kt
@@ -1,10 +1,9 @@
 package com.firstpenguin.app.domain.system.controller
 
 import com.firstpenguin.app.domain.system.dto.EnvironmentResponse
+import com.firstpenguin.app.domain.system.usecase.SystemUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.core.env.Environment
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -13,18 +12,9 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/system")
 @Tag(name = "시스템", description = "시스템 상태 확인 API")
 class SystemController(
-    private val environment: Environment,
-    @Value("\${app.token.enabled:false}") private val devTokenEnabled: Boolean,
+    private val systemUseCase: SystemUseCase,
 ) {
     @GetMapping("/environment")
     @Operation(summary = "실행 환경 확인 API", description = "민감정보 없이 active profile과 개발용 토큰 활성화 여부를 반환한다.")
-    fun getEnvironment(): EnvironmentResponse {
-        val activeProfiles = environment.activeProfiles.toList().ifEmpty { listOf(DEFAULT_PROFILE) }
-        return EnvironmentResponse(activeProfiles, activeProfiles.contains(PROD_PROFILE), devTokenEnabled)
-    }
-
-    private companion object {
-        const val DEFAULT_PROFILE = "default"
-        const val PROD_PROFILE = "prod"
-    }
+    fun getEnvironment(): EnvironmentResponse = systemUseCase.getEnvironment()
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/system/controller/SystemController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/system/controller/SystemController.kt
@@ -1,0 +1,30 @@
+package com.firstpenguin.app.domain.system.controller
+
+import com.firstpenguin.app.domain.system.dto.EnvironmentResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.env.Environment
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/system")
+@Tag(name = "시스템", description = "시스템 상태 확인 API")
+class SystemController(
+    private val environment: Environment,
+    @Value("\${app.token.enabled:false}") private val devTokenEnabled: Boolean,
+) {
+    @GetMapping("/environment")
+    @Operation(summary = "실행 환경 확인 API", description = "민감정보 없이 active profile과 개발용 토큰 활성화 여부를 반환한다.")
+    fun getEnvironment(): EnvironmentResponse {
+        val activeProfiles = environment.activeProfiles.toList().ifEmpty { listOf(DEFAULT_PROFILE) }
+        return EnvironmentResponse(activeProfiles, activeProfiles.contains(PROD_PROFILE), devTokenEnabled)
+    }
+
+    private companion object {
+        const val DEFAULT_PROFILE = "default"
+        const val PROD_PROFILE = "prod"
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/system/dto/EnvironmentResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/system/dto/EnvironmentResponse.kt
@@ -1,0 +1,7 @@
+package com.firstpenguin.app.domain.system.dto
+
+data class EnvironmentResponse(
+    val activeProfiles: List<String>,
+    val prod: Boolean,
+    val devTokenEnabled: Boolean,
+)

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/system/usecase/SystemUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/system/usecase/SystemUseCase.kt
@@ -1,0 +1,24 @@
+package com.firstpenguin.app.domain.system.usecase
+
+import com.firstpenguin.app.domain.system.dto.EnvironmentResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Service
+
+@Service
+class SystemUseCase(
+    private val environment: Environment,
+    @Value("\${app.token.enabled:false}") private val devTokenEnabled: Boolean,
+) {
+    fun getEnvironment(): EnvironmentResponse {
+        val activeProfiles = activeProfiles()
+        return EnvironmentResponse(activeProfiles, activeProfiles.contains(PROD_PROFILE), devTokenEnabled)
+    }
+
+    private fun activeProfiles(): List<String> = environment.activeProfiles.toList().ifEmpty { listOf(DEFAULT_PROFILE) }
+
+    private companion object {
+        const val DEFAULT_PROFILE = "default"
+        const val PROD_PROFILE = "prod"
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfigTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfigTest.kt
@@ -34,6 +34,11 @@ class SecurityConfigTest {
         assertTrue(permitAllPatterns().contains("/users/*/signup-date"))
     }
 
+    @Test
+    fun `시스템 환경 확인 API는 인증 없이 접근할 수 있다`() {
+        assertTrue(permitAllPatterns().contains("/system/environment"))
+    }
+
     private fun permitAllPatterns(): List<String> {
         val field = SecurityConfig::class.java.getDeclaredField("PERMIT_ALL_PATTERNS")
         field.isAccessible = true

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/system/controller/SystemControllerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/system/controller/SystemControllerTest.kt
@@ -1,0 +1,28 @@
+package com.firstpenguin.app.domain.system.controller
+
+import org.junit.jupiter.api.Test
+import org.springframework.mock.env.MockEnvironment
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SystemControllerTest {
+    @Test
+    fun `prod profile이면 prod true를 반환한다`() {
+        val environment = MockEnvironment().apply { setActiveProfiles("prod") }
+        val response = SystemController(environment, true).getEnvironment()
+
+        assertEquals(listOf("prod"), response.activeProfiles)
+        assertTrue(response.prod)
+        assertTrue(response.devTokenEnabled)
+    }
+
+    @Test
+    fun `active profile이 없으면 default를 반환한다`() {
+        val response = SystemController(MockEnvironment(), false).getEnvironment()
+
+        assertEquals(listOf("default"), response.activeProfiles)
+        assertFalse(response.prod)
+        assertFalse(response.devTokenEnabled)
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/system/controller/SystemControllerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/system/controller/SystemControllerTest.kt
@@ -1,28 +1,20 @@
 package com.firstpenguin.app.domain.system.controller
 
+import com.firstpenguin.app.domain.system.dto.EnvironmentResponse
+import com.firstpenguin.app.domain.system.usecase.SystemUseCase
 import org.junit.jupiter.api.Test
-import org.springframework.mock.env.MockEnvironment
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import org.mockito.Mockito
+import kotlin.test.assertSame
 
 class SystemControllerTest {
     @Test
-    fun `prod profile이면 prod true를 반환한다`() {
-        val environment = MockEnvironment().apply { setActiveProfiles("prod") }
-        val response = SystemController(environment, true).getEnvironment()
+    fun `환경 확인은 usecase로 위임한다`() {
+        val systemUseCase = Mockito.mock(SystemUseCase::class.java)
+        val response = EnvironmentResponse(listOf("prod"), prod = true, devTokenEnabled = true)
 
-        assertEquals(listOf("prod"), response.activeProfiles)
-        assertTrue(response.prod)
-        assertTrue(response.devTokenEnabled)
-    }
+        Mockito.`when`(systemUseCase.getEnvironment()).thenReturn(response)
 
-    @Test
-    fun `active profile이 없으면 default를 반환한다`() {
-        val response = SystemController(MockEnvironment(), false).getEnvironment()
-
-        assertEquals(listOf("default"), response.activeProfiles)
-        assertFalse(response.prod)
-        assertFalse(response.devTokenEnabled)
+        assertSame(response, SystemController(systemUseCase).getEnvironment())
+        Mockito.verify(systemUseCase).getEnvironment()
     }
 }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/system/usecase/SystemUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/system/usecase/SystemUseCaseTest.kt
@@ -1,0 +1,28 @@
+package com.firstpenguin.app.domain.system.usecase
+
+import org.junit.jupiter.api.Test
+import org.springframework.mock.env.MockEnvironment
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SystemUseCaseTest {
+    @Test
+    fun `prod profile이면 prod true를 반환한다`() {
+        val environment = MockEnvironment().apply { setActiveProfiles("prod") }
+        val response = SystemUseCase(environment, true).getEnvironment()
+
+        assertEquals(listOf("prod"), response.activeProfiles)
+        assertTrue(response.prod)
+        assertTrue(response.devTokenEnabled)
+    }
+
+    @Test
+    fun `active profile이 없으면 default를 반환한다`() {
+        val response = SystemUseCase(MockEnvironment(), false).getEnvironment()
+
+        assertEquals(listOf("default"), response.activeProfiles)
+        assertFalse(response.prod)
+        assertFalse(response.devTokenEnabled)
+    }
+}


### PR DESCRIPTION
## 작업 내용

- `GET /api/system/environment` API를 추가했습니다.
- 응답에 `activeProfiles`, `prod`, `devTokenEnabled`를 포함해 현재 실행 환경과 개발용 토큰 활성화 여부를 쉽게 확인할 수 있게 했습니다.
- 인증 없이 호출할 수 있도록 `/system/environment`를 permitAll에 추가했습니다.
- `secret` submodule의 prod 설정에서 `app.token.enabled`를 `true`로 변경하고, 부모 repo에 submodule 포인터를 반영했습니다.

## 확인 방법

```bash
curl https://{prod-domain}/api/system/environment
```

예상 prod 응답:

```json
{
  "activeProfiles": ["prod"],
  "prod": true,
  "devTokenEnabled": true
}
```

## 검증

- `./gradlew test --tests "com.firstpenguin.app.domain.system.controller.SystemControllerTest" --tests "com.firstpenguin.app.domain.auth.config.SecurityConfigTest"`
- `./gradlew lintKotlin`
- push hook: gitleaks, Gradle test

## 참고

- 실제 운영 반영은 배포 후 확인 가능합니다.
