### PR TITLE
운영 임시 로그인 토큰 API 추가

### DIFF
--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfig.kt
@@ -114,6 +114,7 @@ class SecurityConfig(
                 "/auth/refresh",
                 "/auth/logout",
                 "/auth/dev-token",
+                "/auth/temporary-login-token",
                 "/oauth2/**",
                 "/login/oauth2/**",
                 "/monthly-settlements/shared",

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthController.kt
@@ -4,14 +4,12 @@ import com.firstpenguin.app.domain.auth.dto.AccessTokenResponse
 import com.firstpenguin.app.domain.auth.dto.TokenPairResponse
 import com.firstpenguin.app.domain.auth.token.RefreshTokenCookieManager
 import com.firstpenguin.app.domain.auth.usecase.DevAuthUseCase
-import com.firstpenguin.app.global.security.ADMIN_BATCH_SECRET_HEADER
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.HttpHeaders
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -35,11 +33,8 @@ class DevAuthController(
         summary = "[TEMP] 운영 임시 로그인 토큰 발급",
         description = "app.token.enabled=true일 때만 활성화. user_id=9065 사용자의 Access Token과 Refresh Token을 발급합니다.",
     )
-    fun temporaryLoginToken(
-        @RequestHeader(ADMIN_BATCH_SECRET_HEADER, required = false) adminSecret: String?,
-        response: HttpServletResponse,
-    ): TokenPairResponse {
-        val tokenPair = devAuthUseCase.issueTemporaryLoginToken(adminSecret)
+    fun temporaryLoginToken(response: HttpServletResponse): TokenPairResponse {
+        val tokenPair = devAuthUseCase.issueTemporaryLoginToken()
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookieManager.create(tokenPair.refreshToken).toString())
         return TokenPairResponse.from(tokenPair)
     }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthController.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthController.kt
@@ -1,11 +1,17 @@
 package com.firstpenguin.app.domain.auth.controller
 
 import com.firstpenguin.app.domain.auth.dto.AccessTokenResponse
+import com.firstpenguin.app.domain.auth.dto.TokenPairResponse
+import com.firstpenguin.app.domain.auth.token.RefreshTokenCookieManager
 import com.firstpenguin.app.domain.auth.usecase.DevAuthUseCase
+import com.firstpenguin.app.global.security.ADMIN_BATCH_SECRET_HEADER
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpHeaders
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -15,8 +21,26 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "인증")
 class DevAuthController(
     private val devAuthUseCase: DevAuthUseCase,
+    private val refreshTokenCookieManager: RefreshTokenCookieManager,
 ) {
     @GetMapping("/dev-token")
-    @Operation(summary = "[DEV] 개발용 토큰 발급", description = "app.token.enabled=true일 때만 활성화. 고정 더미 유저의 Access Token 반환.")
+    @Operation(
+        summary = "[DEV] 개발용 토큰 발급",
+        description = "app.token.enabled=true일 때만 활성화. 고정 더미 유저의 Access Token 반환.",
+    )
     fun devToken(): AccessTokenResponse = devAuthUseCase.issueDevToken()
+
+    @GetMapping("/temporary-login-token")
+    @Operation(
+        summary = "[TEMP] 운영 임시 로그인 토큰 발급",
+        description = "app.token.enabled=true일 때만 활성화. user_id=9065 사용자의 Access Token과 Refresh Token을 발급합니다.",
+    )
+    fun temporaryLoginToken(
+        @RequestHeader(ADMIN_BATCH_SECRET_HEADER, required = false) adminSecret: String?,
+        response: HttpServletResponse,
+    ): TokenPairResponse {
+        val tokenPair = devAuthUseCase.issueTemporaryLoginToken(adminSecret)
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookieManager.create(tokenPair.refreshToken).toString())
+        return TokenPairResponse.from(tokenPair)
+    }
 }

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/dto/TokenPairResponse.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/dto/TokenPairResponse.kt
@@ -1,0 +1,26 @@
+package com.firstpenguin.app.domain.auth.dto
+
+import com.firstpenguin.app.domain.auth.model.TokenPair
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Access Token과 Refresh Token 발급 응답")
+data class TokenPairResponse(
+    @field:Schema(
+        description = "보호 API 호출 시 Authorization Bearer 헤더에 넣는 Access Token",
+        example = "eyJhbGciOiJIUzI1NiJ9...",
+    )
+    val accessToken: String,
+    @field:Schema(
+        description = "Access Token 재발급과 로그아웃에 사용할 Refresh Token",
+        example = "eyJhbGciOiJIUzI1NiJ9...",
+    )
+    val refreshToken: String,
+) {
+    companion object {
+        fun from(tokenPair: TokenPair): TokenPairResponse =
+            TokenPairResponse(
+                accessToken = tokenPair.accessToken,
+                refreshToken = tokenPair.refreshToken,
+            )
+    }
+}

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCase.kt
@@ -1,25 +1,40 @@
 package com.firstpenguin.app.domain.auth.usecase
 
 import com.firstpenguin.app.domain.auth.dto.AccessTokenResponse
