### PR TITLE
로컬 프론트 dev 인증 연동 지원

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/AuthProperties.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/AuthProperties.kt
@@ -28,6 +28,8 @@ data class AuthProperties(
         var cookieName: String = "refresh_token",
         var cookiePath: String = "/api/auth",
         var secure: Boolean = true,
+        @field:NotBlank
+        var sameSite: String = "Lax",
     )
 
     data class OAuth2(

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/token/RefreshTokenCookieManager.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/token/RefreshTokenCookieManager.kt
@@ -24,6 +24,6 @@ class RefreshTokenCookieManager(
             .from(authProperties.refreshToken.cookieName, value)
             .httpOnly(true)
             .secure(authProperties.refreshToken.secure)
-            .sameSite("Lax")
+            .sameSite(authProperties.refreshToken.sameSite)
             .path(authProperties.refreshToken.cookiePath)
 }

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/token/RefreshTokenCookieManagerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/token/RefreshTokenCookieManagerTest.kt
@@ -1,0 +1,20 @@
+package com.firstpenguin.app.domain.auth.token
+
+import com.firstpenguin.app.domain.auth.config.AuthProperties
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class RefreshTokenCookieManagerTest {
+    @Test
+    fun `refresh token 쿠키는 설정된 SameSite 값을 사용한다`() {
+        val authProperties =
+            AuthProperties(
+                jwt = AuthProperties.Jwt(secret = "secret"),
+                refreshToken = AuthProperties.RefreshToken(sameSite = "None"),
+            )
+
+        val cookie = RefreshTokenCookieManager(authProperties).create("refresh-token")
+
+        assertEquals("None", cookie.sameSite)
+    }
+}


### PR DESCRIPTION
## 변경 사항

- dev secret의 OAuth redirect와 CORS origin을 localhost:5174 테스트 흐름에 맞게 최신화했습니다.
- refresh token cookie의 SameSite 값을 설정으로 제어하도록 변경했습니다.
- SameSite 설정 반영 테스트를 추가했습니다.

## 검증

- ./gradlew formatKotlin
- ./gradlew lintKotlin detekt test
- push hook test 통과

Closes #223