+import com.firstpenguin.app.domain.auth.model.TokenPair
+import com.firstpenguin.app.domain.auth.service.RefreshTokenService
 import com.firstpenguin.app.domain.auth.token.JwtTokenProvider
 import com.firstpenguin.app.domain.user.model.OAuthUserProfile
 import com.firstpenguin.app.domain.user.model.Provider
 import com.firstpenguin.app.domain.user.model.User
 import com.firstpenguin.app.domain.user.service.OAuthUserService
+import com.firstpenguin.app.domain.user.service.UserService
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
+import com.firstpenguin.app.global.security.AdminBatchSecretValidator
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 @Component
 class DevAuthUseCase(
     private val oAuthUserService: OAuthUserService,
+    private val adminBatchSecretValidator: AdminBatchSecretValidator,
+    private val userService: UserService,
+    private val refreshTokenService: RefreshTokenService,
     private val jwtTokenProvider: JwtTokenProvider,
 ) {
     @Transactional
     fun issueDevToken(): AccessTokenResponse {
         val devUser = findOrCreateDevUser()
         return AccessTokenResponse(jwtTokenProvider.createAccessToken(devUser))
+    }
+
+    @Transactional
+    fun issueTemporaryLoginToken(adminSecret: String?): TokenPair {
+        adminBatchSecretValidator.validate(adminSecret)
+        val user = userService.getAuthenticatableById(TEMPORARY_LOGIN_USER_ID)
+        val refreshToken = refreshTokenService.issue(user)
+        return TokenPair(jwtTokenProvider.createAccessToken(user), refreshToken)
     }
 
     private fun findOrCreateDevUser(): User {
@@ -40,6 +55,7 @@ class DevAuthUseCase(
 
     private companion object {
         const val DEV_USER_NICKNAME = "개발자"
+        const val TEMPORARY_LOGIN_USER_ID = 9065L
         val DEV_USER_PROFILE =
             OAuthUserProfile(
                 provider = Provider.KAKAO,

--- a/app/src/main/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCase.kt
+++ b/app/src/main/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCase.kt
@@ -11,14 +11,12 @@ import com.firstpenguin.app.domain.user.service.OAuthUserService
 import com.firstpenguin.app.domain.user.service.UserService
 import com.firstpenguin.app.global.exception.CustomException
 import com.firstpenguin.app.global.exception.ErrorCode
-import com.firstpenguin.app.global.security.AdminBatchSecretValidator
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 @Component
 class DevAuthUseCase(
     private val oAuthUserService: OAuthUserService,
-    private val adminBatchSecretValidator: AdminBatchSecretValidator,
     private val userService: UserService,
     private val refreshTokenService: RefreshTokenService,
     private val jwtTokenProvider: JwtTokenProvider,
@@ -30,8 +28,7 @@ class DevAuthUseCase(
     }
 
     @Transactional
-    fun issueTemporaryLoginToken(adminSecret: String?): TokenPair {
-        adminBatchSecretValidator.validate(adminSecret)
+    fun issueTemporaryLoginToken(): TokenPair {
         val user = userService.getAuthenticatableById(TEMPORARY_LOGIN_USER_ID)
         val refreshToken = refreshTokenService.issue(user)
         return TokenPair(jwtTokenProvider.createAccessToken(user), refreshToken)

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfigTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/config/SecurityConfigTest.kt
@@ -39,6 +39,11 @@ class SecurityConfigTest {
         assertTrue(permitAllPatterns().contains("/system/environment"))
     }
 
+    @Test
+    fun `운영 임시 로그인 토큰 발급 API는 인증 없이 접근할 수 있다`() {
+        assertTrue(permitAllPatterns().contains("/auth/temporary-login-token"))
+    }
+
     private fun permitAllPatterns(): List<String> {
         val field = SecurityConfig::class.java.getDeclaredField("PERMIT_ALL_PATTERNS")
         field.isAccessible = true

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthControllerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthControllerTest.kt
@@ -38,10 +38,10 @@ class DevAuthControllerTest {
         val response = MockHttpServletResponse()
         val tokenPair = TokenPair(ACCESS_TOKEN, REFRESH_TOKEN)
         val refreshTokenCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, REFRESH_TOKEN).build()
-        Mockito.`when`(devAuthUseCase.issueTemporaryLoginToken(ADMIN_SECRET)).thenReturn(tokenPair)
+        Mockito.`when`(devAuthUseCase.issueTemporaryLoginToken()).thenReturn(tokenPair)
         Mockito.`when`(refreshTokenCookieManager.create(REFRESH_TOKEN)).thenReturn(refreshTokenCookie)
 
-        val result = devAuthController.temporaryLoginToken(ADMIN_SECRET, response)
+        val result = devAuthController.temporaryLoginToken(response)
 
         assertEquals(ACCESS_TOKEN, result.accessToken)
         assertEquals(REFRESH_TOKEN, result.refreshToken)
@@ -49,7 +49,6 @@ class DevAuthControllerTest {
     }
 
     private companion object {
-        const val ADMIN_SECRET = "admin-secret"
         const val ACCESS_TOKEN = "access-token"
         const val REFRESH_TOKEN = "refresh-token"
         const val REFRESH_TOKEN_COOKIE_NAME = "refresh_token"

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthControllerTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/controller/DevAuthControllerTest.kt
@@ -1,0 +1,57 @@
+package com.firstpenguin.app.domain.auth.controller
+
+import com.firstpenguin.app.domain.auth.dto.AccessTokenResponse
+import com.firstpenguin.app.domain.auth.model.TokenPair
+import com.firstpenguin.app.domain.auth.token.RefreshTokenCookieManager
+import com.firstpenguin.app.domain.auth.usecase.DevAuthUseCase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseCookie
+import org.springframework.mock.web.MockHttpServletResponse
+import kotlin.test.assertEquals
+
+class DevAuthControllerTest {
+    private lateinit var devAuthUseCase: DevAuthUseCase
+    private lateinit var refreshTokenCookieManager: RefreshTokenCookieManager
+    private lateinit var devAuthController: DevAuthController
+
+    @BeforeEach
+    fun setUp() {
+        devAuthUseCase = Mockito.mock(DevAuthUseCase::class.java)
+        refreshTokenCookieManager = Mockito.mock(RefreshTokenCookieManager::class.java)
+        devAuthController = DevAuthController(devAuthUseCase, refreshTokenCookieManager)
+    }
+
+    @Test
+    fun `기존 개발용 토큰 API는 access token만 내려준다`() {
+        Mockito.`when`(devAuthUseCase.issueDevToken()).thenReturn(AccessTokenResponse(ACCESS_TOKEN))
+
+        val result = devAuthController.devToken()
+
+        assertEquals(ACCESS_TOKEN, result.accessToken)
+    }
+
+    @Test
+    fun `새 임시 로그인 토큰 API는 access token과 refresh token을 함께 내려준다`() {
+        val response = MockHttpServletResponse()
+        val tokenPair = TokenPair(ACCESS_TOKEN, REFRESH_TOKEN)
+        val refreshTokenCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, REFRESH_TOKEN).build()
+        Mockito.`when`(devAuthUseCase.issueTemporaryLoginToken(ADMIN_SECRET)).thenReturn(tokenPair)
+        Mockito.`when`(refreshTokenCookieManager.create(REFRESH_TOKEN)).thenReturn(refreshTokenCookie)
+
+        val result = devAuthController.temporaryLoginToken(ADMIN_SECRET, response)
+
+        assertEquals(ACCESS_TOKEN, result.accessToken)
+        assertEquals(REFRESH_TOKEN, result.refreshToken)
+        assertEquals(refreshTokenCookie.toString(), response.getHeader(HttpHeaders.SET_COOKIE))
+    }
+
+    private companion object {
+        const val ADMIN_SECRET = "admin-secret"
+        const val ACCESS_TOKEN = "access-token"
+        const val REFRESH_TOKEN = "refresh-token"
+        const val REFRESH_TOKEN_COOKIE_NAME = "refresh_token"
+    }
+}

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCaseTest.kt
@@ -8,19 +8,14 @@ import com.firstpenguin.app.domain.user.model.User
 import com.firstpenguin.app.domain.user.model.UserStatus
 import com.firstpenguin.app.domain.user.service.OAuthUserService
 import com.firstpenguin.app.domain.user.service.UserService
-import com.firstpenguin.app.global.exception.CustomException
-import com.firstpenguin.app.global.exception.ErrorCode
-import com.firstpenguin.app.global.security.AdminBatchSecretValidator
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 class DevAuthUseCaseTest {
     private lateinit var oAuthUserService: OAuthUserService
-    private lateinit var adminBatchSecretValidator: AdminBatchSecretValidator
     private lateinit var userService: UserService
     private lateinit var refreshTokenService: RefreshTokenService
     private lateinit var jwtTokenProvider: JwtTokenProvider
@@ -29,14 +24,12 @@ class DevAuthUseCaseTest {
     @BeforeEach
     fun setUp() {
         oAuthUserService = Mockito.mock(OAuthUserService::class.java)
-        adminBatchSecretValidator = Mockito.mock(AdminBatchSecretValidator::class.java)
         userService = Mockito.mock(UserService::class.java)
         refreshTokenService = Mockito.mock(RefreshTokenService::class.java)
         jwtTokenProvider = Mockito.mock(JwtTokenProvider::class.java)
         devAuthUseCase =
             DevAuthUseCase(
                 oAuthUserService,
-                adminBatchSecretValidator,
                 userService,
                 refreshTokenService,
                 jwtTokenProvider,
@@ -53,34 +46,21 @@ class DevAuthUseCaseTest {
         val response = devAuthUseCase.issueDevToken()
 
         assertEquals(ACCESS_TOKEN, response.accessToken)
-        Mockito.verifyNoInteractions(adminBatchSecretValidator, userService, refreshTokenService)
+        Mockito.verifyNoInteractions(userService, refreshTokenService)
     }
 
     @Test
-    fun `임시 토큰 발급 시 관리자 secret 검증 후 9065 사용자 토큰을 발급한다`() {
+    fun `임시 토큰 발급 시 9065 사용자 토큰을 발급한다`() {
         val user = user(TEMPORARY_LOGIN_USER_ID)
         Mockito.`when`(userService.getAuthenticatableById(USER_ID)).thenReturn(user)
         Mockito.`when`(refreshTokenService.issue(user)).thenReturn(REFRESH_TOKEN)
         Mockito.`when`(jwtTokenProvider.createAccessToken(user)).thenReturn(ACCESS_TOKEN)
 
-        val tokenPair = devAuthUseCase.issueTemporaryLoginToken(ADMIN_SECRET)
+        val tokenPair = devAuthUseCase.issueTemporaryLoginToken()
 
         assertEquals(ACCESS_TOKEN, tokenPair.accessToken)
         assertEquals(REFRESH_TOKEN, tokenPair.refreshToken)
-        Mockito.verify(adminBatchSecretValidator).validate(ADMIN_SECRET)
         Mockito.verify(userService).getAuthenticatableById(USER_ID)
-    }
-
-    @Test
-    fun `관리자 secret 검증 실패 시 토큰을 발급하지 않는다`() {
-        Mockito
-            .doThrow(CustomException(ErrorCode.UNAUTHORIZED))
-            .`when`(adminBatchSecretValidator)
-            .validate(null)
-
-        assertFailsWith<CustomException> { devAuthUseCase.issueTemporaryLoginToken(null) }
-
-        Mockito.verifyNoInteractions(userService, refreshTokenService, jwtTokenProvider)
     }
 
     private fun user(id: Long): User {
@@ -103,7 +83,6 @@ class DevAuthUseCaseTest {
         const val DEV_USER_ID = 1L
         const val TEMPORARY_LOGIN_USER_ID = 9065L
         const val USER_ID = TEMPORARY_LOGIN_USER_ID
-        const val ADMIN_SECRET = "admin-secret"
         const val ACCESS_TOKEN = "access-token"
         const val REFRESH_TOKEN = "refresh-token"
         val DEV_USER_PROFILE =

--- a/app/src/test/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCaseTest.kt
+++ b/app/src/test/kotlin/com/firstpenguin/app/domain/auth/usecase/DevAuthUseCaseTest.kt
@@ -1,0 +1,117 @@
+package com.firstpenguin.app.domain.auth.usecase
+
+import com.firstpenguin.app.domain.auth.service.RefreshTokenService
+import com.firstpenguin.app.domain.auth.token.JwtTokenProvider
+import com.firstpenguin.app.domain.user.model.OAuthUserProfile
+import com.firstpenguin.app.domain.user.model.Provider
+import com.firstpenguin.app.domain.user.model.User
+import com.firstpenguin.app.domain.user.model.UserStatus
+import com.firstpenguin.app.domain.user.service.OAuthUserService
+import com.firstpenguin.app.domain.user.service.UserService
+import com.firstpenguin.app.global.exception.CustomException
+import com.firstpenguin.app.global.exception.ErrorCode
+import com.firstpenguin.app.global.security.AdminBatchSecretValidator
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DevAuthUseCaseTest {
+    private lateinit var oAuthUserService: OAuthUserService
+    private lateinit var adminBatchSecretValidator: AdminBatchSecretValidator
+    private lateinit var userService: UserService
+    private lateinit var refreshTokenService: RefreshTokenService
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var devAuthUseCase: DevAuthUseCase
+
+    @BeforeEach
+    fun setUp() {
+        oAuthUserService = Mockito.mock(OAuthUserService::class.java)
+        adminBatchSecretValidator = Mockito.mock(AdminBatchSecretValidator::class.java)
+        userService = Mockito.mock(UserService::class.java)
+        refreshTokenService = Mockito.mock(RefreshTokenService::class.java)
+        jwtTokenProvider = Mockito.mock(JwtTokenProvider::class.java)
+        devAuthUseCase =
+            DevAuthUseCase(
+                oAuthUserService,
+                adminBatchSecretValidator,
+                userService,
+                refreshTokenService,
+                jwtTokenProvider,
+            )
+    }
+
+    @Test
+    fun `개발용 토큰 발급은 기존 더미 사용자 access token만 반환한다`() {
+        val user = user(DEV_USER_ID)
+        Mockito.`when`(oAuthUserService.findOAuthUser(DEV_USER_PROFILE)).thenReturn(user)
+        Mockito.`when`(oAuthUserService.updateOAuthLogin(user, DEV_USER_PROFILE)).thenReturn(user)
+        Mockito.`when`(jwtTokenProvider.createAccessToken(user)).thenReturn(ACCESS_TOKEN)
+
+        val response = devAuthUseCase.issueDevToken()
+
+        assertEquals(ACCESS_TOKEN, response.accessToken)
+        Mockito.verifyNoInteractions(adminBatchSecretValidator, userService, refreshTokenService)
+    }
+
+    @Test
+    fun `임시 토큰 발급 시 관리자 secret 검증 후 9065 사용자 토큰을 발급한다`() {
+        val user = user(TEMPORARY_LOGIN_USER_ID)
+        Mockito.`when`(userService.getAuthenticatableById(USER_ID)).thenReturn(user)
+        Mockito.`when`(refreshTokenService.issue(user)).thenReturn(REFRESH_TOKEN)
+        Mockito.`when`(jwtTokenProvider.createAccessToken(user)).thenReturn(ACCESS_TOKEN)
+
+        val tokenPair = devAuthUseCase.issueTemporaryLoginToken(ADMIN_SECRET)
+
+        assertEquals(ACCESS_TOKEN, tokenPair.accessToken)
+        assertEquals(REFRESH_TOKEN, tokenPair.refreshToken)
+        Mockito.verify(adminBatchSecretValidator).validate(ADMIN_SECRET)
+        Mockito.verify(userService).getAuthenticatableById(USER_ID)
+    }
+
+    @Test
+    fun `관리자 secret 검증 실패 시 토큰을 발급하지 않는다`() {
+        Mockito
+            .doThrow(CustomException(ErrorCode.UNAUTHORIZED))
+            .`when`(adminBatchSecretValidator)
+            .validate(null)
+
+        assertFailsWith<CustomException> { devAuthUseCase.issueTemporaryLoginToken(null) }
+
+        Mockito.verifyNoInteractions(userService, refreshTokenService, jwtTokenProvider)
+    }
+
+    private fun user(id: Long): User {
+        val now = LocalDateTime.now()
+
+        return User(
+            id = id,
+            nickname = "penguin",
+            profileImageId = null,
+            status = UserStatus.ACTIVE,
+            withdrawalRequestedAt = null,
+            withdrawalDueAt = null,
+            deletedAt = null,
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    private companion object {
+        const val DEV_USER_ID = 1L
+        const val TEMPORARY_LOGIN_USER_ID = 9065L
+        const val USER_ID = TEMPORARY_LOGIN_USER_ID
+        const val ADMIN_SECRET = "admin-secret"
+        const val ACCESS_TOKEN = "access-token"
+        const val REFRESH_TOKEN = "refresh-token"
+        val DEV_USER_PROFILE =
+            OAuthUserProfile(
+                provider = Provider.KAKAO,
+                providerId = "dev-user",
+                email = "dev@firstpenguin.com",
+                providerDisplayName = "개발자",
+            )
+    }
+}


### PR DESCRIPTION
## 변경 사항

- 기존 `/api/auth/dev-token`은 유지하고, 별도 `/api/auth/temporary-login-token` API를 추가했습니다.
- 신규 API는 로그인 전 호출 가능하도록 permitAll에 추가했습니다.
- `app.token.enabled=true` 동안 별도 인증 헤더 없이 `user_id=9065` 사용자의 accessToken과 refreshToken을 발급합니다.
- 발급한 refreshToken은 응답 body와 refreshToken 쿠키로 함께 내려줍니다.
- refreshToken 저장은 기존 발급 로직을 재사용합니다.
- pre-push 훅 통과를 위해 `secret` submodule 포인터를 최신화했습니다.

## 검증

- `./gradlew formatKotlin test --tests 'com.firstpenguin.app.domain.auth.*' lintKotlin detekt`\n- pre-push hook: `cd app && ./gradlew clean test`\n\nCloses #225